### PR TITLE
Switch from sidebar to top-nav header layout

### DIFF
--- a/resources/js/components/layout/AppContent.vue
+++ b/resources/js/components/layout/AppContent.vue
@@ -15,7 +15,7 @@ const className = computed(() => props.class);
     <SidebarInset v-if="props.variant === 'sidebar'" :class="className">
         <slot />
     </SidebarInset>
-    <main v-else class="mx-auto flex h-full w-full max-w-7xl flex-1 flex-col gap-4 rounded-xl" :class="className">
+    <main v-else class="flex h-full w-full flex-1 flex-col" :class="className">
         <slot />
     </main>
 </template>

--- a/resources/js/components/layout/AppFooter.vue
+++ b/resources/js/components/layout/AppFooter.vue
@@ -1,0 +1,83 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3'
+import { Github, Youtube } from 'lucide-vue-next'
+import AppLogoIcon from '@/AppLogoIcon.vue'
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { Separator } from '@/ui/separator'
+
+const year = new Date().getFullYear()
+</script>
+
+<template>
+    <footer class="bg-gradient-to-b from-gray-800 to-gray-950 text-gray-300">
+        <div class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
+            <!-- Newsletter -->
+            <div class="mb-10 text-center">
+                <h3 class="text-lg font-semibold text-white">Stay up to date</h3>
+                <p class="mt-1 text-sm text-gray-400">Get notified when new content is added.</p>
+                <form class="mx-auto mt-4 flex max-w-md gap-2">
+                    <Input
+                        type="email"
+                        name="email"
+                        placeholder="Enter your email"
+                        required
+                        class="h-10 flex-1 border-white/20 bg-white/10 text-sm text-white placeholder:text-gray-400 focus:border-white/40"
+                    />
+                    <Button type="submit" class="h-10 shrink-0">Subscribe</Button>
+                </form>
+            </div>
+
+            <Separator class="bg-gray-700" />
+
+            <!-- Branding + socials -->
+            <div class="flex flex-col items-center gap-6 pt-8">
+                <div class="flex items-center gap-3">
+                    <div class="flex size-10 items-center justify-center rounded-md bg-white/10">
+                        <AppLogoIcon class="size-6 fill-current text-white" />
+                    </div>
+                    <div>
+                        <Link href="/" class="text-lg font-semibold text-white hover:text-gray-200">Clayton TV</Link>
+                        <p class="text-xs text-gray-400">Christian media library</p>
+                    </div>
+                </div>
+
+                <!-- Social icons -->
+                <div class="flex items-center gap-4">
+                    <a
+                        href="https://www.youtube.com/@ClaytonTV"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-gray-400 transition-colors hover:text-white"
+                        aria-label="YouTube"
+                    >
+                        <Youtube class="size-5" />
+                    </a>
+                    <a
+                        href="https://vimeo.com/claytontv"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-gray-400 transition-colors hover:text-white"
+                        aria-label="Vimeo"
+                    >
+                        <svg class="size-5" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M23.977 6.416c-.105 2.338-1.739 5.543-4.894 9.609C15.9 20.48 12.96 22.5 10.548 22.5c-1.49 0-2.751-1.38-3.783-4.135l-2.07-7.584C3.966 8.023 3.19 6.643 2.358 6.643c-.188 0-.845.396-1.97 1.185L-.001 7.23c1.238-1.09 2.46-2.18 3.658-3.269 1.65-1.427 2.888-2.178 3.715-2.253 1.952-.189 3.152 1.146 3.604 4.005.486 3.086.824 5.006 1.012 5.756.562 2.556 1.18 3.834 1.855 3.834.524 0 1.311-.829 2.36-2.487 1.047-1.66 1.608-2.924 1.68-3.792.15-1.435-.414-2.153-1.69-2.153-.601 0-1.22.138-1.856.414 1.232-4.038 3.587-5.999 7.066-5.883 2.58.075 3.796 1.749 3.574 5.034z" />
+                        </svg>
+                    </a>
+                    <a
+                        href="https://github.com/Clayton-TV"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-gray-400 transition-colors hover:text-white"
+                        aria-label="GitHub"
+                    >
+                        <Github class="size-5" />
+                    </a>
+                </div>
+
+                <!-- Copyright -->
+                <p class="text-xs text-gray-500">&copy; {{ year }} The Jesmond Trust. All rights reserved.</p>
+            </div>
+        </div>
+    </footer>
+</template>

