### PR TITLE
Uninstall unused UI packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,10 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@headlessui/vue": "^1.7.23",
-        "@heroicons/vue": "^2.2.0",
         "@inertiajs/vue3": "^2.0.9",
-        "@tabler/icons-vue": "^3.34.0",
         "@tailwindcss/vite": "^4.1.6",
         "@vitejs/plugin-vue": "^5.2.4",
         "@vueuse/core": "^13.1.0",
@@ -1198,30 +1195,6 @@
         }
       }
     },
-    "node_modules/@headlessui/vue": {
-      "version": "1.7.23",
-      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.23.tgz",
-      "integrity": "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/vue-virtual": "^3.0.0-beta.60"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "vue": "^3.2.0"
-      }
-    },
-    "node_modules/@heroicons/vue": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.2.0.tgz",
-      "integrity": "sha512-G3dbSxoeEKqbi/DFalhRxJU4mTXJn7GwZ7ae8NuEQzd1bqdd0jAbdaBZlHPcvPD2xI1iGzNVB4k20Un2AguYPw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "vue": ">= 3"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1883,32 +1856,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@tabler/icons": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.34.0.tgz",
-      "integrity": "sha512-jtVqv0JC1WU2TTEBN32D9+R6mc1iEBuPwLnBsWaR02SIEciu9aq5806AWkCHuObhQ4ERhhXErLEK7Fs+tEZxiA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/codecalm"
-      }
-    },
-    "node_modules/@tabler/icons-vue": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-vue/-/icons-vue-3.34.0.tgz",
-      "integrity": "sha512-5JAR3ij6APih9NNO94EA/IN7sl13Z2f60x7+F82Dt74Bt5iou0clf9mLcCDCvv3Ea91sbkNWOCF6JEx5z1bz/g==",
-      "license": "MIT",
-      "dependencies": {
-        "@tabler/icons": "3.34.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/codecalm"
-      },
-      "peerDependencies": {
-        "vue": ">=3.0.1"
       }
     },
     "node_modules/@tailwindcss/node": {

--- a/package.json
+++ b/package.json
@@ -36,10 +36,7 @@
     "vue-tsc": "^2.2.8"
   },
   "dependencies": {
-    "@headlessui/vue": "^1.7.23",
-    "@heroicons/vue": "^2.2.0",
     "@inertiajs/vue3": "^2.0.9",
-    "@tabler/icons-vue": "^3.34.0",
     "@tailwindcss/vite": "^4.1.6",
     "@vitejs/plugin-vue": "^5.2.4",
     "@vueuse/core": "^13.1.0",


### PR DESCRIPTION
## Summary
- Uninstalls `@headlessui/vue`, `@heroicons/vue`, and `@tabler/icons-vue` from the project
- These packages have zero imports remaining after the frontend component refactoring
- Reduces bundle size and dependency count

Closes #114

## Test plan
- [ ] Verify `npm run build` completes without errors
- [ ] Verify no runtime errors related to missing imports
- [ ] Confirm no remaining imports of these packages exist in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)