### PR TITLE
Page to browse videos within a topic

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -18,7 +18,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-from .views import index, search, video, browse
+from .views import index, search, video, browse_topic
 
 urlpatterns = [
     path("", index, name="home"),
@@ -27,5 +27,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("search", search, name="search"),
     path("video/<int:id>", video, name="video"),
-    path("browse/<str:id>", browse, name="browse"),
+    path("topic/<str:id>", browse_topic, name="browse_topic"),
 ]

--- a/app/urls.py
+++ b/app/urls.py
@@ -18,7 +18,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-from .views import index, search, video
+from .views import index, search, video, browse
 
 urlpatterns = [
     path("", index, name="home"),
@@ -27,4 +27,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("search", search, name="search"),
     path("video/<int:id>", video, name="video"),
+    path("browse/<str:id>", browse, name="browse"),
 ]

--- a/app/views.py
+++ b/app/views.py
@@ -53,6 +53,7 @@ def video(request, id):
         {"video": Video.objects.get(id=id)},
     )
 
+
 def browse_topic(request, id):
     try:
         topic = Topic.objects.get(name=id)

--- a/app/views.py
+++ b/app/views.py
@@ -53,7 +53,7 @@ def video(request, id):
         {"video": Video.objects.get(id=id)},
     )
 
-def browse(request, id):
+def browse_topic(request, id):
     try:
         topic = Topic.objects.get(name=id)
     except Topic.DoesNotExist as e:

--- a/app/views.py
+++ b/app/views.py
@@ -2,7 +2,7 @@ from inertia import render
 import django
 from catalogue.models.video import Video
 from catalogue.models.topic import Topic
-
+from urllib.parse import unquote  # Import for URL decoding
 
 def index(request):
     # TODO: paginate
@@ -12,7 +12,7 @@ def index(request):
     topics_all = Topic.objects.all()
 
     topics_data = [
-        {"category": t.category, "name": t.name, "videosCount": len(t.video_set.all())}
+        {"category": t.category, "name": t.name, "videosCount": len(t.video_set.all()), "url": t.get_absolute_url()}
         for t in topics_all
     ]
 
@@ -55,15 +55,18 @@ def video(request, id):
 
 
 def browse_topic(request, id):
+    # Decode the URL-encoded `id` parameter
+    decoded_id = unquote(id)
+
     try:
-        topic = Topic.objects.get(name=id)
+        topic = Topic.objects.get(name=decoded_id)
     except Topic.DoesNotExist as e:
         return render(
             request,
             "Browse",
             {
                 "videos": [],
-                "title": "Topic not found: '%s'" % id,
+                "title": "Topic not found: '%s'" % decoded_id,
                 "description": "Error retreiving topic data: '%s'" % e,
             },
         )
@@ -73,7 +76,7 @@ def browse_topic(request, id):
         "Browse",
         {
             "videos": topic.video_set.all(),
-            "title": "Topic: %s" % id,
+            "title": "Topic: %s" % decoded_id,
             "description": topic.summary,
         },
     )

--- a/app/views.py
+++ b/app/views.py
@@ -52,3 +52,27 @@ def video(request, id):
         "Video",
         {"video": Video.objects.get(id=id)},
     )
+
+def browse(request, id):
+    try:
+        topic = Topic.objects.get(name=id)
+    except Topic.DoesNotExist as e:
+        return render(
+            request,
+            "Browse",
+            {
+                "videos": [],
+                "title": "Topic not found: '%s'" % id,
+                "description": "Error retreiving topic data: '%s'" % e,
+            },
+        )
+
+    return render(
+        request,
+        "Browse",
+        {
+            "videos": topic.video_set.all(),
+            "title": "Topic: %s" % id,
+            "description": topic.summary,
+        },
+    )

--- a/app/views.py
+++ b/app/views.py
@@ -4,6 +4,7 @@ from catalogue.models.video import Video
 from catalogue.models.topic import Topic
 from urllib.parse import unquote  # Import for URL decoding
 
