### PR TITLE
Epic 1: observability wiring (Sentry, PostHog, DB health checks)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,9 @@ VITE_HOST=localhost
 VITE_PORT=5173
 INERTIA_SSR_ENABLED=False
 # INERTIA_SSR_URL=http://127.0.0.1:13714
+
+# Observability (leave empty locally; set on servers / CI)
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=
+VITE_POSTHOG_KEY=
+VITE_POSTHOG_HOST=

--- a/.github/workflows/deploy-to-beta.yaml
+++ b/.github/workflows/deploy-to-beta.yaml
@@ -42,6 +42,10 @@ jobs:
 
       - name: Build assets
         run: npm run build-only
+        env:
+          # Vite env vars bake in at build time; analytics no-ops if unset.
+          VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ vars.VITE_POSTHOG_HOST }}
 
       - name: Configure SSH
         run: |

--- a/app/production_settings.py
+++ b/app/production_settings.py
@@ -8,6 +8,18 @@ from .base_settings import *  # noqa: F403
 SECRET_KEY = os.environ.get("SECRET_KEY")
 DEBUG = os.getenv("DEBUG", "False").lower() in ("true", "1", "yes")
 
+# Error tracking (self-hosted, sentry.tgo.dev). Activates only when a DSN is
+# present in the environment, so local/CI runs are unaffected.
+if os.getenv("SENTRY_DSN"):
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=os.environ["SENTRY_DSN"],
+        environment=os.getenv("SENTRY_ENVIRONMENT", "beta"),
+        traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "0.1")),
+        send_default_pii=False,
+    )
+
 # Django wildcard syntax is a leading dot (".example.com" matches subdomains);
 # the previous "*.claytontv.co.uk" entry matched nothing.
 ALLOWED_HOSTS = ["claytontv.test", "claytontv.co.uk", ".claytontv.co.uk"]
@@ -35,6 +47,10 @@ else:
         "default": dj_database_url.config(
             default=os.getenv("DATABASE_URL"),
             conn_max_age=600,
+            # Pooled connections must be health-checked: a postgres restart
+            # during the 2026-06-12 apt upgrade left every worker serving a
+            # dead connection ("SSL connection has been closed unexpectedly").
+            conn_health_checks=True,
         ),
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "claytontv",
       "dependencies": {
         "@headlessui/vue": "^1.7.23",
         "@heroicons/vue": "^2.2.0",
@@ -17,6 +16,7 @@
         "clsx": "^2.1.1",
         "concurrently": "^9.1.2",
         "lucide-vue-next": "^0.509.0",
+        "posthog-js": "^1.386.6",
         "reka-ui": "^2.2.1",
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^4.1.6",
@@ -1570,6 +1570,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@posthog/core": {
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.32.3.tgz",
+      "integrity": "sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.386.3"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.386.3",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.386.3.tgz",
+      "integrity": "sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
@@ -2303,6 +2318,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
@@ -3258,6 +3280,17 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3380,6 +3413,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.9.tgz",
+      "integrity": "sha512-4dPSRMRDqHvs0V4YDFCsaIZo4if5u0xM+llyxiM2fwuZFdKArUBAF3VtI2+n8NKg9P870WMdYk0UhqQNoWXbfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -3886,6 +3928,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "6.1.0",
@@ -5267,6 +5315,32 @@
         "node": ">=4"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.386.6",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.386.6.tgz",
+      "integrity": "sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@posthog/core": "^1.32.3",
+        "@posthog/types": "^1.386.3",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5427,6 +5501,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6380,6 +6460,12 @@
       "peerDependencies": {
         "typescript": ">=5.0.0"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "clsx": "^2.1.1",
     "concurrently": "^9.1.2",
     "lucide-vue-next": "^0.509.0",
+    "posthog-js": "^1.386.6",
     "reka-ui": "^2.2.1",
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "dj-database-url>=2.3",
     "inertia-django>=1.2",
     "django-vite>=3.1",
+    "sentry-sdk>=2.62.0",
 ]
 
 [dependency-groups]

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -2,6 +2,7 @@ import '../css/app.css';
 
 import { createInertiaApp } from '@inertiajs/vue3';
 import { createApp, createSSRApp, DefineComponent, h } from 'vue';
+import { initializeAnalytics } from '~/lib/analytics';
 import { resolvePageComponent } from '~/lib/inertia-helper';
 import { initializeTheme } from './composables/useAppearance';
 
@@ -41,3 +42,4 @@ createInertiaApp({
 });
 
 initializeTheme();
+initializeAnalytics();

--- a/resources/js/lib/analytics.ts
+++ b/resources/js/lib/analytics.ts
@@ -1,0 +1,38 @@
+import { router } from '@inertiajs/vue3';
+
+/**
+ * Privacy-respecting analytics (self-hosted PostHog).
+ *
+ * Activates only when VITE_POSTHOG_KEY is present at build time, so local
+ * dev and CI capture nothing. Configured cookieless: persistence lives in
+ * memory only, no cross-visit identifiers, no person profiles for anonymous
+ * visitors — usage trends without tracking individuals.
+ *
+ * posthog-js is heavy (~200 kB), so it loads as a lazy chunk after boot and
+ * never ships in keyless builds.
+ */
+export async function initializeAnalytics() {
+    const key = import.meta.env.VITE_POSTHOG_KEY;
+
+    if (!key) {
+        return;
+    }
+
+    const { default: posthog } = await import('posthog-js');
+
+    posthog.init(key, {
+        api_host: import.meta.env.VITE_POSTHOG_HOST || 'https://posthog.tgo.dev',
+        persistence: 'memory',
+        person_profiles: 'identified_only',
+        autocapture: false,
+        capture_pageview: true,
+        capture_pageleave: false,
+        disable_session_recording: true,
+        respect_dnt: true,
+    });
+
+    // Inertia SPA visits don't reload the page; report them as pageviews.
+    router.on('navigate', (event) => {
+        posthog.capture('$pageview', { $current_url: event.detail.page.url });
+    });
+}

--- a/tests/test_production_settings.py
+++ b/tests/test_production_settings.py
@@ -1,0 +1,38 @@
+"""Production settings are env-driven; import the module fresh per scenario."""
+
+import importlib
+import sys
+
+import sentry_sdk
+
+
+def reload_production_settings(monkeypatch, **env):
+    for key in ("SENTRY_DSN", "SENTRY_ENVIRONMENT", "DATABASE_URL", "REDIS_URL"):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    sys.modules.pop("app.production_settings", None)
+    return importlib.import_module("app.production_settings")
+
+
+def test_pooled_connections_are_health_checked(monkeypatch):
+    """A postgres restart once left every worker serving a dead pooled
+    connection (500s until manual restart); health checks make that self-heal."""
+    settings = reload_production_settings(monkeypatch, DATABASE_URL="postgres://u:p@localhost:5432/db")
+
+    db = settings.DATABASES["default"]
+    assert db["CONN_HEALTH_CHECKS"] is True
+    assert db["CONN_MAX_AGE"] == 600
+
+
+def test_sentry_initializes_only_when_dsn_is_set(monkeypatch):
+    calls = []
+    monkeypatch.setattr(sentry_sdk, "init", lambda **kwargs: calls.append(kwargs))
+
+    reload_production_settings(monkeypatch)
+    assert calls == []
+
+    reload_production_settings(monkeypatch, SENTRY_DSN="https://key@sentry.tgo.dev/1")
+    assert len(calls) == 1
+    assert calls[0]["dsn"] == "https://key@sentry.tgo.dev/1"
+    assert calls[0]["send_default_pii"] is False

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "python-dotenv" },
     { name = "redis" },
