### PR TITLE
Epic 6 phase 1: card/nav polish, mobile overflow fix, lazy images

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -37,7 +37,8 @@ createInertiaApp({
             .mount(el);
     },
     progress: {
-        color: '#4B5563',
+        // Brand red (matches --primary) so navigation feedback reads as intentional
+        color: 'oklch(0.637 0.237 25.331)',
     },
 });
 

--- a/resources/js/components/atoms/VideoCardItem.vue
+++ b/resources/js/components/atoms/VideoCardItem.vue
@@ -1,60 +1,74 @@
 <script setup>
-import { computed } from "vue"
-import { IconPlayerPlay } from "@tabler/icons-vue"
-import { Link } from "@inertiajs/vue3"
-import LogoMark from "@/atoms/LogoMark.vue"
+import LogoMark from '@/atoms/LogoMark.vue';
+import { IconPlayerPlay } from '@tabler/icons-vue';
+
 defineProps({
     video: {
         type: Object,
         required: true,
     },
-})
+});
 
 const getVideoThumbnail = (video) => {
-    if (video.thumbnail?.startsWith("http")) {
-        return video.thumbnail
+    if (video.thumbnail?.startsWith('http')) {
+        return video.thumbnail;
     } else {
         const youtubeRegex = /^.*(youtu\.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/;
         const youtubeId = video.url.match(youtubeRegex)?.[2];
         if (youtubeId) {
-            // If youtube URL
-            // Attempt to split the video ID off the end, then shoehorn it into the thumbnail URL
-            return `https://img.youtube.com/vi/${youtubeId}/mqdefault.jpg`
+            // Derive the thumbnail from the YouTube video ID when none is stored
+            return `https://img.youtube.com/vi/${youtubeId}/mqdefault.jpg`;
         }
     }
-    return null
-}
+    return null;
+};
 </script>
 
 <template>
-    <div class="w-full h-full flex rounded-md bg-gradient-to-br from-gray-700 to-gray-900 group">
-        <LogoMark class="fill-primary pointer-events-none place-self-center items-center justify-center absolute inset-0 h-[40%] object-cover opacity-80 group-hover:opacity-55" />
+    <div class="group relative flex h-full w-full overflow-hidden rounded-lg bg-gradient-to-br from-gray-700 to-gray-900">
+        <LogoMark class="fill-primary pointer-events-none absolute inset-0 h-[40%] place-self-center object-cover opacity-80" />
 
-        <img v-if="getVideoThumbnail(video)" :src="getVideoThumbnail(video)" alt="" class="pointer-events-none place-self-center items-center justify-center absolute inset-0 size-full object-cover group-hover:opacity-75 rounded-md" onerror="this.style.opacity='0';" />
+        <img
+            v-if="getVideoThumbnail(video)"
+            :src="getVideoThumbnail(video)"
+            alt=""
+            loading="lazy"
+            decoding="async"
+            class="pointer-events-none absolute inset-0 size-full place-self-center object-cover transition-transform duration-300 ease-out group-hover:scale-[1.03] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
+            onerror="this.style.opacity='0';"
+        />
 
-        <div class="absolute inset-0 place-self-center group flex h-min w-min cursor-pointer items-center justify-center rounded-full p-2 hover:bg-gray-100/20">
-            <IconPlayerPlay class="h-14 w-14 stroke-1 text-gray-100"/>
+        <!-- Bottom scrim keeps the play glyph and title legible over any thumbnail -->
+        <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" aria-hidden="true"></div>
+
+        <div
+            class="absolute inset-0 flex h-min w-min items-center justify-center place-self-center rounded-full bg-black/30 p-2 opacity-90 backdrop-blur-[2px] transition-opacity duration-200 ease-out group-hover:opacity-100"
+            aria-hidden="true"
+        >
+            <IconPlayerPlay class="h-14 w-14 stroke-1 text-gray-100" />
         </div>
 
-        <div class="flex flex-col px-2.5 py-3.5 sm:px-3.5 w-svw sm:py-2 gap-y-1 place-self-end z-10 rounded-b-md bg-black/60 z-50">
-            <h3 class="line-clamp-1 group-hover:line-clamp-3 transition transition-all duration-150 text-lg leading-snug sm:text-2xl font-bold text-white">
+        <div class="z-10 flex w-full flex-col gap-y-1 place-self-end bg-black/60 px-2.5 py-3.5 backdrop-blur-sm sm:px-3.5 sm:py-2">
+            <h3 class="line-clamp-1 text-lg leading-snug font-bold text-white group-hover:line-clamp-3 sm:text-2xl">
                 {{ video.name }}
             </h3>
             <div class="flex flex-row justify-between">
-                <p class="line-clamp-1 truncate text-sm text-white h-6">
-                    {{ video.date_recorded ? "Recorded: " + video.date_recorded : "Added: " + video.date_created }}
+                <p class="line-clamp-1 h-6 truncate text-sm text-white tabular-nums">
+                    {{ video.date_recorded ? 'Recorded: ' + video.date_recorded : 'Added: ' + video.date_created }}
                 </p>
-                <p class="flex w-min items-center gap-x-1.5 rounded bg-red-400/90 px-1.5 py-0.5 sm:px-2 text-xs font-bold uppercase tracking-wide" v-if="video.is_livestream">
+                <p
+                    class="bg-primary text-primary-foreground flex w-min items-center gap-x-1.5 rounded px-1.5 py-0.5 text-xs font-bold tracking-wide uppercase sm:px-2"
+                    v-if="video.is_livestream"
+                >
                     <span class="relative flex h-2.5 w-2.5">
-                        <span class="absolute h-full w-full animate-ping inline-flex opacity-50 bg-white rounded-full" />
-                        <span class="h-full w-full inline-flex relative bg-white rounded-full" />
+                        <span class="absolute inline-flex h-full w-full animate-ping rounded-full bg-white opacity-50 motion-reduce:animate-none" />
+                        <span class="relative inline-flex h-full w-full rounded-full bg-white" />
                     </span>
                     <span class="pb-[1.5px]">Live</span>
                 </p>
             </div>
         </div>
     </div>
-
 </template>
 
 <style scoped></style>

--- a/resources/js/components/layouts/AppLayout.vue
+++ b/resources/js/components/layouts/AppLayout.vue
@@ -53,9 +53,10 @@ const submitSearch = () => {
                                     <Link
                                         v-for="option in navOptions"
                                         :key="option.name"
-                                        :class="isCurrent(option.href) ? 'bg-gray-900 text-white' : ''"
-                                        class="rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white"
+                                        :class="isCurrent(option.href) ? 'bg-white/10 text-white' : 'text-gray-300'"
+                                        class="focus-visible:ring-ring rounded-md px-3 py-2.5 text-sm font-medium transition-colors duration-150 outline-none hover:bg-gray-700 hover:text-white focus-visible:ring-2"
                                         :href="option.href"
+                                        :aria-current="isCurrent(option.href) ? 'page' : undefined"
                                     >
                                         {{ option.name }}
                                     </Link>
@@ -69,9 +70,10 @@ const submitSearch = () => {
                                     <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
                                         <MagnifyingGlassIcon aria-hidden="true" class="h-5 w-5 text-gray-400" />
                                     </div>
+                                    <!-- text-base (16px) prevents iOS Safari from zooming the page on focus -->
                                     <input
                                         id="search"
-                                        class="block h-9 w-full rounded-md border-0 bg-gray-700 py-1.5 pr-3 pl-10 text-gray-300 placeholder:text-gray-400 focus:bg-white focus:text-gray-900 focus:ring-0 sm:text-sm sm:leading-6"
+                                        class="focus:ring-ring block h-10 w-full rounded-md border-0 bg-gray-700 py-1.5 pr-3 pl-10 text-base text-gray-100 transition-colors duration-150 placeholder:text-gray-400 focus:bg-gray-600 focus:ring-2 focus:outline-none sm:leading-6"
                                         name="search"
                                         v-model="searchForm.search"
                                         placeholder="Search"

--- a/resources/js/components/organisms/VideoCardGrid.vue
+++ b/resources/js/components/organisms/VideoCardGrid.vue
@@ -1,7 +1,6 @@
 <script setup>
-import { computed } from "vue"
-import VideoCardItem from "@/atoms/VideoCardItem.vue"
-import { Link, router } from "@inertiajs/vue3"
+import VideoCardItem from '@/atoms/VideoCardItem.vue';
+import { Link, router } from '@inertiajs/vue3';
 defineProps({
     videos: {
         type: Array,
@@ -21,19 +20,19 @@ defineProps({
     has_next_page: {
         type: Boolean,
     },
-})
+});
 
 const prevPage = () => {
-    const pageRegex = /[?&]page=([0-9]+).*/
-    const curPage = parseInt(window.location.search.match(pageRegex)?.[1])
-    router.get("#", {"page" : (isNaN(curPage) || curPage <= 1) ? 1 : curPage - 1})
-}
+    const pageRegex = /[?&]page=([0-9]+).*/;
+    const curPage = parseInt(window.location.search.match(pageRegex)?.[1]);
+    router.get('#', { page: isNaN(curPage) || curPage <= 1 ? 1 : curPage - 1 });
+};
 
 const nextPage = () => {
-    const pageRegex = /[?&]page=([0-9]+).*/
-    const curPage = parseInt(window.location.search.match(pageRegex)?.[1])
-    router.get("#", {"page" : isNaN(curPage) ? 2 : curPage + 1}) // If no page parameter then next page is second not first
-}
+    const pageRegex = /[?&]page=([0-9]+).*/;
+    const curPage = parseInt(window.location.search.match(pageRegex)?.[1]);
+    router.get('#', { page: isNaN(curPage) ? 2 : curPage + 1 }); // If no page parameter then next page is second not first
+};
 </script>
 
 <template>
@@ -46,31 +45,37 @@ const nextPage = () => {
         </div>
 
         <div class="mt-2 w-full overflow-x-hidden">
-            <ul class="grid gridl-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 overflow-x-auto px-4 lg:px-8">
-                <li
-                    v-for="video in videos"
-                    :key="video.id"
-                    class="relative isolate max-h-[60dvh] w-full max-w-[90vw] mx-auto aspect-video hover:opacity-75">
-                    <Link :href="`/video/`+video.id"
+            <ul class="grid grid-cols-1 gap-4 overflow-x-auto px-4 sm:grid-cols-2 lg:grid-cols-3 lg:px-8">
+                <li v-for="video in videos" :key="video.id" class="relative isolate mx-auto aspect-video max-h-[60dvh] w-full max-w-[90vw]">
+                    <!-- Link is the block (not display:contents) so keyboard focus can draw a ring -->
+                    <Link
+                        :href="`/video/` + video.id"
                         :id="video.id"
-                        class="contents">
+                        class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                    >
                         <VideoCardItem :video="video" />
-                        <span class="sr-only">
-                            View video for {{ video.name }}
-                        </span>
+                        <span class="sr-only"> View video for {{ video.name }} </span>
                     </Link>
                 </li>
             </ul>
         </div>
 
-        <div class="flex">
-            <button class="bg-blue-950 w-auto rounded-md p-2 ml-auto mr-2 cursor-pointer disabled:cursor-default opacity-50 enabled:opacity-100" @click="prevPage()" :disabled="!has_prev_page">
+        <nav class="flex gap-x-4" aria-label="Pagination">
+            <button
+                class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-md bg-gray-800 px-4 py-2 font-medium text-gray-100 transition-colors duration-150 outline-none hover:bg-gray-700 focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-gray-800"
+                @click="prevPage()"
+                :disabled="!has_prev_page"
+            >
                 Prev Page
             </button>
-            <button class="bg-blue-950 w-auto rounded-md p-2 mr-auto ml-2 cursor-pointer disabled:cursor-default opacity-50 enabled:opacity-100" @click="nextPage()" :disabled="!has_next_page">
+            <button
+                class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-md bg-gray-800 px-4 py-2 font-medium text-gray-100 transition-colors duration-150 outline-none hover:bg-gray-700 focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-gray-800"
+                @click="nextPage()"
+                :disabled="!has_next_page"
+            >
                 Next Page
             </button>
-        </div>
+        </nav>
     </section>
 </template>
 


### PR DESCRIPTION
## Summary
- Fixes the 375px horizontal scroll (card overlay used `w-svw`)
- Keyboard-focusable video cards (was `display: contents` — no ring possible), visible active-nav state + `aria-current`
- Lazy-loaded thumbnails, transform-only hover micro-interactions, `prefers-reduced-motion` respected throughout, no `transition: all`
- 44px tap targets on pagination, 16px search input (no iOS focus zoom), brand-red progress bar + LIVE badge

## Verification
Browser-verified desktop and 375px mobile; document no longer overflows; build + tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)