### PR TITLE
Epic 6.6: destination pages (speaker detail, series detail v2)

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -574,15 +574,19 @@ def browse_series(request, id):
             },
         )
 
-    # Episodes live on the Series.videos M2M — the video_set FK reverse is
-    # never populated, which is why this page used to show zero episodes.
-    paginator = Paginator(series.videos.order_by("-date_recorded"), pagination_per_page)
+    # Episodes live on the Series.videos M2M (the video_set FK reverse is never
+    # populated). Order by episode number where ingestion assigned one, oldest
+    # first — a course reads start-to-finish, not newest-first.
+    episodes = series.videos.order_by("number_in_series", "date_recorded")
+    paginator = Paginator(episodes, 50)
     page_num = 1
     try:
         page_num = int(request.GET.get("page", 1))
     except ValueError:
         page_num = 1
     paginated = paginator.page(page_num)
+
+    start_episode = episodes.first()
     return render(
         request,
         "SeriesDetail",
@@ -594,7 +598,19 @@ def browse_series(request, id):
                 "year_start": series.year_start,
                 "year_end": series.year_end,
             },
-            "videos": video_card_props(paginated.object_list),
+            "start_url": f"/video/{start_episode.id}" if start_episode else None,
+            "episodes": [
+                {
+                    "id": v.id,
+                    "name": v.name,
+                    "number": v.number_in_series,
+                    "url": f"/video/{v.id}",
+                    "date": v.date_recorded.isoformat() if v.date_recorded else None,
+                    "thumbnail": v.thumbnail,
+                }
+                for v in paginated.object_list
+            ],
+            "page_start": (page_num - 1) * 50,
             "has_prev_page": paginated.has_previous(),
             "has_next_page": paginated.has_next(),
         },
@@ -604,32 +620,42 @@ def browse_series(request, id):
 def browse_speaker(request, id):
     decoded_id = unquote(id)
 
-    try:
-        speaker = Speaker.objects.get(name=decoded_id)
-    except Speaker.DoesNotExist as e:
+    # Speaker names are unique; id is the stable fallback for future links.
+    speaker = Speaker.objects.filter(name=decoded_id).first() or Speaker.objects.filter(id=decoded_id).first()
+    if speaker is None:
         return render(
             request,
             "Browse",
-            {
-                "videos": [],
-                "title": f"Speaker not found: '{decoded_id}'",
-                "description": f"Error retreiving speaker data: '{e}'",
-            },
+            {"videos": [], "title": f"Speaker not found: '{decoded_id}'"},
         )
 
-    paginator = Paginator(speaker.video_set.all(), pagination_per_page)
+    talks = speaker.video_set.order_by("-date_recorded")
+    paginator = Paginator(talks, pagination_per_page)
     page_num = 1
     try:
         page_num = int(request.GET.get("page", 1))
     except ValueError:
         page_num = 1
     paginated = paginator.page(page_num)
