### PR TITLE
Normalize import paths to use @ alias

### DIFF
--- a/resources/js/components/organisms/CategoriesBrowseWidget.vue
+++ b/resources/js/components/organisms/CategoriesBrowseWidget.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
-import CardSkeleton from '../atoms/CardSkeleton.vue';
+import CardSkeleton from '@/atoms/CardSkeleton.vue';
 const props = defineProps({
     categories_data: {
         type: Object,


### PR DESCRIPTION
## Summary
- Replace the remaining relative `../atoms/` import with the `@/atoms/` alias in `CategoriesBrowseWidget.vue`
- Ensures consistent import style across all frontend components

## Test plan
- [x] Verify `poe dev` starts without import resolution errors
- [x] Verify `npm run type-check` passes
- [x] Confirm CategoriesBrowseWidget renders correctly with CardSkeleton

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)