--- a/resources/js/components/layout/AppFooter.vue
+++ b/resources/js/components/layout/AppFooter.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { Link } from '@inertiajs/vue3'
 import { Github, Youtube } from 'lucide-vue-next'
-import AppLogoIcon from '@/AppLogoIcon.vue'
+import LogoMark from '@/atoms/LogoMark.vue'
 import { Button } from '@/ui/button'
 import { Input } from '@/ui/input'
-import { Separator } from '@/ui/separator'
 
 const year = new Date().getFullYear()
 </script>
@@ -13,54 +12,47 @@ const year = new Date().getFullYear()
     <footer class="bg-gradient-to-b from-gray-800 to-gray-950 text-gray-300">
         <div class="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8">
             <!-- Newsletter -->
-            <div class="mb-10 text-center">
-                <h3 class="text-lg font-semibold text-white">Stay up to date</h3>
-                <p class="mt-1 text-sm text-gray-400">Get notified when new content is added.</p>
-                <form class="mx-auto mt-4 flex max-w-md gap-2">
+            <div class="mx-auto max-w-lg">
+                <h3 class="text-xl font-bold text-white">Want some occasional updates from us?</h3>
+                <form class="mt-4 flex flex-col gap-3">
                     <Input
                         type="email"
                         name="email"
                         placeholder="Enter your email"
                         required
-                        class="h-10 flex-1 border-white/20 bg-white/10 text-sm text-white placeholder:text-gray-400 focus:border-white/40"
+                        class="h-12 w-full rounded-lg border-white/20 bg-white/10 text-sm text-white placeholder:text-gray-400 focus:border-white/40"
                     />
-                    <Button type="submit" class="h-10 shrink-0">Subscribe</Button>
+                    <Button type="submit" class="h-12 w-full text-base font-semibold">Subscribe</Button>
                 </form>
             </div>
 
-            <Separator class="bg-gray-700" />
-
             <!-- Branding + socials -->
-            <div class="flex flex-col items-center gap-6 pt-8">
-                <div class="flex items-center gap-3">
-                    <div class="flex size-10 items-center justify-center rounded-md bg-white/10">
-                        <AppLogoIcon class="size-6 fill-current text-white" />
-                    </div>
-                    <div>
-                        <Link href="/" class="text-lg font-semibold text-white hover:text-gray-200">Clayton TV</Link>
-                        <p class="text-xs text-gray-400">Christian media library</p>
-                    </div>
-                </div>
+            <div class="mt-12 flex flex-col items-center gap-4">
+                <Link href="/" class="flex items-center gap-3">
+                    <LogoMark class="size-12 fill-red-500" />
+                    <span class="text-3xl font-bold text-white">Clayton TV</span>
+                </Link>
+                <p class="text-base italic text-gray-400">Your digital catalogue for Godly content.</p>
 
                 <!-- Social icons -->
-                <div class="flex items-center gap-4">
+                <div class="mt-2 flex items-center gap-3">
                     <a
                         href="https://www.youtube.com/@ClaytonTV"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-gray-400 transition-colors hover:text-white"
+                        class="flex size-12 items-center justify-center rounded-lg bg-white/10 text-gray-300 transition-colors hover:bg-white/20 hover:text-white"
                         aria-label="YouTube"
                     >
-                        <Youtube class="size-5" />
+                        <Youtube class="size-6" />
                     </a>
                     <a
                         href="https://vimeo.com/claytontv"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-gray-400 transition-colors hover:text-white"
