### PR TITLE
Claytontv/56/video results grid

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -8,8 +8,12 @@ from urllib.parse import unquote  # Import for URL decoding
 def index(request):
     # TODO: paginate
 
-    livestreams = Video.objects.filter(is_livestream=True).order_by("-date_created")[:10]
-    latest_videos = Video.objects.filter(is_livestream=False).order_by("-date_created")[:10]
+    livestreams = Video.objects.filter(is_livestream=True).order_by("-date_created")[
+        :10
+    ]
+    latest_videos = Video.objects.filter(is_livestream=False).order_by("-date_created")[
+        :10
+    ]
     topics_all = Topic.objects.all()
 
     topics_data = [

--- a/app/views.py
+++ b/app/views.py
@@ -8,8 +8,8 @@ from urllib.parse import unquote  # Import for URL decoding
 def index(request):
     # TODO: paginate
 
-    livestreams = Video.objects.filter(is_livestream=True).order_by("-date_created")
-    latest_videos = Video.objects.filter(is_livestream=False).order_by("-date_created")
+    livestreams = Video.objects.filter(is_livestream=True).order_by("-date_created")[:10]
+    latest_videos = Video.objects.filter(is_livestream=False).order_by("-date_created")[:10]
     topics_all = Topic.objects.all()
 
     topics_data = [

--- a/resources/js/Components/Atoms/VideoCardItem.vue
+++ b/resources/js/Components/Atoms/VideoCardItem.vue
@@ -1,0 +1,55 @@
+<script setup>
+import { computed } from "vue"
+import { IconPlayerPlay } from "@tabler/icons-vue"
+import { Link } from "@inertiajs/vue3"
+defineProps({
+    video: {
+        type: Object,
+        required: true,
+    },
+})
+
+const getVideoThumbnail = (videoUrl) => {
+    const youtubeRegex = /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
+    const youtubeId = videoUrl.match(youtubeRegex)?.[2];
+    if (youtubeId) {
+        // If youtube URL
+        // Attempt to split the video ID off the end, then shoehorn it into the thumbnail URL
+        return `https://img.youtube.com/vi/${youtubeId}/mqdefault.jpg`
+    } else {
+        return "https://via.placeholder.com/1080x640"
+    }
+}
+</script>
+
+<template>
+    <div class="absolute inset-0 place-self-center">
+        <div
+            class="group flex h-min w-min cursor-pointer items-center justify-center rounded-full p-2 hover:bg-gray-100/20">
+            <IconPlayerPlay
+                class="h-14 w-14 stroke-1 text-gray-100"/>
+        </div>
+    </div>
+
+
+    <div class="flex flex-col px-2.5 py-3.5 sm:px-3.5 sm:py-5 gap-y-1">
+        <p
+            class="flex w-fit items-center gap-x-1.5 rounded bg-claytonRed/90 px-1.5 py-0.5 sm:px-2 sm:py-1 text-xs font-bold uppercase tracking-wide" v-if="video.is_livestream">
+            <span class="relative flex h-2.5 w-2.5">
+                <span
+                    class="absolute h-full w-full animate-ping inline-flex opacity-50 bg-white rounded-full" />
+                <span class="h-full w-full inline-flex relative bg-white rounded-full" />
+            </span>
+            <span class="pb-[1.5px]">Live</span>
+        </p>
+        <h3
+            class="line-clamp-1 text-lg leading-snug sm:text-2xl font-bold text-gray-100">
+            {{ video.name }}
+        </h3>
+        <p class="line-clamp-1 truncate text-sm text-gray-400">
+            10:30 AM Sunday 20th Oct
+        </p>
+    </div>
+</template>
+
+<style scoped></style>

--- a/resources/js/Components/Atoms/VideoCardItem.vue
+++ b/resources/js/Components/Atoms/VideoCardItem.vue
@@ -40,7 +40,7 @@ const getVideoThumbnail = (videoUrl) => {
                 {{ video.name }}
             </h3>
             <p class="line-clamp-1 truncate text-sm text-gray-400">
-                10:30 AM Sunday 20th Oct
+                {{ video.date_recorded ? "Recorded: " + video.date_recorded : "Added: " + video.date_created }}
             </p>
         </div>
     </div>

--- a/resources/js/Components/Atoms/VideoCardItem.vue
+++ b/resources/js/Components/Atoms/VideoCardItem.vue
@@ -23,33 +23,28 @@ const getVideoThumbnail = (videoUrl) => {
 </script>
 
 <template>
-    <div class="absolute inset-0 place-self-center">
-        <div
-            class="group flex h-min w-min cursor-pointer items-center justify-center rounded-full p-2 hover:bg-gray-100/20">
-            <IconPlayerPlay
-                class="h-14 w-14 stroke-1 text-gray-100"/>
+    <div class="w-full h-full flex rounded-md bg-gradient-to-br from-gray-700 to-gray-900">
+        <div class="absolute inset-0 place-self-center group flex h-min w-min cursor-pointer items-center justify-center rounded-full p-2 hover:bg-gray-100/20">
+            <IconPlayerPlay class="h-14 w-14 stroke-1 text-gray-100"/>
+        </div>
+
+        <div class="flex flex-col px-2.5 py-3.5 sm:px-3.5 sm:py-5 gap-y-1 place-self-end">
+            <p class="flex items-center gap-x-1.5 rounded bg-claytonRed/90 px-1.5 py-0.5 sm:px-2 sm:py-1 text-xs font-bold uppercase tracking-wide" v-if="video.is_livestream">
+                <span class="relative flex h-2.5 w-2.5">
+                    <span class="absolute h-full w-full animate-ping inline-flex opacity-50 bg-white rounded-full" />
+                    <span class="h-full w-full inline-flex relative bg-white rounded-full" />
+                </span>
+                <span class="pb-[1.5px]">Live</span>
+            </p>
+            <h3 class="line-clamp-1 text-lg leading-snug sm:text-2xl font-bold text-gray-100">
+                {{ video.name }}
+            </h3>
+            <p class="line-clamp-1 truncate text-sm text-gray-400">
+                10:30 AM Sunday 20th Oct
+            </p>
         </div>
     </div>
 
-
-    <div class="flex flex-col px-2.5 py-3.5 sm:px-3.5 sm:py-5 gap-y-1">
-        <p
-            class="flex w-fit items-center gap-x-1.5 rounded bg-claytonRed/90 px-1.5 py-0.5 sm:px-2 sm:py-1 text-xs font-bold uppercase tracking-wide" v-if="video.is_livestream">
-            <span class="relative flex h-2.5 w-2.5">
-                <span
-                    class="absolute h-full w-full animate-ping inline-flex opacity-50 bg-white rounded-full" />
-                <span class="h-full w-full inline-flex relative bg-white rounded-full" />
-            </span>
-            <span class="pb-[1.5px]">Live</span>
-        </p>
-        <h3
-            class="line-clamp-1 text-lg leading-snug sm:text-2xl font-bold text-gray-100">
-            {{ video.name }}
-        </h3>
-        <p class="line-clamp-1 truncate text-sm text-gray-400">
-            10:30 AM Sunday 20th Oct
-        </p>
-    </div>
 </template>
 
 <style scoped></style>

--- a/resources/js/Components/Atoms/VideoCardItem.vue
+++ b/resources/js/Components/Atoms/VideoCardItem.vue
@@ -29,7 +29,7 @@ const getVideoThumbnail = (videoUrl) => {
         </div>
 
         <div class="flex flex-col px-2.5 py-3.5 sm:px-3.5 sm:py-5 gap-y-1 place-self-end">
-            <p class="flex items-center gap-x-1.5 rounded bg-claytonRed/90 px-1.5 py-0.5 sm:px-2 sm:py-1 text-xs font-bold uppercase tracking-wide" v-if="video.is_livestream">
+            <p class="flex w-min items-center gap-x-1.5 rounded bg-claytonRed/90 px-1.5 py-0.5 sm:px-2 sm:py-1 text-xs font-bold uppercase tracking-wide" v-if="video.is_livestream">
                 <span class="relative flex h-2.5 w-2.5">
                     <span class="absolute h-full w-full animate-ping inline-flex opacity-50 bg-white rounded-full" />
                     <span class="h-full w-full inline-flex relative bg-white rounded-full" />

--- a/resources/js/Components/Organisms/VideoCardGrid.vue
+++ b/resources/js/Components/Organisms/VideoCardGrid.vue
@@ -28,46 +28,6 @@ const getVideoThumbnail = (videoUrl) => {
         return "https://via.placeholder.com/1080x640"
     }
 }
-
-const playVideo = (id) => {
-    const video = document.getElementById(id)
-
-    if (!video) {
-        console.log("Video not found")
-        return
-    }
-
-    // Play the video
-    video.play()
-
-    // Show controls when video is playing
-    video.controls = true
-
-    // Pause other videos
-    const videos = document.querySelectorAll("video")
-    videos.forEach((v) => {
-        if (v.id !== id) {
-            v.pause()
-            v.controls = false
-        }
-    })
-
-    // Scroll to the video
-    video.scrollIntoView({ behavior: "smooth", block: "center" })
-
-    // Add event listener to exit fullscreen
-    document.addEventListener("fullscreenchange", () => {
-        if (!document.fullscreenElement) {
-            video.pause()
-            video.controls = false
-        }
-    })
-
-    // Add event listener to pause video when it ends
-    video.addEventListener("ended", () => {
-        video.controls = false
-    })
-}
 </script>
 
 <template>
@@ -80,11 +40,11 @@ const playVideo = (id) => {
         </div>
 
         <div class="mt-2 w-full overflow-x-hidden">
-            <ul class="flex snap-x snap-mandatory gap-x-4 overflow-x-auto px-2">
+            <ul class="grid gridl-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 overflow-x-auto px-4 lg:px-8">
                 <li
                     v-for="video in videos"
                     :key="video.id"
-                    class="relative isolate mb-3 aspect-[10/16] max-h-[42dvh] w-auto max-w-[90vw] shrink-0 snap-center md:aspect-video hover:opacity-75">
+                    class="relative isolate max-h-[60dvh] w-full max-w-[90vw] mx-auto aspect-video hover:opacity-75">
                     <Link :href="`/video/`+video.id"
                         :id="video.id"
                         class="contents">

--- a/resources/js/Components/Organisms/VideoCardList.vue
+++ b/resources/js/Components/Organisms/VideoCardList.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue"
 import { IconPlayerPlay } from "@tabler/icons-vue"
 import { Link } from "@inertiajs/vue3"
+import VideoCardItem from "@/Atoms/VideoCardItem.vue"
 defineProps({
     videos: {
         type: Array,
@@ -91,38 +92,12 @@ const playVideo = (id) => {
                     class="relative isolate mb-3 flex aspect-[10/16] max-h-[42dvh] w-auto max-w-[90vw] shrink-0 snap-center flex-col justify-end gap-y-2 rounded-md bg-gradient-to-br from-gray-700 to-gray-900 md:aspect-video hover:opacity-75">
                     <Link :href="`/video/`+video.id"
                         :id="video.id"
-                        class="absolute inset-0 h-full w-full rounded-md object-cover">
-                        <div class="absolute inset-0 place-self-center">
-                            <div
-                                class="group flex h-min w-min cursor-pointer items-center justify-center rounded-full p-2 hover:bg-gray-100/20">
-                                <IconPlayerPlay
-                                    class="h-14 w-14 stroke-1 text-gray-100"/>
-                            </div>
-                        </div>
+                        class="contents">
+                        <VideoCardItem :video="video" />
                         <span class="sr-only">
                             View video for {{ video.name }}
                         </span>
                     </Link>
-
-
-                    <div class="flex flex-col px-2.5 py-3.5 sm:px-3.5 sm:py-5 gap-y-1">
-                        <p
-                            class="flex w-fit items-center gap-x-1.5 rounded bg-claytonRed/90 px-1.5 py-0.5 sm:px-2 sm:py-1 text-xs font-bold uppercase tracking-wide" v-if="is_livestreams">
-                            <span class="relative flex h-2.5 w-2.5">
-                                <span
-                                    class="absolute h-full w-full animate-ping inline-flex opacity-50 bg-white rounded-full" />
-                                <span class="h-full w-full inline-flex relative bg-white rounded-full" />
-                            </span>
-                            <span class="pb-[1.5px]">Live</span>
-                        </p>
-                        <h3
-                            class="line-clamp-1 text-lg leading-snug sm:text-2xl font-bold text-gray-100">
-                            {{ video.name }}
-                        </h3>
-                        <p class="line-clamp-1 truncate text-sm text-gray-400">
-                            10:30 AM Sunday 20th Oct
-                        </p>
-                    </div>
                 </li>
             </ul>
         </div>

--- a/resources/js/Components/Organisms/VideoViewer.vue
+++ b/resources/js/Components/Organisms/VideoViewer.vue
@@ -13,7 +13,8 @@ const getYoutubeId = (videoUrl) => {
 }
 
 const getVimeoId = (videoUrl) => {
-    const vimeoRegex = /^(http|https):\/\/vimeo.com\/([\w]+).*/; // Match strings starting with http://vimeo.com/ or https://vimeo.com/ then match from the first forwardslash after domain name until next forwardslash or end of url
+    // Regex to match strings starting with http://vimeo.com/ or https://vimeo.com/ and from there, match and extract an alphanumeric string until the end or any non-alphanumeric character (eg another forwardslash)
+    const vimeoRegex = /^(http|https):\/\/vimeo.com\/([\w]+).*/;
     const vimeoId = videoUrl.match(vimeoRegex)?.[2];
     return vimeoId
 }

--- a/resources/js/Components/Organisms/VideoViewer.vue
+++ b/resources/js/Components/Organisms/VideoViewer.vue
@@ -58,8 +58,7 @@ const videoThumbnail = (videoUrl) => {
         <div class="w-full">
             <h1 class="border-t border-gray-800 divide-grey-900 pointer-events-none my-4 text-2xl lg:text-3xl lg:pb-4 font-bold text-gray-100 line-clamp-2" v-if="video.name">{{ video.name }}</h1>
             <p
-                class="pointer-events-none line-clamp-2 text-sm font-normal text-gray-500" v-if="video.description">
-                {{ video.description }}
+                class="pointer-events-none line-clamp-2 text-sm font-normal text-gray-500" v-if="video.description" v-html="video.description">
             </p>
             <div class="grid grid-cols-4 gap-1">
                 <span

--- a/resources/js/Components/Organisms/VideoViewer.vue
+++ b/resources/js/Components/Organisms/VideoViewer.vue
@@ -12,10 +12,19 @@ const getYoutubeId = (videoUrl) => {
     return youtubeId
 }
 
+const getVimeoId = (videoUrl) => {
+    const vimeoRegex = /^(http|https):\/\/vimeo.com\/([\w]+).*/; // Match strings starting with http://vimeo.com/ or https://vimeo.com/ then match from the first forwardslash after domain name until next forwardslash or end of url
+    const vimeoId = videoUrl.match(vimeoRegex)?.[2];
+    return vimeoId
+}
+
 const getEmbedUrl = (videoUrl) => {
     const youtubeId = getYoutubeId(videoUrl)
+    const vimeoId = getVimeoId(videoUrl)
     if (youtubeId) {
         return `https://www.youtube-nocookie.com/embed/${youtubeId}?autoplay=0&playsinline=1`
+    } else if (vimeoId) {
+        return `https://player.vimeo.com/video/${vimeoId}`
     } else {
         return false
     }

--- a/resources/js/Components/Pages/Browse.vue
+++ b/resources/js/Components/Pages/Browse.vue
@@ -2,8 +2,7 @@
 import { computed } from "vue"
 import { IconPlayerPlay } from "@tabler/icons-vue"
 import { Link } from "@inertiajs/vue3"
-import VideoCardList from "@/Organisms/VideoCardList.vue"
-import Topics from "@/Organisms/Topics.vue"
+import VideoCardGrid from "@/Organisms/VideoCardGrid.vue"
 
 const props = defineProps({
     videos: {
@@ -20,7 +19,7 @@ const props = defineProps({
 
 <template>
     <!-- Something here to allow the user to navigate to the linked topics, maybe a bit like a breadcrumb trail -->
-    <VideoCardList
+    <VideoCardGrid
         :videos="videos"
         :title="title"
         :description="description ?? `Browsing videos under ` + title" />

--- a/resources/js/Components/Pages/Search.vue
+++ b/resources/js/Components/Pages/Search.vue
@@ -2,7 +2,7 @@
 import { computed } from "vue"
 import { IconPlayerPlay } from "@tabler/icons-vue"
 import { Head, Link } from "@inertiajs/vue3"
-import VideoCardList from "@/Organisms/VideoCardList.vue"
+import VideoCardGrid from "@/Organisms/VideoCardGrid.vue"
 
 const props = defineProps({
     results: {
@@ -16,5 +16,5 @@ const props = defineProps({
 
 <template>
     <Head :title="`Search: ` + searchquery" />
-    <VideoCardList :videos="results" :title="`Search for '` + searchquery + `'`" :description="`Found ` + results.length + (results.length == 1 ? ' result' : ' results')" />
+    <VideoCardGrid :videos="results" :title="`Search for '` + searchquery + `'`" :description="`Found ` + results.length + (results.length == 1 ? ' result' : ' results')" />
 </template>

--- a/resources/js/Components/Pages/Welcome.vue
+++ b/resources/js/Components/Pages/Welcome.vue
@@ -22,8 +22,7 @@ const props = defineProps({
     <VideoCardList
         :videos="livestreams"
         title="Watch Live"
-        description="We're live! Check out the current live streams below."
-        is_livestreams />
+        description="We're live! Check out the current live streams below." />
     <VideoCardList
         :videos="latest_videos"
         title="Latest Videos"


### PR DESCRIPTION
## Description

Implement vertically-scrolling grid view for videos.
Used for browsing topics, search results, etc.

This includes breaking out the video card item from VideoCardList (the horizontal scrolling carousel) into its own Atom, and using that for the both the horizontal and vertical views.

The horizontal view is still used for the homepage.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

I've tested this myself and as far as I can see it works:
- Doesn't break the existing horizontal scrolling carousel VideoCardList
- The new VideoCardGrid functions as expected, with a grid (column count responsive to screen width) that scrolls vertically.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


## What should reviewers look for?

Would be good to test on other browsers / OSes to make sure both horizontal and vertical views work, the whole card is clickable as link, etc.