+
 def index(request):
     # TODO: paginate
 
@@ -12,7 +13,12 @@ def index(request):
     topics_all = Topic.objects.all()
 
     topics_data = [
-        {"category": t.category, "name": t.name, "videosCount": len(t.video_set.all()), "url": t.get_absolute_url()}
+        {
+            "category": t.category,
+            "name": t.name,
+            "videosCount": len(t.video_set.all()),
+            "url": t.get_absolute_url(),
+        }
         for t in topics_all
     ]
 

--- a/app/views.py
+++ b/app/views.py
@@ -12,7 +12,7 @@ def index(request):
     topics_all = Topic.objects.all()
 
     topics_data = [
-        {"category": t.category, "name": t.name, "videosCount": len(t.videos.all())}
+        {"category": t.category, "name": t.name, "videosCount": len(t.video_set.all())}
         for t in topics_all
     ]
 

--- a/catalogue/models/topic.py
+++ b/catalogue/models/topic.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.urls import reverse  # generate urls by reversing url pattern
 from urllib.parse import quote  # Import for URL encoding
 
+
 class Topic(models.Model):
     """Model representing video topics"""
 
@@ -34,7 +35,9 @@ class Topic(models.Model):
 
     def get_absolute_url(self):
         """Returns the url to access a particular topic instance"""
-        encoded_name = quote(self.name, safe="")  # Encode the name, escaping all special characters
+        encoded_name = quote(
+            self.name, safe=""
+        )  # Encode the name, escaping all special characters
         return reverse("browse_topic", args=[encoded_name])
 
     class Meta:

--- a/catalogue/models/topic.py
+++ b/catalogue/models/topic.py
@@ -3,7 +3,7 @@ from django.db import models
 # from .video import Video
 # from .series import Series
 from django.urls import reverse  # generate urls by reversing url pattern
-
+from urllib.parse import quote  # Import for URL encoding
 
 class Topic(models.Model):
     """Model representing video topics"""
@@ -34,7 +34,8 @@ class Topic(models.Model):
 
     def get_absolute_url(self):
         """Returns the url to access a particular topic instance"""
-        return reverse("topic-detail", args=[str(self.name)])
+        encoded_name = quote(self.name, safe="")  # Encode the name, escaping all special characters
+        return reverse("browse_topic", args=[encoded_name])
 
     class Meta:
         ordering = ["name"]

