### PR TITLE
Fix path alias mismatch between Vite and TypeScript

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,7 +11,8 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./resources/js/components/*"],
+      "~/*": ["./resources/js/*"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,8 @@
     "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
-      /* Specify a set of entries that re-map imports to additional lookup locations. */ "@/*": ["./resources/js/*"],
+      "@/*": ["./resources/js/components/*"],
+      "~/*": ["./resources/js/*"],
       "ziggy-js": ["./vendor/tightenco/ziggy"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
## Summary
- Align `tsconfig.json` and `tsconfig.app.json` path aliases to match `vite.config.ts`
- `@/*` now correctly resolves to `resources/js/components/*` (was `resources/js/*`)
- `~/*` added for `resources/js/*` (matches Vite)
- Fixed `tsconfig.app.json` which had a stale `./src/*` mapping

## Test plan
- [x] `npm run type-check` passes (pre-existing errors only, none introduced by this change)
- [x] `npm run lint` passes (pre-existing errors only, none introduced by this change)
- [x] `poe test` passes

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)