+                        class="flex size-12 items-center justify-center rounded-lg bg-white/10 text-gray-300 transition-colors hover:bg-white/20 hover:text-white"
                         aria-label="Vimeo"
                     >
-                        <svg class="size-5" viewBox="0 0 24 24" fill="currentColor">
+                        <svg class="size-6" viewBox="0 0 24 24" fill="currentColor">
                             <path d="M23.977 6.416c-.105 2.338-1.739 5.543-4.894 9.609C15.9 20.48 12.96 22.5 10.548 22.5c-1.49 0-2.751-1.38-3.783-4.135l-2.07-7.584C3.966 8.023 3.19 6.643 2.358 6.643c-.188 0-.845.396-1.97 1.185L-.001 7.23c1.238-1.09 2.46-2.18 3.658-3.269 1.65-1.427 2.888-2.178 3.715-2.253 1.952-.189 3.152 1.146 3.604 4.005.486 3.086.824 5.006 1.012 5.756.562 2.556 1.18 3.834 1.855 3.834.524 0 1.311-.829 2.36-2.487 1.047-1.66 1.608-2.924 1.68-3.792.15-1.435-.414-2.153-1.69-2.153-.601 0-1.22.138-1.856.414 1.232-4.038 3.587-5.999 7.066-5.883 2.58.075 3.796 1.749 3.574 5.034z" />
                         </svg>
                     </a>
@@ -68,16 +60,16 @@ const year = new Date().getFullYear()
                         href="https://github.com/Clayton-TV"
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-gray-400 transition-colors hover:text-white"
+                        class="flex size-12 items-center justify-center rounded-lg bg-white/10 text-gray-300 transition-colors hover:bg-white/20 hover:text-white"
                         aria-label="GitHub"
                     >
-                        <Github class="size-5" />
+                        <Github class="size-6" />
                     </a>
                 </div>
-
-                <!-- Copyright -->
-                <p class="text-xs text-gray-500">&copy; {{ year }} The Jesmond Trust. All rights reserved.</p>
             </div>
+
+            <!-- Copyright -->
+            <p class="mt-10 text-center text-sm text-gray-500">&copy; {{ year }} The Jesmond Trust. All rights reserved.</p>
         </div>
     </footer>
 </template>

