### PR TITLE
feat (claytontv/6): hide Livestreams section from landing page if there are no livestreams returned

### DIFF
--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -20,12 +20,17 @@ const props = defineProps({
 </script>
 
 <template>
-    <VideoCardList :videos="livestreams" description="We're live! Check out the current live streams below." title="Watch Live" />
-    <Link href="/livestreams" class="flex w-fit mx-auto">
-        <button class="bg-blue-950 w-auto rounded-md p-3 cursor-pointer">
-            Browse All
-        </button>
-    </Link>
+    <div v-if="livestreams?.length">
+        <VideoCardList
+            :videos="livestreams"
+            description="We're live! Check out the current live streams below."
+            title="Watch Live"
+            class="flex justify-center"
+        />
+        <Link href="/livestreams" class="mx-auto flex w-fit">
+            <button class="w-auto cursor-pointer rounded-md bg-blue-950 p-3">Browse All</button>
+        </Link>
+    </div>
     <VideoCardList :videos="latest_videos" description="Watch our most recent videos here." title="Latest Videos" />
     <Link href="/latest" class="flex w-fit mx-auto">
         <button class="bg-blue-950 w-auto rounded-md p-3 cursor-pointer">


### PR DESCRIPTION
Hide livestreams section from landing page if there are no livestreams being returned

I've tested this:
- with empty livestreams array
- with one livestream video being returned and the section will show again