### PR TITLE
fix (claytontv/122): use justify-safe-center to auto justify video card list

### DIFF
--- a/resources/js/components/organisms/VideoCardList.vue
+++ b/resources/js/components/organisms/VideoCardList.vue
@@ -68,7 +68,7 @@ const playVideo = (id) => {
         </div>
 
         <div class="mt-2 w-full overflow-x-hidden">
-            <ul class="flex snap-x snap-mandatory gap-x-4 overflow-x-auto px-2">
+            <ul class="flex snap-x snap-mandatory gap-x-4 overflow-x-auto px-2 justify-center-safe">
                 <li
                     v-for="video in videos"
                     :key="video.id"


### PR DESCRIPTION
Use 'justify-safe-center' so that:
- items are centred if there are not enough items to spill over the x axis,
- otherwise display items with items pulled to the left