### PR TITLE
Add frontend linting/formatting to CI and pre-commit

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,25 @@ jobs:
           poetry install --no-interaction --no-root --only dev
           poetry self add 'poethepoet[poetry_plugin]'
 
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Lint frontend
+        run: npm run lint
+
+      - name: Check frontend formatting
+        run: npm run format-check
+
+      - name: Type check frontend
+        run: npm run type-check
+
       - name: gitleaks check
         run: docker run -v .:/src zricethezav/gitleaks:latest dir /src
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,3 +8,16 @@ repos:
     rev: v8.24.2
     hooks:
       - id: gitleaks
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier
+        entry: npx prettier --check
+        language: system
+        files: '\.(js|ts|vue|css|json)$'
+        exclude: 'package-lock\.json'
+      - id: eslint
+        name: eslint
+        entry: npx eslint
+        language: system
+        files: '\.(js|ts|vue)$'

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,8 +1,8 @@
-import { globalIgnores } from 'eslint/config'
-import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
-import pluginVue from 'eslint-plugin-vue'
-import pluginOxlint from 'eslint-plugin-oxlint'
-import skipFormatting from '@vue/eslint-config-prettier/skip-formatting'
+import skipFormatting from '@vue/eslint-config-prettier/skip-formatting';
+import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript';
+import pluginOxlint from 'eslint-plugin-oxlint';
+import pluginVue from 'eslint-plugin-vue';
+import { globalIgnores } from 'eslint/config';
 
 // To allow more languages other than `ts` in `.vue` files, uncomment the following lines:
 // import { configureVueProject } from '@vue/eslint-config-typescript'
@@ -15,7 +15,7 @@ export default defineConfigWithVueTs(
         files: ['**/*.{ts,mts,tsx,vue}'],
     },
 
-    globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
+    globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**', '**/.venv/**']),
 
     pluginVue.configs['flat/essential'],
     vueTsConfigs.recommended,

--- a/resources/js/composables/useAppearance.ts
+++ b/resources/js/composables/useAppearance.ts
@@ -8,7 +8,7 @@ export function updateTheme(value: Appearance) {
     }
 
     if (value === 'system') {
-        const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+        const _mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
 
         // FIXME: Currently the light mode looks awful due to various hardcoded colours. Force dark mode for now until that is fixed. See also /templates/app.html
         //const systemTheme = mediaQueryList.matches ? 'dark' : 'light';


### PR DESCRIPTION
## Summary
- Add `npm run lint`, `npm run format-check`, and `npm run type-check` to CI QA workflow
- Add Prettier and ESLint to pre-commit hooks alongside existing ruff hooks

## Test plan
- [x] CI workflow YAML is valid
- [x] Pre-commit config is valid
- [ ] Push branch to verify CI runs frontend checks

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)