### PR TITLE
Add components.json for shadcn-vue CLI

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://shadcn-vue.com/schema.json",
+  "style": "default",
+  "typescript": true,
+  "tsConfigPath": "./tsconfig.json",
+  "framework": "vite",
+  "tailwind": {
+    "config": "",
+    "css": "resources/css/app.css",
+    "baseColor": "neutral"
+  },
+  "aliases": {
+    "components": "@",
+    "utils": "@/lib/utils",
+    "ui": "@/ui",
+    "composables": "~/composables",
+    "lib": "@/lib"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `components.json` configuration for shadcn-vue CLI
- Aliases match the existing Vite config (`@` = components, `~` = resources/js)
- Enables `npx shadcn-vue@latest add <component>` to work correctly

## Test plan
- [x] Config file is valid JSON matching shadcn-vue schema
- [x] No code changes, purely additive config

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)