### PR TITLE
Consolidate icon libraries to Lucide

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
         "@headlessui/vue": "^1.7.23",
         "@heroicons/vue": "^2.2.0",
         "@inertiajs/vue3": "^2.0.9",
-        "@tabler/icons-vue": "^3.34.0",
         "@tailwindcss/vite": "^4.1.6",
         "@vitejs/plugin-vue": "^5.2.4",
         "@vueuse/core": "^13.1.0",
@@ -1883,32 +1882,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@tabler/icons": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.34.0.tgz",
-      "integrity": "sha512-jtVqv0JC1WU2TTEBN32D9+R6mc1iEBuPwLnBsWaR02SIEciu9aq5806AWkCHuObhQ4ERhhXErLEK7Fs+tEZxiA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/codecalm"
-      }
-    },
-    "node_modules/@tabler/icons-vue": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-vue/-/icons-vue-3.34.0.tgz",
-      "integrity": "sha512-5JAR3ij6APih9NNO94EA/IN7sl13Z2f60x7+F82Dt74Bt5iou0clf9mLcCDCvv3Ea91sbkNWOCF6JEx5z1bz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@tabler/icons": "3.34.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/codecalm"
-      },
-      "peerDependencies": {
-        "vue": ">=3.0.1"
       }
     },
     "node_modules/@tailwindcss/node": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@headlessui/vue": "^1.7.23",
     "@heroicons/vue": "^2.2.0",
     "@inertiajs/vue3": "^2.0.9",
-    "@tabler/icons-vue": "^3.34.0",
     "@tailwindcss/vite": "^4.1.6",
     "@vitejs/plugin-vue": "^5.2.4",
     "@vueuse/core": "^13.1.0",

--- a/resources/js/components/atoms/VideoCardItem.vue
+++ b/resources/js/components/atoms/VideoCardItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import LogoMark from '@/atoms/LogoMark.vue';
-import { IconPlayerPlay } from '@tabler/icons-vue';
+import { Play } from 'lucide-vue-next';
 defineProps({
     video: {
         type: Object,
@@ -41,7 +41,7 @@ const getVideoThumbnail = (video) => {
         <div
             class="group absolute inset-0 flex h-min w-min cursor-pointer items-center justify-center place-self-center rounded-full p-2 hover:bg-gray-100/20"
         >
-            <IconPlayerPlay class="h-14 w-14 stroke-1 text-gray-100" />
+            <Play class="h-14 w-14 stroke-1 text-gray-100" />
         </div>
 
         <div class="z-10 z-50 flex w-svw flex-col gap-y-1 place-self-end rounded-b-md bg-black/60 px-2.5 py-3.5 sm:px-3.5 sm:py-2">


### PR DESCRIPTION
## Summary
- Replace `IconPlayerPlay` from `@tabler/icons-vue` with `Play` from `lucide-vue-next` in `VideoCardItem.vue`
- Remove unused Tabler import from `Browse.vue`
- Uninstall `@tabler/icons-vue` — Lucide is the shadcn-vue default

## Test plan
- [x] `npm run lint` passes (pre-existing oxlint warning in `useAppearance.ts` unrelated)
- [x] Zero remaining `@tabler` imports
- [x] Manual: play icon renders on video cards

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)