### PR TITLE
Normalize import paths to use @ alias

### DIFF
--- a/resources/js/components/organisms/CategoriesBrowseWidget.vue
+++ b/resources/js/components/organisms/CategoriesBrowseWidget.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
-import CardSkeleton from '../atoms/CardSkeleton.vue';
+import CardSkeleton from '@/atoms/CardSkeleton.vue';
 const props = defineProps({
     categories_data: {
         type: Object,


### PR DESCRIPTION
## Summary
- Replace relative imports in `CategoriesBrowseWidget.vue` with `@/` path aliases
- Ensures all component imports use consistent alias-based paths

## Test plan
- [x] `npm run lint` passes (pre-existing issues only)
- [x] No behavioral change, purely import path normalization

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)