+
+    def series():
+        # Series this speaker features in: series whose videos include theirs.
+        return [
+            {"name": s.name, "summary": s.summary, "videosCount": s.videos_count, "url": s.get_absolute_url()}
+            for s in Series.objects.filter(videos__speaker=speaker)
+            .distinct()
+            .annotate(videos_count=Count("videos"))
+            .order_by("-videos_count")[:6]
+        ]
+
     return render(
         request,
-        "Browse",
+        "SpeakerDetail",
         {
-            "title": f"Speaker: {decoded_id}",
-            "description": f"{speaker.bio} (page {page_num} of {paginator.num_pages})",
+            "speaker": {"name": speaker.name, "bio": speaker.bio, "talksCount": paginator.count},
+            # defer() (not optional): the <Deferred> component auto-loads it
+            # right after first paint, so the page shows talks immediately.
+            "series": defer(series),
             "videos": video_card_props(paginated.object_list),
             "has_prev_page": paginated.has_previous(),
             "has_next_page": paginated.has_next(),

--- a/resources/js/components/molecules/EpisodeRow.vue
+++ b/resources/js/components/molecules/EpisodeRow.vue
@@ -1,0 +1,46 @@
+<script setup>
+import { Link } from '@inertiajs/vue3';
+import { IconPlayerPlayFilled } from '@tabler/icons-vue';
+
+defineProps({
+    episode: { type: Object, required: true },
+    // Display position: episode number where the data has one, else row index
+    position: { type: Number, required: true },
+});
+
+const thumb = (episode) => {
+    if (episode.thumbnail?.startsWith('http')) return episode.thumbnail;
+    return null;
+};
+</script>
+
+<template>
+    <Link
+        :href="episode.url"
+        prefetch
+        class="group focus-visible:ring-ring flex items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-3 transition-colors duration-150 outline-none hover:border-white/20 hover:bg-white/[0.06] focus-visible:ring-2"
+    >
+        <span class="w-6 shrink-0 text-center text-sm font-medium text-gray-500 tabular-nums">{{ position }}</span>
+        <span class="relative aspect-video w-28 shrink-0 overflow-hidden rounded-md bg-gray-800 sm:w-32">
+            <img
+                v-if="thumb(episode)"
+                :src="thumb(episode)"
+                alt=""
+                loading="lazy"
+                decoding="async"
+                class="h-full w-full object-cover"
+                onerror="this.style.opacity='0'"
+            />
+            <span
+                class="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-150 group-hover:opacity-100"
+                aria-hidden="true"
+            >
+                <IconPlayerPlayFilled class="h-7 w-7 text-white drop-shadow" />
+            </span>
+        </span>
+        <span class="min-w-0 flex-1">
+            <span class="block truncate text-[15px] font-medium text-gray-100">{{ episode.name }}</span>
+            <span v-if="episode.date" class="mt-0.5 block text-xs text-gray-500 tabular-nums">{{ episode.date }}</span>
+        </span>
+    </Link>
+</template>

--- a/resources/js/pages/SeriesDetail.vue
+++ b/resources/js/pages/SeriesDetail.vue
@@ -1,12 +1,14 @@
 <script setup>
+import EpisodeRow from '@/molecules/EpisodeRow.vue';
 import PaginationNav from '@/molecules/PaginationNav.vue';
-import VideoCardGrid from '@/organisms/VideoCardGrid.vue';
-import { Head } from '@inertiajs/vue3';
-import { IconBook2 } from '@tabler/icons-vue';
+import { Head, Link } from '@inertiajs/vue3';
+import { IconBook2, IconPlayerPlayFilled } from '@tabler/icons-vue';
 
 const props = defineProps({
     series_meta: { type: Object, required: true },
-    videos: { type: Array, default: () => [] },
+    episodes: { type: Array, default: () => [] },
+    start_url: { type: String, default: null },
+    page_start: { type: Number, default: 0 },
     has_prev_page: { type: Boolean },
     has_next_page: { type: Boolean },
 });
@@ -14,16 +16,18 @@ const props = defineProps({
 const looksLikeYear = (value) => /^\d{4}$/.test(String(value ?? '').trim());
 
 const years = () => {
-    // Legacy year fields hold free text (e.g. "18--2,2"); only show clean years
     const { year_start: start, year_end: end } = props.series_meta;
     if (!looksLikeYear(start)) return null;
     return looksLikeYear(end) && end !== start ? `${start}–${end}` : start;
 };
+
+// Episode number where the data has one; otherwise the running row index.
+const positionFor = (episode, index) => episode.number ?? props.page_start + index + 1;
 </script>
 
 <template>
     <Head :title="series_meta.name" />
-    <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
+    <div class="mx-auto max-w-4xl px-4 py-10 lg:px-8">
         <header class="flex flex-col gap-6 sm:flex-row sm:items-start">
             <div class="bg-primary/10 flex h-24 w-24 flex-none items-center justify-center rounded-2xl" aria-hidden="true">
                 <IconBook2 class="text-primary h-10 w-10 stroke-[1.5]" />
@@ -38,12 +42,25 @@ const years = () => {
                 <p v-if="series_meta.summary" class="mt-3 max-w-prose text-[15px] leading-relaxed text-gray-400">
                     {{ series_meta.summary }}
                 </p>
+                <Link
+                    v-if="start_url"
+                    :href="start_url"
+                    prefetch
+                    class="bg-primary text-primary-foreground focus-visible:ring-ring hover:bg-primary/90 mt-4 inline-flex min-h-11 items-center gap-2 rounded-lg px-5 text-sm font-semibold transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+                >
+                    <IconPlayerPlayFilled class="h-4 w-4" aria-hidden="true" />
+                    Start from the beginning
+                </Link>
             </div>
         </header>
 
-        <div class="mt-10">
-            <VideoCardGrid :videos="videos" :has_prev_page="false" :has_next_page="false" />
-        </div>
+        <section class="mt-10" aria-label="Episodes">
+            <ol class="space-y-2.5">
+                <li v-for="(episode, index) in episodes" :key="episode.id">
+                    <EpisodeRow :episode="episode" :position="positionFor(episode, index)" />
+                </li>
+            </ol>
+        </section>
 
         <div class="mt-10">
             <PaginationNav :has-prev-page="has_prev_page" :has-next-page="has_next_page" />

--- a/resources/js/pages/SpeakerDetail.vue
+++ b/resources/js/pages/SpeakerDetail.vue
@@ -1,0 +1,80 @@
+<script setup>
+import VideoCardItem from '@/atoms/VideoCardItem.vue';
+import PaginationNav from '@/molecules/PaginationNav.vue';
+import SectionHeading from '@/molecules/SectionHeading.vue';
+import SeriesCard from '@/molecules/SeriesCard.vue';
+import { Skeleton } from '@/ui/skeleton';
+import { Deferred, Head, Link } from '@inertiajs/vue3';
+
+const props = defineProps({
+    speaker: { type: Object, required: true },
+    series: { type: Array, default: null },
+    videos: { type: Array, default: () => [] },
+    has_prev_page: { type: Boolean },
+    has_next_page: { type: Boolean },
+});
+
+// "Surname, First" → initials for the avatar tile
+const initials = (name) =>
+    name
+        .split(/[,\s]+/)
+        .filter(Boolean)
+        .slice(0, 2)
+        .map((part) => part[0]?.toUpperCase())
+        .join('');
+</script>
+
+<template>
+    <Head :title="speaker.name" />
+    <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
+        <header class="flex items-center gap-5">
+            <span
+                class="bg-primary/10 text-primary flex h-16 w-16 flex-none items-center justify-center rounded-full text-xl font-semibold"
+                aria-hidden="true"
+            >
+                {{ initials(speaker.name) }}
+            </span>
+            <div>
+                <p class="text-primary text-xs font-semibold tracking-[0.12em] uppercase">Speaker</p>
+                <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">{{ speaker.name }}</h1>
+                <p class="mt-1 text-sm text-gray-500 tabular-nums">{{ speaker.talksCount }} {{ speaker.talksCount === 1 ? 'talk' : 'talks' }}</p>
+            </div>
+        </header>
+
+        <p v-if="speaker.bio" class="mt-5 max-w-prose text-[15px] leading-relaxed text-gray-400">{{ speaker.bio }}</p>
+
+        <Deferred data="series">
+            <template #fallback>
+                <section class="mt-12" aria-label="Series">
+                    <Skeleton class="h-7 w-56 bg-white/5" />
+                    <div class="mt-5 grid gap-5 sm:grid-cols-2"><Skeleton v-for="n in 2" :key="n" class="h-28 rounded-xl bg-white/5" /></div>
+                </section>
+            </template>
+            <section v-if="series?.length" class="mt-12" aria-label="Series">
+                <SectionHeading title="Featured in these series" />
+                <div class="grid gap-5 sm:grid-cols-2">
+                    <SeriesCard v-for="entry in series" :key="entry.url" :series="entry" />
+                </div>
+            </section>
+        </Deferred>
+
+        <section class="mt-12" aria-label="Talks">
+            <SectionHeading title="All talks" />
+            <ul class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                <li v-for="video in videos" :key="video.id" class="relative isolate aspect-video">
+                    <Link
+                        :href="`/video/${video.id}`"
+                        prefetch
+                        class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                    >
+                        <VideoCardItem :video="video" />
+                        <span class="sr-only">View video for {{ video.name }}</span>
+                    </Link>
+                </li>
+            </ul>
+            <div class="mt-10">
+                <PaginationNav :has-prev-page="has_prev_page" :has-next-page="has_next_page" />
+            </div>
+        </section>
+    </div>
+</template>

--- a/tests/test_category_pages.py
+++ b/tests/test_category_pages.py
@@ -74,7 +74,7 @@ class TestSeriesDetail:
         assert props["series_meta"]["name"] == "John's Gospel"
         assert props["series_meta"]["summary"] == "A walk through John."
         assert props["series_meta"]["videosCount"] == 2
-        assert len(props["videos"]) == 2
+        assert len(props["episodes"]) == 2  # v2: numbered episode rows (see test_destination_pages)
 
     def test_unknown_series_renders_not_found(self, client):
         response = client.get("/series/Nope")

--- a/tests/test_destination_pages.py
+++ b/tests/test_destination_pages.py
@@ -1,0 +1,82 @@
+import json
+
+import pytest
+
+from tests.factories import SeriesFactory, SpeakerFactory, VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+
+def below_fold(client, url, props):
+    response = client.get(
+        url,
+        HTTP_X_INERTIA="true",
+        HTTP_X_INERTIA_PARTIAL_COMPONENT="SpeakerDetail",
+        HTTP_X_INERTIA_PARTIAL_DATA=props,
+    )
+    return json.loads(response.content)["props"]
+
+
+class TestSpeakerDetail:
+    def test_renders_name_talk_count_and_talks(self, client):
+        speaker = SpeakerFactory(name="Dominic Steele")
+        talk = VideoFactory(name="Romans 1")
+        talk.speaker.add(speaker)
+
+        page = inertia_page(client.get("/speaker/Dominic%20Steele"))
+
+        assert page["component"] == "SpeakerDetail"
+        assert page["props"]["speaker"]["name"] == "Dominic Steele"
+        assert page["props"]["speaker"]["talksCount"] == 1
+        assert [v["name"] for v in page["props"]["videos"]] == ["Romans 1"]
+
+    def test_series_are_deferred_and_list_what_the_speaker_features_in(self, client):
+        speaker = SpeakerFactory(name="Vaughan Roberts")
+        series = SeriesFactory(name="John's Gospel")
+        talk = VideoFactory()
+        talk.speaker.add(speaker)
+        series.videos.add(talk)
+        other = SeriesFactory(name="Unrelated")
+        other.videos.add(VideoFactory())
+
+        first = inertia_page(client.get("/speaker/Vaughan%20Roberts"))
+        assert "series" not in first["props"]  # deferred — absent on first load
+        # defer() registers it for the <Deferred> component's auto-load
+        assert "series" in first.get("deferredProps", {}).get("default", [])
+
+        props = below_fold(client, "/speaker/Vaughan%20Roberts", "series")
+        assert [s["name"] for s in props["series"]] == ["John's Gospel"]
+
+    def test_unknown_speaker_is_handled(self, client):
+        assert inertia_page(client.get("/speaker/Nobody"))["props"]["title"].startswith("Speaker not found")
+
+
+class TestSeriesDetailEpisodes:
+    def test_episodes_are_numbered_and_ordered_for_a_course(self, client):
+        series = SeriesFactory(name="Acts")
+        e1 = VideoFactory(name="Acts 1", number_in_series=1)
+        e2 = VideoFactory(name="Acts 2", number_in_series=2)
+        e3 = VideoFactory(name="Acts 3", number_in_series=3)
+        # add out of order; the page must present them in episode order
+        for v in (e3, e1, e2):
+            series.videos.add(v)
+
+        page = inertia_page(client.get("/series/" + series.id_number))
+
+        assert page["component"] == "SeriesDetail"
+        episodes = page["props"]["episodes"]
+        assert [(e["number"], e["name"]) for e in episodes] == [(1, "Acts 1"), (2, "Acts 2"), (3, "Acts 3")]
+        assert page["props"]["start_url"] == f"/video/{e1.id}"
+
+    def test_episode_global_numbering_survives_pagination(self, client):
+        series = SeriesFactory(name="Big series")
+        for n in range(55):
+            v = VideoFactory(number_in_series=n + 1)
+            series.videos.add(v)
+
+        props = inertia_page(client.get(f"/series/{series.id_number}", {"page": 2}))["props"]
+
+        assert props["page_start"] == 50  # row index offset for "episode N" labels
+        assert len(props["episodes"]) == 5
+        assert props["has_prev_page"] is True


### PR DESCRIPTION
## Summary
- **Speaker detail**: real "more from this voice" page — avatar, talk count, deferred "Featured in these series", all talks. Bio/photo fill-rate confirmed zero, so the design doesn't depend on them.
- **Series detail v2**: numbered episode list (uses Epic 2.2's `number_in_series`), oldest-first, "Start from the beginning" CTA — the Laracasts course pattern.
- New `EpisodeRow` molecule; pagination keeps global episode numbering.

## Verification
60/60 tests (5 new); browser-verified both pages on real data. Fixed an `optional()`/`<Deferred>` mismatch found during verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)