### PR TITLE
fix: order videos using date_recorded instead of date_created

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -9,8 +9,8 @@ from catalogue.models.video import Video
 def index(request):
     # Implementation of pagination will be needed in the future
 
-    livestreams = Video.objects.filter(is_livestream=True).order_by("-date_created")[:10]
-    latest_videos = Video.objects.filter(is_livestream=False).order_by("-date_created")[:10]
+    livestreams = Video.objects.filter(is_livestream=True).order_by("-date_recorded")[:10]
+    latest_videos = Video.objects.filter(is_livestream=False).order_by("-date_recorded")[:10]
     topics_all = Topic.objects.all()
 
     topics_data = [


### PR DESCRIPTION
Fix sorting issue while displaying latest videos to ensure it is in descending order by date_recorded not date_created

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

I've tested this using the imported data and sense checking the dates displayed in the latest videos list

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