--- a/resources/js/Components/Organisms/Topics.vue
+++ b/resources/js/Components/Organisms/Topics.vue
@@ -96,19 +96,19 @@ function selectCategory(category) {
         <ul
             v-else
             class="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-2 sm:gap-x-6 lg:grid-cols-3 xl:gap-x-8">
-            <li
+            <Link
                 v-for="(subcategory, index) in filteredSubCategories"
                 :key="index"
-                class="contents">
-                <Link :href="`/topic/`+subcategory.name" :id="subcategory.name" class="rounded-lg bg-blue-950 p-4">
-                    <h2 class="font-bold">{{ subcategory.name }}</h2>
-                    <div>
-                        {{ subcategory.videosCount }} programme{{
-                            subcategory.videosCount == 1 ? "" : "s"
-                        }}
-                    </div>
-                </Link>
-            </li>
+                :href="subcategory.url"
+                :id="subcategory.name"
+                class="rounded-lg bg-blue-950 p-4">
+                <h2 class="font-bold">{{ subcategory.name }}</h2>
+                <div>
+                    {{ subcategory.videosCount }} programme{{
+                        subcategory.videosCount == 1 ? "" : "s"
+                    }}
+                </div>
+            </Link>
         </ul>
     </div>
 </template>

--- a/resources/js/Components/Organisms/Topics.vue
+++ b/resources/js/Components/Organisms/Topics.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from "vue"
 import LoadingSpinner from "../Atoms/LoadingSpinner.vue"
 import CardSkeleton from "../Atoms/CardSkeleton.vue"
+import { Link } from "@inertiajs/vue3"
 const props = defineProps({
     topics_data: {
         type: Object,
@@ -98,13 +99,15 @@ function selectCategory(category) {
             <li
                 v-for="(subcategory, index) in filteredSubCategories"
                 :key="index"
-                class="rounded-lg bg-blue-950 p-4">
-                <h2 class="font-bold">{{ subcategory.name }}</h2>
-                <div>
-                    {{ subcategory.videosCount }} programme{{
-                        subcategory.videosCount > 1 ? "s" : ""
-                    }}
-                </div>
+                class="contents">
+                <Link :href="`/topic/`+subcategory.name" :id="subcategory.name" class="rounded-lg bg-blue-950 p-4">
+                    <h2 class="font-bold">{{ subcategory.name }}</h2>
+                    <div>
+                        {{ subcategory.videosCount }} programme{{
+                            subcategory.videosCount == 1 ? "" : "s"
+                        }}
+                    </div>
+                </Link>
             </li>
         </ul>
     </div>

--- a/resources/js/Components/Organisms/Topics.vue
+++ b/resources/js/Components/Organisms/Topics.vue
@@ -10,7 +10,12 @@ const props = defineProps({
 })
 
 // List out category from all topics, then filter down to only keep the first instance of each category
-const categories = ref(props.topics_data.map((t) => t.category).filter((item, index, array) => (array.indexOf(item) == index)))
+const categories = ref([
+    "All",
+    ...props.topics_data
+        .map((t) => t.category)
+        .filter((item, index, array) => array.indexOf(item) == index),
+])
 
 // For each topic entry, obtain its name, category it belongs to, and number of videos it encompasses
 const subCategories = ref(props.topics_data)
@@ -40,8 +45,6 @@ function selectCategory(category) {
         setTimeout(() => {
             isLoadingSubCategories.value = false
         }, 800)
-    } else {
-        selectedCategory.value = "All"
     }
 }
 </script>

--- a/resources/js/Components/Pages/Browse.vue
+++ b/resources/js/Components/Pages/Browse.vue
@@ -1,0 +1,27 @@
+<script setup>
+import { computed } from "vue"
+import { IconPlayerPlay } from "@tabler/icons-vue"
+import { Link } from "@inertiajs/vue3"
+import VideoCardList from "@/Organisms/VideoCardList.vue"
+import Topics from "@/Organisms/Topics.vue"
+
+const props = defineProps({
+    videos: {
+        type: Array,
+    },
+    title: {
+        type: String,
+    },
+    description: {
+        type: String,
+    },
+})
+</script>
+
+<template>
+    <!-- Something here to allow the user to navigate to the linked topics, maybe a bit like a breadcrumb trail -->
+    <VideoCardList
+        :videos="videos"
+        :title="title"
+        :description="description ?? `Browsing videos under ` + title" />
+</template>


### PR DESCRIPTION
## Description

Adds a page accessible at `/topic/<topic name>`  which shows a VideoCardList of the videos that have that topic assigned to them

Relates to #56 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
I've tested this myself. My database currently only has a few entries in though, would be better to test with a better-populated database.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## What should reviewers look for?

1. Click a topic card on the welcome page
2. Observe the new page which shows the videos which should be showing, based on the topic selected
4. Mess with the URL to point to a topic which doesn't exist
5. Observe the graceful failure with basic error page (should maybe create/use a real error page)

I think currently the VideoCardList scrolls horizontally, I think it would probably be better long-term to have a video grid for this page instead, which scrolls vertically?

Currently the topic name supplied in the URL must exactly match what's in the database Topic.name field - changing character cases or changing spaces to dashes or underscores or camelcase all end up failing to find the topic and returning the error page - it ought to be changed to handle these more graciously.

<!-- adapted from a template used by the Data Safe Haven team at The Alan Turing Institute -->