+    { name = "sentry-sdk" },
     { name = "whitenoise" },
 ]
 
@@ -108,6 +109,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.3" },
     { name = "python-dotenv", specifier = ">=1.1" },
     { name = "redis", specifier = ">=5.2" },
+    { name = "sentry-sdk", specifier = ">=2.62.0" },
     { name = "whitenoise", specifier = ">=6.9" },
 ]
 
@@ -556,6 +558,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
     { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
     { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/5d/a343201726150e05f2036eeb6e493e2e2f8bf8a66f5aa70f2f4ac96f9ca3/sentry_sdk-2.62.0.tar.gz", hash = "sha256:3c870b9f50d9fd15b58c817dbde1c7cfaa9fe3f05df0a4c6edd5571cb82f5491", size = 463986, upload-time = "2026-06-08T13:23:49.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/07/05440381627877aae223fd68f330df9b9fc6641d08bf65328b55235617a2/sentry_sdk-2.62.0-py3-none-any.whl", hash = "sha256:27f61d13a86c3c1648dec666dd5a64f79772dd6a84b446f11866601ecab24f6f", size = 490586, upload-time = "2026-06-08T13:23:47.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Sentry (sentry.tgo.dev) gated on `SENTRY_DSN`; PostHog (posthog.tgo.dev) gated on build-time `VITE_POSTHOG_KEY`, cookieless/privacy-first, lazy-loaded so the main bundle stays 198 kB
- Inertia SPA navigations reported as pageviews
- `CONN_HEALTH_CHECKS=True` — makes the postgres-restart incident class self-healing
- Settings behaviour covered by tests; deploy workflow bakes the Vite vars

## Activation (after merge)
1. `SENTRY_DSN=` (+ optional `SENTRY_ENVIRONMENT=beta`) in `/srv/beta-claytontv/shared/.env`, then `sudo systemctl restart gunicorn-claytontv-beta`
2. `VITE_POSTHOG_KEY` secret in the GitHub `beta` environment (next deploy bakes it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)