### PR TITLE
Epic 6.4–6.6 slice: watch/browse/search cohesion + deferred props + prefetch

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -2,7 +2,7 @@ from urllib.parse import unquote  # Import for URL decoding
 
 from django.core.paginator import Paginator
 from django.db.models import Count
-from inertia import render
+from inertia import defer, render
 
 from catalogue.models.bible_book import Bible_Book
 from catalogue.models.channel import Channel
@@ -214,12 +214,26 @@ def video(request, id):
                 else:
                     video_metadata[p] = {"name": props[p][0].name, "url": props[p][0].get_absolute_url()}
 
+        def up_next():
+            # Series→video links live on the Series.videos M2M (no reverse
+            # accessor from Video: related_name="+"), so filter by membership.
+            series = Series.objects.filter(videos=video_object).first()
+            if series is None:
+                return None
+            return {
+                "series": {"name": series.name, "url": series.get_absolute_url()},
+                "videos": video_card_props(series.videos.exclude(id=video_object.id).order_by("-date_recorded")[:6]),
+            }
+
         return render(
             request,
             "WatchVideo",
             {
                 "video": video_object,
                 "video_metadata": video_metadata,
+                # Deferred: the player paints immediately; the rail streams in
+                # right after via the Inertia v3 deferred-props round trip.
+                "up_next": defer(up_next),
             },
         )
     except Video.DoesNotExist:

