### PR TITLE
Fix layout import paths to use ~ alias

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -5,7 +5,7 @@ import { createApp, DefineComponent, h } from 'vue';
 import { resolvePageComponent } from '~/lib/inertia-helper';
 import { initializeTheme } from './composables/useAppearance';
 
-import AppLayout from '@/layouts/AppLayout.vue';
+import AppLayout from '~/layouts/AppLayout.vue';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Clayton TV';
 

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import AppLayout from '@/layouts/app/AppSidebarLayout.vue';
+import AppLayout from '~/layouts/app/AppSidebarLayout.vue';
 import type { BreadcrumbItemType } from '@/types';
 
 interface Props {

--- a/resources/js/pages/CatalogueIndex.vue
+++ b/resources/js/pages/CatalogueIndex.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import Video from '@/atoms/Video.vue';
 import PlaceholderPattern from '@/PlaceholderPattern.vue';
-import AppLayout from '@/layouts/AppLayout.vue';
+import AppLayout from '~/layouts/AppLayout.vue';
 import { BreadcrumbItem } from '@/types';
 import { Deferred, Head } from '@inertiajs/vue3';
 


### PR DESCRIPTION
## Summary
- Fix `app.ts`, `layouts/AppLayout.vue`, and `pages/CatalogueIndex.vue` to use `~/layouts/` instead of `@/layouts/`
- The `@` alias resolves to `resources/js/components/`, but layouts live at `resources/js/layouts/`
- These imports were previously resolving to the legacy `components/layouts/AppLayout.vue` which was deleted in #125

**This is a critical fix** — the deploy workflow is currently failing because the Vite build can't find the deleted file.

## Test plan
- [x] Import paths correctly resolve to `resources/js/layouts/`
- [ ] `npm run build-only` passes (currently blocked by a separate `@tabler/icons-vue` issue from #132)
- [ ] Deploy workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)