### PR TITLE
Implement browse-by pages for more things

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -18,7 +18,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 
-from .views import index, search, video, browse_topic
+from .views import index, search, video, browse_bible_book, browse_channel, browse_demographic, browse_ministry, browse_series, browse_speaker, browse_topic
 
 urlpatterns = [
     path("", index, name="home"),
@@ -27,5 +27,11 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("search", search, name="search"),
     path("video/<int:id>", video, name="video"),
+    path("book/<str:id>", browse_bible_book, name="browse_bible_book"),
+    path("channel/<str:id>", browse_channel, name="browse_channel"),
+    path("demographic/<str:id>", browse_demographic, name="browse_demographic"),
+    path("ministry/<str:id>", browse_ministry, name="browse_ministry"),
+    path("series/<str:id>", browse_series, name="browse_series"),
+    path("speaker/<str:id>", browse_speaker, name="browse_speaker"),
     path("topic/<str:id>", browse_topic, name="browse_topic"),
 ]

--- a/app/views.py
+++ b/app/views.py
@@ -1,6 +1,12 @@
 from inertia import render
 import django
 from catalogue.models.video import Video
+from catalogue.models.bible_book import Bible_Book
+from catalogue.models.channel import Channel
+from catalogue.models.demograpic import Demographic # FIXME Can we rename the file to fix spelling? Or does that break things?
+from catalogue.models.ministry import Ministry
+from catalogue.models.series import Series
+from catalogue.models.speaker import Speaker
 from catalogue.models.topic import Topic
 from urllib.parse import unquote  # Import for URL decoding
 
@@ -59,6 +65,167 @@ def video(request, id):
         {"video": Video.objects.get(id=id)},
     )
 
+def browse_bible_book(request, id):
+    # Decode the URL-encoded `id` parameter
+    decoded_id = unquote(id)
+
+    try:
+        bible_book = Bible_Book.objects.get(name=decoded_id)
+    except Bible_Book.DoesNotExist as e:
+        return render(
+            request,
+            "Browse",
+            {
+                "videos": [],
+                "title": "Bible book not found: '%s'" % decoded_id,
+                "description": "Error retreiving Bible book data: '%s'" % e,
+            },
+        )
+
+    return render(
+        request,
+        "Browse",
+        {
+            "videos": bible_book.video_set.all(),
+            "title": "Bible book: %s" % decoded_id,
+            "description": bible_book.summary,
+        },
+    )
+
+def browse_channel(request, id):
+    # Decode the URL-encoded `id` parameter
+    decoded_id = unquote(id)
+
+    try:
+        channel = Channel.objects.get(name=decoded_id)
+    except Channel.DoesNotExist as e:
+        return render(
+            request,
+            "Browse",
+            {
+                "videos": [],
+                "title": "Channel not found: '%s'" % decoded_id,
+                "description": "Error retreiving channel data: '%s'" % e,
+            },
+        )
+
+    return render(
+        request,
+        "Browse",
+        {
+            "videos": channel.video_set.all(),
+            "title": "Channel: %s" % decoded_id,
+            "description": channel.summary,
+        },
+    )
+
+def browse_demographic(request, id):
+    # Decode the URL-encoded `id` parameter
+    decoded_id = unquote(id)
+
+    try:
+        demographic = Demographic.objects.get(name=decoded_id)
+    except Demographic.DoesNotExist as e:
+        return render(
+            request,
+            "Browse",
+            {
+                "videos": [],
+                "title": "Demographic not found: '%s'" % decoded_id,
+                "description": "Error retreiving demographic data: '%s'" % e,
+            },
+        )
+
+    return render(
+        request,
+        "Browse",
+        {
+            "videos": demographic.video_set.all(),
+            "title": "Demographic: %s" % decoded_id,
+            "description": demographic.summary,
+        },
+    )
+
+def browse_ministry(request, id):
+    # Decode the URL-encoded `id` parameter
+    decoded_id = unquote(id)
+
+    try:
+        ministry = Ministry.objects.get(name=decoded_id)
+    except Ministry.DoesNotExist as e:
+        return render(
+            request,
+            "Browse",
+            {
+                "videos": [],
+                "title": "Ministry not found: '%s'" % decoded_id,
+                "description": "Error retreiving ministry data: '%s'" % e,
+            },
+        )
+
+    return render(
+        request,
+        "Browse",
+        {
+            "videos": ministry.video_set.all(),
+            "title": "Ministry: %s" % decoded_id,
+            "description": ministry.summary,
+        },
+    )
+
+def browse_series(request, id):
+    # Decode the URL-encoded `id` parameter
+    decoded_id = unquote(id)
+
+    try:
+        series = Series.objects.get(name=decoded_id)
+    except Series.DoesNotExist as e:
+        return render(
+            request,
+            "Browse",
+            {
+                "videos": [],
+                "title": "Series not found: '%s'" % decoded_id,
+                "description": "Error retreiving series data: '%s'" % e,
+            },
+        )
+
+    return render(
+        request,
+        "Browse",
+        {
+            "videos": series.video_set.all(),
+            "title": "Series: %s" % decoded_id,
+            "description": series.summary,
+        },
+    )
+
+def browse_speaker(request, id):
+    # Decode the URL-encoded `id` parameter
+    decoded_id = unquote(id)
+
+    try:
+        speaker = Speaker.objects.get(name=decoded_id)
+    except Speaker.DoesNotExist as e:
+        return render(
+            request,
+            "Browse",
+            {
+                "videos": [],
+                "title": "Speaker not found: '%s'" % decoded_id,
+                "description": "Error retreiving speaker data: '%s'" % e,
+            },
+        )
+
+    return render(
+        request,
+        "Browse",
+        {
+            "videos": speaker.video_set.all(),
+            "title": "Speaker: %s" % decoded_id,
+            "description": speaker.bio,
+        },
+    )
 
 def browse_topic(request, id):
     # Decode the URL-encoded `id` parameter


### PR DESCRIPTION
Added browse-by Bible book, channel, demographic, ministry, series, speaker

Currently there's no way to access these pages beyond typing the URL manually - think this should be tackled before merging the PR

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

I've briefly tested this myself but my database is not fully linked so not tested thoroughly.
The first commit doesn't really add anything new beyond copy-pasting the existing browse_topic function and tweak for each different browse-by thing.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