--- a/resources/js/components/layout/AppHeader.vue
+++ b/resources/js/components/layout/AppHeader.vue
@@ -56,6 +56,7 @@ function isActive(href: string): boolean {
                         <NavigationMenuLink as-child>
                             <Link
                                 :href="item.href"
+                                prefetch
                                 :class="[
                                     navigationMenuTriggerStyle(),
                                     'bg-transparent text-gray-300 hover:bg-white/10 hover:text-white focus:bg-white/10 focus:text-white',
@@ -123,6 +124,7 @@ function isActive(href: string): boolean {
                             v-for="item in navItems"
                             :key="item.name"
                             :href="item.href"
+                            prefetch
                             :class="[
                                 'rounded-md px-3 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-white/10 hover:text-white',
                                 isActive(item.href) && 'bg-white/10 text-white',

--- a/resources/js/components/layout/AppHeader.vue
+++ b/resources/js/components/layout/AppHeader.vue
@@ -2,7 +2,7 @@
 import { Link, usePage } from '@inertiajs/vue3'
 import { computed, ref } from 'vue'
 import { Menu, Search } from 'lucide-vue-next'
-import AppLogoIcon from '@/AppLogoIcon.vue'
+import LogoMark from '@/atoms/LogoMark.vue'
 import { Button } from '@/ui/button'
 import { Input } from '@/ui/input'
 import { Separator } from '@/ui/separator'
@@ -43,9 +43,7 @@ function isActive(href: string): boolean {
         <div class="mx-auto flex h-14 max-w-7xl items-center gap-4 px-4 sm:px-6 lg:px-8">
             <!-- Logo -->
             <Link href="/" class="flex shrink-0 items-center gap-2">
-                <div class="flex size-8 items-center justify-center rounded-md bg-white/10">
-                    <AppLogoIcon class="size-5 fill-current text-white" />
-                </div>
+                <LogoMark class="size-7 fill-red-500" />
                 <span class="text-sm font-semibold text-white">Clayton TV</span>
             </Link>
 
@@ -97,7 +95,7 @@ function isActive(href: string): boolean {
                 <SheetContent side="right" class="w-72 bg-gray-900 text-white border-gray-800">
                     <SheetHeader>
                         <SheetTitle class="flex items-center gap-2 text-white">
-                            <AppLogoIcon class="size-5 fill-current text-white" />
+                            <LogoMark class="size-6 fill-red-500" />
                             Clayton TV
                         </SheetTitle>
                         <SheetDescription class="sr-only">Navigation menu</SheetDescription>

--- a/resources/js/components/layout/AppHeader.vue
+++ b/resources/js/components/layout/AppHeader.vue
@@ -1,0 +1,139 @@
+<script setup lang="ts">
+import { Link, usePage } from '@inertiajs/vue3'
+import { computed, ref } from 'vue'
+import { Menu, Search } from 'lucide-vue-next'
+import AppLogoIcon from '@/AppLogoIcon.vue'
+import { Button } from '@/ui/button'
+import { Input } from '@/ui/input'
+import { Separator } from '@/ui/separator'
+import {
+    NavigationMenu,
+    NavigationMenuItem,
+    NavigationMenuLink,
+    NavigationMenuList,
+    navigationMenuTriggerStyle,
+} from '@/ui/navigation-menu'
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetHeader,
+    SheetTitle,
+    SheetTrigger,
+} from '@/ui/sheet'
+
+const navItems = [
+    { name: 'Livestreams', href: '/livestreams' },
+    { name: 'Latest', href: '/latest' },
+    { name: 'Series', href: '/series' },
+    { name: 'Topics', href: '/topic' },
+]
+
+const currentUrl = computed(() => usePage().url)
+const searchQuery = ref('')
+const mobileOpen = ref(false)
+
+function isActive(href: string): boolean {
+    return currentUrl.value.startsWith(href)
+}
+</script>
+
+<template>
+    <header class="sticky top-0 z-50 w-full border-b bg-gray-900 shadow-sm">
+        <div class="mx-auto flex h-14 max-w-7xl items-center gap-4 px-4 sm:px-6 lg:px-8">
+            <!-- Logo -->
+            <Link href="/" class="flex shrink-0 items-center gap-2">
+                <div class="flex size-8 items-center justify-center rounded-md bg-white/10">
+                    <AppLogoIcon class="size-5 fill-current text-white" />
+                </div>
+                <span class="text-sm font-semibold text-white">Clayton TV</span>
+            </Link>
+
+            <!-- Desktop nav -->
+            <NavigationMenu class="hidden md:flex" :viewport="false">
+                <NavigationMenuList>
+                    <NavigationMenuItem v-for="item in navItems" :key="item.name">
+                        <NavigationMenuLink as-child>
+                            <Link
+                                :href="item.href"
+                                :class="[
+                                    navigationMenuTriggerStyle(),
+                                    'bg-transparent text-gray-300 hover:bg-white/10 hover:text-white focus:bg-white/10 focus:text-white',
+                                    isActive(item.href) && 'bg-white/10 text-white',
+                                ]"
+                            >
+                                {{ item.name }}
+                            </Link>
+                        </NavigationMenuLink>
+                    </NavigationMenuItem>
+                </NavigationMenuList>
+            </NavigationMenu>
+
+            <div class="flex-1" />
+
+            <!-- Desktop search -->
+            <form action="/search" method="get" class="hidden items-center gap-2 md:flex">
+                <div class="relative">
+                    <Search class="absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-gray-400" />
+                    <Input
+                        v-model="searchQuery"
+                        type="search"
+                        name="q"
+                        placeholder="Search..."
+                        class="h-9 w-48 border-white/20 bg-white/10 pl-8 text-sm text-white placeholder:text-gray-400 focus:border-white/40 focus:bg-white/15 lg:w-64"
+                    />
+                </div>
+            </form>
+
+            <!-- Mobile hamburger -->
+            <Sheet v-model:open="mobileOpen">
+                <SheetTrigger as-child>
+                    <Button variant="ghost" size="icon" class="md:hidden text-gray-300 hover:bg-white/10 hover:text-white">
+                        <Menu class="size-5" />
+                        <span class="sr-only">Open menu</span>
+                    </Button>
+                </SheetTrigger>
+                <SheetContent side="right" class="w-72 bg-gray-900 text-white border-gray-800">
+                    <SheetHeader>
+                        <SheetTitle class="flex items-center gap-2 text-white">
+                            <AppLogoIcon class="size-5 fill-current text-white" />
+                            Clayton TV
+                        </SheetTitle>
+                        <SheetDescription class="sr-only">Navigation menu</SheetDescription>
+                    </SheetHeader>
+
+                    <!-- Mobile search -->
+                    <form action="/search" method="get" class="px-1 pb-4">
+                        <div class="relative">
+                            <Search class="absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-gray-400" />
+                            <Input
+                                type="search"
+                                name="q"
+                                placeholder="Search..."
+                                class="h-9 w-full border-white/20 bg-white/10 pl-8 text-sm text-white placeholder:text-gray-400"
+                            />
+                        </div>
+                    </form>
+
+                    <Separator class="bg-gray-700" />
+
+                    <!-- Mobile nav links -->
+                    <nav class="flex flex-col gap-1 pt-4">
+                        <Link
+                            v-for="item in navItems"
+                            :key="item.name"
+                            :href="item.href"
+                            :class="[
+                                'rounded-md px-3 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-white/10 hover:text-white',
+                                isActive(item.href) && 'bg-white/10 text-white',
+                            ]"
+                            @click="mobileOpen = false"
+                        >
+                            {{ item.name }}
+                        </Link>
+                    </nav>
+                </SheetContent>
+            </Sheet>
+        </div>
+    </header>
+</template>

--- a/resources/js/components/ui/navigation-menu/NavigationMenu.vue
+++ b/resources/js/components/ui/navigation-menu/NavigationMenu.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { NavigationMenuRootProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { NavigationMenuRoot, useForwardPropsEmits } from 'reka-ui'
+import { cn } from '@/lib/utils'
+import NavigationMenuViewport from './NavigationMenuViewport.vue'
+
+const props = withDefaults(
+    defineProps<NavigationMenuRootProps & { class?: HTMLAttributes['class']; viewport?: boolean }>(),
+    { viewport: true },
+)
+
+const emits = defineEmits<NavigationMenuRootProps>()
+
+const delegatedProps = reactiveOmit(props, 'class', 'viewport')
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+    <NavigationMenuRoot
+        data-slot="navigation-menu"
+        :data-viewport="viewport"
+        v-bind="forwarded"
+        :class="cn('group/navigation-menu relative flex max-w-max flex-1 items-center justify-center', props.class)"
+    >
+        <slot />
+        <NavigationMenuViewport v-if="viewport" />
+    </NavigationMenuRoot>
+</template>

--- a/resources/js/components/ui/navigation-menu/NavigationMenuContent.vue
+++ b/resources/js/components/ui/navigation-menu/NavigationMenuContent.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { NavigationMenuContentProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { NavigationMenuContent, useForwardPropsEmits } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<NavigationMenuContentProps & { class?: HTMLAttributes['class'] }>()
+
+const emits = defineEmits<NavigationMenuContentProps>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+    <NavigationMenuContent
+        data-slot="navigation-menu-content"
+        v-bind="forwarded"
+        :class="
+            cn(
+                'data-[motion^=from-]:animate-in data-[motion^=to-]:animate-out data-[motion^=from-]:fade-in data-[motion^=to-]:fade-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 top-0 left-0 w-full p-2 pr-2.5 md:absolute md:w-auto',
+                'group-data-[viewport=false]/navigation-menu:bg-popover group-data-[viewport=false]/navigation-menu:text-popover-foreground group-data-[viewport=false]/navigation-menu:data-[state=open]:animate-in group-data-[viewport=false]/navigation-menu:data-[state=closed]:animate-out group-data-[viewport=false]/navigation-menu:data-[state=closed]:zoom-out-95 group-data-[viewport=false]/navigation-menu:data-[state=open]:zoom-in-95 group-data-[viewport=false]/navigation-menu:mt-1.5 group-data-[viewport=false]/navigation-menu:overflow-hidden group-data-[viewport=false]/navigation-menu:rounded-md group-data-[viewport=false]/navigation-menu:border group-data-[viewport=false]/navigation-menu:shadow group-data-[viewport=false]/navigation-menu:[&_[data-slot=navigation-menu-link]]:focus:ring-0 group-data-[viewport=false]/navigation-menu:[&_[data-slot=navigation-menu-link]]:focus:outline-none',
+                props.class,
+            )
+        "
+    >
+        <slot />
+    </NavigationMenuContent>
+</template>

--- a/resources/js/components/ui/navigation-menu/NavigationMenuIndicator.vue
+++ b/resources/js/components/ui/navigation-menu/NavigationMenuIndicator.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { NavigationMenuIndicatorProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { NavigationMenuIndicator, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<NavigationMenuIndicatorProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+    <NavigationMenuIndicator
+        data-slot="navigation-menu-indicator"
+        v-bind="forwardedProps"
+        :class="
+            cn(
+                'data-[state=visible]:animate-in data-[state=hidden]:animate-out data-[state=hidden]:fade-out data-[state=visible]:fade-in top-full z-[1] flex h-1.5 items-end justify-center overflow-hidden',
+                props.class,
+            )
+        "
+    >
+        <div class="bg-border relative top-[60%] size-2 rotate-45 rounded-tl-sm shadow-md" />
+    </NavigationMenuIndicator>
+</template>

--- a/resources/js/components/ui/navigation-menu/NavigationMenuItem.vue
+++ b/resources/js/components/ui/navigation-menu/NavigationMenuItem.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { NavigationMenuItemProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { NavigationMenuItem, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<NavigationMenuItemProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+    <NavigationMenuItem
+        data-slot="navigation-menu-item"
+        v-bind="forwardedProps"
+        :class="cn('relative', props.class)"
+    >
+        <slot />
+    </NavigationMenuItem>
+</template>

--- a/resources/js/components/ui/navigation-menu/NavigationMenuLink.vue
+++ b/resources/js/components/ui/navigation-menu/NavigationMenuLink.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import type { NavigationMenuLinkProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { NavigationMenuLink, useForwardPropsEmits } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<NavigationMenuLinkProps & { class?: HTMLAttributes['class'] }>()
+
+const emits = defineEmits<NavigationMenuLinkProps>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+const forwarded = useForwardPropsEmits(delegatedProps, emits)
+</script>
+
+<template>
+    <NavigationMenuLink
+        data-slot="navigation-menu-link"
+        v-bind="forwarded"
+        :class="
+            cn(
+                'data-active:focus:bg-accent data-active:hover:bg-accent data-active:bg-accent/50 inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50',
+                props.class,
+            )
+        "
+    >
+        <slot />
+    </NavigationMenuLink>
+</template>

--- a/resources/js/components/ui/navigation-menu/NavigationMenuList.vue
+++ b/resources/js/components/ui/navigation-menu/NavigationMenuList.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { NavigationMenuListProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { NavigationMenuList, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<NavigationMenuListProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+    <NavigationMenuList
+        data-slot="navigation-menu-list"
+        v-bind="forwardedProps"
+        :class="cn('group flex flex-1 list-none items-center justify-center gap-1', props.class)"
+    >
+        <slot />
+    </NavigationMenuList>
+</template>

--- a/resources/js/components/ui/navigation-menu/NavigationMenuTrigger.vue
+++ b/resources/js/components/ui/navigation-menu/NavigationMenuTrigger.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import type { NavigationMenuTriggerProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { NavigationMenuTrigger, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+import { ChevronDown } from 'lucide-vue-next'
+import { navigationMenuTriggerStyle } from '.'
+
+const props = defineProps<NavigationMenuTriggerProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+    <NavigationMenuTrigger
+        data-slot="navigation-menu-trigger"
+        v-bind="forwardedProps"
+        :class="cn(navigationMenuTriggerStyle(), 'group', props.class)"
+    >
+        <slot />
+        <ChevronDown
+            class="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
+            aria-hidden="true"
+        />
+    </NavigationMenuTrigger>
+</template>

--- a/resources/js/components/ui/navigation-menu/NavigationMenuViewport.vue
+++ b/resources/js/components/ui/navigation-menu/NavigationMenuViewport.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { NavigationMenuViewportProps } from 'reka-ui'
+import type { HTMLAttributes } from 'vue'
+import { reactiveOmit } from '@vueuse/core'
+import { NavigationMenuViewport, useForwardProps } from 'reka-ui'
+import { cn } from '@/lib/utils'
+
+const props = defineProps<NavigationMenuViewportProps & { class?: HTMLAttributes['class'] }>()
+
+const delegatedProps = reactiveOmit(props, 'class')
+const forwardedProps = useForwardProps(delegatedProps)
+</script>
+
+<template>
+    <div class="absolute top-full left-0 isolate z-50 flex justify-center">
+        <NavigationMenuViewport
+            data-slot="navigation-menu-viewport"
+            v-bind="forwardedProps"
+            :class="
+                cn(
+                    'origin-top-center bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 relative mt-1.5 h-[var(--reka-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border shadow md:w-[var(--reka-navigation-menu-viewport-width)] left-[var(--reka-navigation-menu-viewport-left)]',
+                    props.class,
+                )
+            "
+        />
+    </div>
+</template>

--- a/resources/js/components/ui/navigation-menu/index.ts
+++ b/resources/js/components/ui/navigation-menu/index.ts
@@ -1,0 +1,14 @@
+import { cva } from 'class-variance-authority'
+
+export { default as NavigationMenu } from './NavigationMenu.vue'
+export { default as NavigationMenuContent } from './NavigationMenuContent.vue'
+export { default as NavigationMenuIndicator } from './NavigationMenuIndicator.vue'
+export { default as NavigationMenuItem } from './NavigationMenuItem.vue'
+export { default as NavigationMenuLink } from './NavigationMenuLink.vue'
+export { default as NavigationMenuList } from './NavigationMenuList.vue'
+export { default as NavigationMenuTrigger } from './NavigationMenuTrigger.vue'
+export { default as NavigationMenuViewport } from './NavigationMenuViewport.vue'
+
+export const navigationMenuTriggerStyle = cva(
+    'group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1',
+)

--- a/resources/js/layouts/AppLayout.vue
+++ b/resources/js/layouts/AppLayout.vue
@@ -1,18 +1,9 @@
 <script setup lang="ts">
-import AppLayout from '~/layouts/app/AppSidebarLayout.vue';
-import type { BreadcrumbItemType } from '~/types';
-
-interface Props {
-    breadcrumbs?: BreadcrumbItemType[];
-}
-
-withDefaults(defineProps<Props>(), {
-    breadcrumbs: () => [],
-});
+import AppHeaderLayout from '~/layouts/app/AppHeaderLayout.vue';
 </script>
 
 <template>
-    <AppLayout :breadcrumbs="breadcrumbs">
+    <AppHeaderLayout>
         <slot />
-    </AppLayout>
+    </AppHeaderLayout>
 </template>

--- a/resources/js/layouts/app/AppHeaderLayout.vue
+++ b/resources/js/layouts/app/AppHeaderLayout.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import AppContent from '@/AppContent.vue'
+import AppFooter from '@/layout/AppFooter.vue'
+import AppHeader from '@/layout/AppHeader.vue'
+import AppShell from '@/AppShell.vue'
+</script>
+
+<template>
+    <AppShell variant="header">
+        <AppHeader />
+        <AppContent variant="header">
+            <slot />
+        </AppContent>
+        <AppFooter />
+    </AppShell>
+</template>

--- a/resources/js/layouts/app/AppHeaderLayout.vue
+++ b/resources/js/layouts/app/AppHeaderLayout.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import AppContent from '@/AppContent.vue'
-import AppFooter from '@/layout/AppFooter.vue'
-import AppHeader from '@/layout/AppHeader.vue'
-import AppShell from '@/AppShell.vue'
+import AppContent from '@/layout/AppContent.vue';
+import AppFooter from '@/layout/AppFooter.vue';
+import AppHeader from '@/layout/AppHeader.vue';
+import AppShell from '@/layout/AppShell.vue';
 </script>
 
 <template>

--- a/resources/js/pages/CatalogueIndex.vue
+++ b/resources/js/pages/CatalogueIndex.vue
@@ -1,16 +1,8 @@
 <script lang="ts" setup>
 import Video from '@/atoms/Video.vue';
 import PlaceholderPattern from '@/layout/PlaceholderPattern.vue';
-import { Deferred, Head } from '@inertiajs/vue3';
 import AppLayout from '~/layouts/AppLayout.vue';
-import type { BreadcrumbItem } from '~/types';
-
-const breadcrumbs: BreadcrumbItem[] = [
-    {
-        title: 'Catalogue',
-        href: '/catalogue',
-    },
-];
+import { Deferred, Head } from '@inertiajs/vue3';
 
 defineProps<{
     videos: any[];
@@ -19,9 +11,9 @@ defineProps<{
 
 <template>
     <Head title="Catalogue" />
-    <AppLayout :breadcrumbs>
-        <div class="@container flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
-            <div class="grid min-w-24 auto-rows-min grid-cols-1 gap-y-4 @md:grid-cols-2 @xl:grid-cols-3">
+    <AppLayout>
+        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4 @container">
+            <div class="grid auto-rows-min min-w-24 gap-y-4 grid-cols-1 @md:grid-cols-2 @xl:grid-cols-3">
                 <Deferred data="videos">
                     <template #fallback>
                         <div class="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">


### PR DESCRIPTION
## Summary

- Replace sidebar layout with a sticky top navigation bar (AppHeader) featuring horizontal nav links, search input, and mobile hamburger Sheet menu
- Add footer (AppFooter) with newsletter signup form, social icons (YouTube, Vimeo, GitHub), and copyright
- Install shadcn-vue NavigationMenu component for accessible nav links
- Create AppHeaderLayout using existing `AppShell` and `AppContent` header variants
- Remove breadcrumbs from AppLayout and CatalogueIndex

## Test plan

- [ ] `poe dev` — site loads with top navigation bar instead of sidebar
- [ ] Logo links to `/`
- [ ] Nav links (Livestreams, Latest, Series, Topics) navigate correctly and highlight active page
- [ ] Search input is present and submits to `/search`
- [ ] Mobile: hamburger menu opens Sheet with nav links and search
- [ ] Footer renders with newsletter form, social icons, copyright
- [ ] All existing pages (Welcome, Browse, CatalogueIndex, WatchVideo, CategoriesBrowsePage) render correctly

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)