### PR TITLE
Improve support for embedded videos

### DIFF
--- a/resources/js/Components/Organisms/VideoViewer.vue
+++ b/resources/js/Components/Organisms/VideoViewer.vue
@@ -13,7 +13,8 @@ const getYoutubeId = (videoUrl) => {
 }
 
 const getVimeoId = (videoUrl) => {
-    const vimeoRegex = /^(http|https):\/\/vimeo.com\/([\w]+).*/; // Match strings starting with http://vimeo.com/ or https://vimeo.com/ then match from the first forwardslash after domain name until next forwardslash or end of url
+    // Regex to match strings starting with http://vimeo.com/ or https://vimeo.com/ and from there, match and extract an alphanumeric string until the end or any non-alphanumeric character (eg another forwardslash)
+    const vimeoRegex = /^(http|https):\/\/vimeo.com\/([\w]+).*/;
     const vimeoId = videoUrl.match(vimeoRegex)?.[2];
     return vimeoId
 }

--- a/resources/js/Components/Organisms/VideoViewer.vue
+++ b/resources/js/Components/Organisms/VideoViewer.vue
@@ -12,10 +12,19 @@ const getYoutubeId = (videoUrl) => {
     return youtubeId
 }
 
+const getVimeoId = (videoUrl) => {
+    const vimeoRegex = /^(http|https):\/\/vimeo.com\/([\w]+).*/; // Match strings starting with http://vimeo.com/ or https://vimeo.com/ then match from the first forwardslash after domain name until next forwardslash or end of url
+    const vimeoId = videoUrl.match(vimeoRegex)?.[2];
+    return vimeoId
+}
+
 const getEmbedUrl = (videoUrl) => {
     const youtubeId = getYoutubeId(videoUrl)
+    const vimeoId = getVimeoId(videoUrl)
     if (youtubeId) {
         return `https://www.youtube-nocookie.com/embed/${youtubeId}?autoplay=0&playsinline=1`
+    } else if (vimeoId) {
+        return `https://player.vimeo.com/video/${vimeoId}`
     } else {
         return false
     }


### PR DESCRIPTION
Currently only Youtube videos are embedded; any other sources give a generic "Unable to load embedded video" error message. This PR is to add support for more embedded sources. As of opening this PR the branch adds support for Vimeo videos.

To do:
- Check more vimeo URLs to make sure this works as intended
- Check handling of youtube `?t=` timestamps in URLs and change to support if necessary
- Are there any other sources we are using which we need to support embedding?