--- a/resources/js/components/layouts/AppHeader.vue
+++ b/resources/js/components/layouts/AppHeader.vue
@@ -45,6 +45,7 @@ const submitSearch = () => {
                     v-for="option in navOptions"
                     :key="option.name"
                     :href="option.href"
+                    prefetch
                     :class="isCurrent(option.href) ? 'bg-white/10 text-white' : 'text-gray-400'"
                     class="focus-visible:ring-ring rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2"
                     :aria-current="isCurrent(option.href) ? 'page' : undefined"

--- a/resources/js/components/molecules/SeriesCard.vue
+++ b/resources/js/components/molecules/SeriesCard.vue
@@ -10,6 +10,7 @@ defineProps({
 <template>
     <Link
         :href="series.url"
+        prefetch
         class="group focus-visible:ring-ring flex gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-4 transition-colors duration-150 outline-none hover:border-white/20 hover:bg-white/[0.06] focus-visible:ring-2"
     >
         <div class="bg-primary/10 flex h-20 w-20 flex-none items-center justify-center rounded-lg" aria-hidden="true">

--- a/resources/js/components/organisms/VideoCardGrid.vue
+++ b/resources/js/components/organisms/VideoCardGrid.vue
@@ -36,44 +36,42 @@ const nextPage = () => {
 </script>
 
 <template>
-    <section class="mb-10 flex flex-col items-center gap-y-6">
-        <div class="space-y-2">
-            <h2 class="mt-8 text-center text-3xl font-bold text-gray-100" v-if="title">
+    <section class="flex flex-col gap-y-6">
+        <div v-if="title || description">
+            <h1 v-if="title" class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">
                 {{ title }}
-            </h2>
-            <p class="mt-2 text-center text-gray-400" v-if="description" v-html="description"></p>
+            </h1>
+            <p v-if="description" class="mt-2 text-sm text-gray-500" v-html="description"></p>
         </div>
 
-        <div class="mt-2 w-full overflow-x-hidden">
-            <ul class="grid grid-cols-1 gap-4 overflow-x-auto px-4 sm:grid-cols-2 lg:grid-cols-3 lg:px-8">
-                <li v-for="video in videos" :key="video.id" class="relative isolate mx-auto aspect-video max-h-[60dvh] w-full max-w-[90vw]">
-                    <!-- Link is the block (not display:contents) so keyboard focus can draw a ring -->
-                    <Link
-                        :href="`/video/` + video.id"
-                        :id="video.id"
-                        class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-black motion-reduce:transition-none motion-reduce:hover:translate-y-0"
-                    >
-                        <VideoCardItem :video="video" />
-                        <span class="sr-only"> View video for {{ video.name }} </span>
-                    </Link>
-                </li>
-            </ul>
-        </div>
+        <ul class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            <li v-for="video in videos" :key="video.id" class="relative isolate aspect-video">
+                <Link
+                    :href="`/video/` + video.id"
+                    :id="video.id"
+                    prefetch
+                    class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                >
+                    <VideoCardItem :video="video" />
+                    <span class="sr-only"> View video for {{ video.name }} </span>
+                </Link>
+            </li>
+        </ul>
 
-        <nav class="flex gap-x-4" aria-label="Pagination">
+        <nav v-if="has_prev_page || has_next_page" class="flex justify-center gap-x-3" aria-label="Pagination">
             <button
-                class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-md bg-gray-800 px-4 py-2 font-medium text-gray-100 transition-colors duration-150 outline-none hover:bg-gray-700 focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-gray-800"
+                class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-lg border border-white/15 px-5 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-35 disabled:hover:border-white/15"
                 @click="prevPage()"
                 :disabled="!has_prev_page"
             >
-                Prev Page
+                Previous
             </button>
             <button
-                class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-md bg-gray-800 px-4 py-2 font-medium text-gray-100 transition-colors duration-150 outline-none hover:bg-gray-700 focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-gray-800"
+                class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-lg border border-white/15 px-5 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-35 disabled:hover:border-white/15"
                 @click="nextPage()"
                 :disabled="!has_next_page"
             >
-                Next Page
+                Next
             </button>
         </nav>
     </section>

--- a/resources/js/components/organisms/VideoViewer.vue
+++ b/resources/js/components/organisms/VideoViewer.vue
@@ -39,42 +39,22 @@ const getEmbedUrl = (videoUrl) => {
 </script>
 
 <template>
-    <div class="mx-4 mb-0 mb-2 flex flex-col p-2 lg:p-0">
-        <div class="aspect-video max-h-[max(calc(100vh-20rem),85vh)]">
-            <iframe
-                class="mx-auto aspect-video h-full"
-                :src="getEmbedUrl(video.url)"
-                allow="autoplay; clipboard-write"
-                referrerpolicy="strict-origin-when-cross-origin"
-                allowfullscreen
-                v-if="getEmbedUrl(video.url)"
-            >
-            </iframe>
-            <div class="h-full bg-gray-900 p-4" v-else>
-                <!-- Shown if there was a problem generating the embedded video iframe src -->
-                Unable to load embedded video for
-                <a :href="video.url" class="underline">
-                    {{ video.url }}
-                </a>
-            </div>
-        </div>
-        <div class="w-full">
-            <h1
-                class="divide-grey-900 pointer-events-none my-4 line-clamp-2 border-t border-gray-800 text-2xl font-bold text-gray-100 lg:pb-4 lg:text-3xl"
-                v-if="video.name"
-            >
-                {{ video.name }}
-            </h1>
-            <p class="pointer-events-none line-clamp-2 text-sm font-normal text-gray-500" v-if="video.description" v-html="video.description"></p>
-            <div class="grid grid-cols-4 gap-1">
-                <span class="pointer-events-none col-span-2 text-xs font-normal text-gray-400">{{ video.speaker?.[0]?.name ?? 'Speaker Name' }}</span>
-                <span class="pointer-events-none col-span-1 text-right text-xs font-normal text-gray-400">{{
-                    video.date_created ?? '01/01/01'
-                }}</span>
-                <span class="pointer-events-none col-span-1 text-right text-xs font-normal text-gray-400">{{ video.duration ?? '00:00' }}</span>
-            </div>
+    <div class="aspect-video w-full overflow-hidden rounded-xl border border-white/10 bg-black">
+        <iframe
+            v-if="getEmbedUrl(video.url)"
+            class="h-full w-full"
+            :src="getEmbedUrl(video.url)"
+            allow="autoplay; clipboard-write; fullscreen; picture-in-picture"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allowfullscreen
+            :title="video.name"
+        >
+        </iframe>
+        <div v-else class="flex h-full items-center justify-center p-6 text-sm text-gray-400">
+            <p>
+                We couldn't embed this video.
+                <a :href="video.url" class="text-primary underline underline-offset-4" rel="noopener" target="_blank">Watch it at the source</a>
+            </p>
         </div>
     </div>
 </template>
-
-<style scoped></style>

--- a/resources/js/pages/Browse.vue
+++ b/resources/js/pages/Browse.vue
@@ -1,8 +1,6 @@
 <script setup>
-import { computed } from "vue"
-import { IconPlayerPlay } from "@tabler/icons-vue"
-import { Link } from "@inertiajs/vue3"
-import VideoCardGrid from "@/organisms/VideoCardGrid.vue"
+import VideoCardGrid from '@/organisms/VideoCardGrid.vue';
+import { Head } from '@inertiajs/vue3';
 
 const props = defineProps({
     videos: {
@@ -20,14 +18,12 @@ const props = defineProps({
     has_next_page: {
         type: Boolean,
     },
-})
+});
 </script>
 
 <template>
-    <VideoCardGrid
-        :videos="videos"
-        :title="title"
-        :description="description ?? `Browsing videos under ` + title"
-        :has_prev_page
-        :has_next_page />
+    <Head :title="title" />
+    <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
+        <VideoCardGrid :videos="videos" :title="title" :description="description ?? `Browsing videos under ` + title" :has_prev_page :has_next_page />
+    </div>
 </template>

--- a/resources/js/pages/CatalogueIndex.vue
+++ b/resources/js/pages/CatalogueIndex.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import Video from '@/atoms/Video.vue';
-import PlaceholderPattern from '@/PlaceholderPattern.vue';
 import AppLayout from '@/layouts/AppLayout.vue';
+import PlaceholderPattern from '@/PlaceholderPattern.vue';
 import { BreadcrumbItem } from '@/types';
 import { Deferred, Head } from '@inertiajs/vue3';
 
@@ -20,8 +20,8 @@ defineProps<{
 <template>
     <Head title="Catalogue" />
     <AppLayout :breadcrumbs>
-        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4 @container">
-            <div class="grid auto-rows-min min-w-24 gap-y-4 grid-cols-1 @md:grid-cols-2 @xl:grid-cols-3">
+        <div class="@container flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
+            <div class="grid min-w-24 auto-rows-min grid-cols-1 gap-y-4 @md:grid-cols-2 @xl:grid-cols-3">
                 <Deferred data="videos">
                     <template #fallback>
                         <div class="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">

--- a/resources/js/pages/CategoriesBrowsePage.vue
+++ b/resources/js/pages/CategoriesBrowsePage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import CategoriesBrowseWidget from "@/organisms/CategoriesBrowseWidget.vue"
+import CategoriesBrowseWidget from '@/organisms/CategoriesBrowseWidget.vue';
 
 const props = defineProps({
     title: {
@@ -21,7 +21,7 @@ const props = defineProps({
     subcategories_sort_order: {
         type: String,
     },
-})
+});
 </script>
 
 <template>

--- a/resources/js/pages/Search.vue
+++ b/resources/js/pages/Search.vue
@@ -1,13 +1,11 @@
 <script setup>
-import { computed } from "vue"
-import { IconPlayerPlay } from "@tabler/icons-vue"
-import { Link } from "@inertiajs/vue3"
-import VideoCardGrid from "@/organisms/VideoCardGrid.vue"
-import CategoriesBrowseWidget from '@/organisms/CategoriesBrowseWidget.vue';
+import VideoCardGrid from '@/organisms/VideoCardGrid.vue';
+import { Head, Link } from '@inertiajs/vue3';
 
 const props = defineProps({
     categories: {
         type: Array,
+        default: () => [],
     },
     videos: {
         type: Array,
@@ -24,31 +22,38 @@ const props = defineProps({
     has_next_page: {
         type: Boolean,
     },
-})
+});
 </script>
 
 <template>
-    <!-- TODO might be worth paginating categories separately from video results, and making backend only redo search for one or other when switching pages -->
-    <div class="mt-8 justify-items-center space-y-2">
-        <h2 class="text-center text-3xl font-bold text-gray-100">
-            {{ title }}
-        </h2>
+    <Head :title="title" />
+    <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
+        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">{{ title }}</h1>
+        <p v-if="description" class="mt-2 text-sm text-gray-500">{{ description }}</p>
+
+        <section v-if="categories?.length" class="mt-8" aria-label="Matching categories">
+            <h2 class="text-xs font-medium tracking-wider text-gray-500 uppercase">
+                {{ categories.length }} matching {{ categories.length === 1 ? 'category' : 'categories' }}
+            </h2>
+            <div class="mt-3 flex flex-wrap gap-2.5">
+                <Link
+                    v-for="category in categories"
+                    :key="category.url"
+                    :href="category.url"
+                    prefetch
+                    class="focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-4 text-[13px] text-gray-300 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2"
+                >
+                    <span>{{ category.name }}</span>
+                    <span class="text-xs text-gray-500">{{ category.category }}</span>
+                    <span v-if="category.videosCount" class="rounded-full bg-white/10 px-1.5 py-0.5 text-[11px] text-gray-300 tabular-nums">
+                        {{ category.videosCount }}
+                    </span>
+                </Link>
+            </div>
+        </section>
+
+        <div class="mt-10">
+            <VideoCardGrid :videos :has_prev_page :has_next_page />
+        </div>
     </div>
-
-    <CategoriesBrowseWidget
-        v-if="categories?.length"
-        :categories_data="categories"
-        :description="`Found ` + categories.length + ` categories`"
-        single_parent_category
-        categories_sort_order="count"
-        subcategories_sort_order="count"
-        hide_subcategories_text />
-
-    <br/>
-
-    <VideoCardGrid
-        :videos
-        :description
-        :has_prev_page
-        :has_next_page />
 </template>

--- a/resources/js/pages/WatchVideo.vue
+++ b/resources/js/pages/WatchVideo.vue
@@ -1,28 +1,94 @@
 <script setup>
-import { Head } from '@inertiajs/vue3';
+import VideoCardItem from '@/atoms/VideoCardItem.vue';
+import SectionHeading from '@/molecules/SectionHeading.vue';
 import VideoViewer from '@/organisms/VideoViewer.vue';
-import VideoBrowseByLinks from '@/atoms/VideoBrowseByLinks.vue';
+import { Skeleton } from '@/ui/skeleton';
+import { Deferred, Head, Link } from '@inertiajs/vue3';
 
-defineProps({
-    video: {
-        type: Object,
-        required: true,
-    },
-    video_metadata: {
-        type: Object,
-        required: false,
-    }
-})
+const props = defineProps({
+    video: { type: Object, required: true },
+    video_metadata: { type: Object, required: false, default: () => ({}) },
+    up_next: { type: Object, required: false, default: null },
+});
 
+// Ordered, labelled metadata groups; absent keys simply don't render.
+const metaGroups = [
+    { key: 'speaker', label: 'Speakers' },
+    { key: 'series', label: 'Series' },
+    { key: 'topic', label: 'Topics' },
+    { key: 'bible_book', label: 'Bible books' },
+    { key: 'ministry', label: 'Ministry' },
+    { key: 'demographic', label: 'For' },
+];
+
+const entries = (key) => {
+    const value = props.video_metadata?.[key];
+    if (!value) return [];
+    return Array.isArray(value) ? value : [value];
+};
 </script>
 
 <template>
     <Head :title="video.name" />
-    <div class="main-container">
-        <main class="isolate">
-            <VideoViewer :video="video" />
-            <hr class="mx-4 border-gray-800 mb-2 mt-2 lg:mt-4" />
-            <VideoBrowseByLinks :video="video" :video_metadata />
-        </main>
+    <div class="mx-auto max-w-5xl px-4 py-8 lg:px-8">
+        <VideoViewer :video="video" />
+
+        <div class="mt-6">
+            <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+                <h1 class="font-display text-2xl leading-tight font-bold text-gray-50 sm:text-3xl">{{ video.name }}</h1>
+                <span v-if="video.is_livestream" class="rounded bg-white/10 px-2 py-0.5 text-xs font-bold tracking-wide text-gray-300 uppercase">
+                    Streamed
+                </span>
+            </div>
+            <p class="mt-2 text-sm text-gray-500 tabular-nums">
+                {{ video.date_recorded ? `Recorded ${video.date_recorded}` : `Added ${video.date_created}` }}
+            </p>
+
+            <div class="mt-5 space-y-3">
+                <template v-for="group in metaGroups" :key="group.key">
+                    <div v-if="entries(group.key).length" class="flex flex-wrap items-baseline gap-2">
+                        <span class="w-24 shrink-0 text-xs font-medium tracking-wider text-gray-500 uppercase">{{ group.label }}</span>
+                        <Link
+                            v-for="entry in entries(group.key)"
+                            :key="entry.url"
+                            :href="entry.url"
+                            prefetch
+                            class="focus-visible:ring-ring inline-flex min-h-9 items-center rounded-full border border-white/10 px-3.5 text-[13px] text-gray-300 transition-colors duration-150 outline-none hover:border-white/25 hover:text-white focus-visible:ring-2"
+                        >
+                            {{ entry.name }}
+                        </Link>
+                    </div>
+                </template>
+            </div>
+
+            <p v-if="video.description" class="mt-6 max-w-prose text-[15px] leading-relaxed text-gray-400" v-html="video.description"></p>
+        </div>
+
+        <Deferred data="up_next">
+            <template #fallback>
+                <section class="mt-12" aria-label="More in this series">
+                    <Skeleton class="h-7 w-64 bg-white/5" />
+                    <div class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                        <Skeleton v-for="n in 3" :key="n" class="aspect-video rounded-lg bg-white/5" />
+                    </div>
+                </section>
+            </template>
+
+            <section v-if="up_next?.videos?.length" class="mt-12" aria-label="More in this series">
+                <SectionHeading :title="`More in ${up_next.series.name}`" :more-href="up_next.series.url" more-label="Whole series" />
+                <ul class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                    <li v-for="item in up_next.videos" :key="item.id" class="relative isolate aspect-video">
+                        <Link
+                            :href="`/video/${item.id}`"
+                            prefetch
+                            class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                        >
+                            <VideoCardItem :video="item" />
+                            <span class="sr-only">View video for {{ item.name }}</span>
+                        </Link>
+                    </li>
+                </ul>
+            </section>
+        </Deferred>
     </div>
 </template>

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -63,6 +63,7 @@ const entrance = (delayMs) => ({
                 <li v-for="video in latest_videos" :key="video.id" class="relative isolate aspect-video">
                     <Link
                         :href="`/video/${video.id}`"
+                        prefetch
                         class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                     >
                         <VideoCardItem :video="video" />

--- a/tests/test_watch_up_next.py
+++ b/tests/test_watch_up_next.py
@@ -1,0 +1,50 @@
+import pytest
+
+from tests.factories import SeriesFactory, VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+
+def test_up_next_is_deferred_not_in_first_load(client):
+    """The watch page must paint without waiting on the series rail: up_next
+    arrives via the Inertia deferred-props follow-up request."""
+    video = VideoFactory()
+
+    page = inertia_page(client.get(f"/video/{video.id}"))
+
+    assert "up_next" not in page["props"]
+    assert "up_next" in page.get("deferredProps", {}).get("default", [])
+
+
+def test_up_next_returns_other_videos_from_the_same_series(client):
+    series = SeriesFactory(name="John's Gospel")
+    current = VideoFactory(name="Episode 2")
+    sibling = VideoFactory(name="Episode 1")
+    series.videos.add(current, sibling)
+
+    response = client.get(
+        f"/video/{current.id}",
+        HTTP_X_INERTIA="true",
+        HTTP_X_INERTIA_PARTIAL_COMPONENT="WatchVideo",
+        HTTP_X_INERTIA_PARTIAL_DATA="up_next",
+    )
+
+    props = response.json()["props"]
+    assert props["up_next"]["series"]["name"] == "John's Gospel"
+    names = [v["name"] for v in props["up_next"]["videos"]]
+    assert names == ["Episode 1"]
+    assert "Episode 2" not in names
+
+
+def test_up_next_is_null_when_video_has_no_series(client):
+    video = VideoFactory()
+
+    response = client.get(
+        f"/video/{video.id}",
+        HTTP_X_INERTIA="true",
+        HTTP_X_INERTIA_PARTIAL_COMPONENT="WatchVideo",
+        HTTP_X_INERTIA_PARTIAL_DATA="up_next",
+    )
+
+    assert response.json()["props"]["up_next"] is None


### PR DESCRIPTION
## Summary
- Watch page redesigned: player-only viewer, labelled metadata chips, and a deferred "More in this series" rail (paints instantly, streams in with skeletons) — first use of Inertia v3 deferred props, server-side via inertia-django's defer()
- Browse + Search adopt the homepage's design language (containers, type roles, chips with counts, restyled pagination)
- Hover prefetch on nav, cards, and chips for snappier perceived navigation

## Verification
- 15/15 tests incl. new deferred-prop contract tests (absent from first load, resolves via partial reload, null without series)
- Browser-verified: watch page with live rail, search page, browse pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)