### PR TITLE
Epic 6.6b: Bible book page with passage navigation

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -12,6 +12,7 @@ from catalogue.models.series import Series
 from catalogue.models.speaker import Speaker
 from catalogue.models.topic import Topic
 from catalogue.models.video import Video
+from catalogue.passages import parse_passage, passage_label
 
 pagination_per_page = 24
 
@@ -261,35 +262,49 @@ def video(request, id):
 def browse_bible_book(request, id):
     decoded_id = unquote(id)
 
-    try:
-        bible_book = Bible_Book.objects.get(name=decoded_id)
-    except Bible_Book.DoesNotExist as e:
-        return render(
-            request,
-            "Browse",
-            {
-                "videos": [],
-                "title": f"Bible book not found: '{decoded_id}'",
-                "description": f"Error retreiving Bible book data: '{e}'",
-            },
-        )
+    bible_book = Bible_Book.objects.filter(name=decoded_id).first()
+    if bible_book is None:
+        return render(request, "Browse", {"videos": [], "title": f"Bible book not found: '{decoded_id}'"})
 
-    paginator = Paginator(bible_book.video_set.all(), pagination_per_page)
-    page_num = 1
-    try:
-        page_num = int(request.GET.get("page", 1))
-    except ValueError:
-        page_num = 1
-    paginated = paginator.page(page_num)
+    book_name = bible_book.get_name_display()
+    all_videos = list(bible_book.video_set.order_by("-date_recorded"))
+
+    # Derive the passage from each title; teaching that names a chapter is
+    # ordered by chapter (a book reads in order), the rest ("topical") trails.
+    decorated = []
+    chapters = set()
+    for video in all_videos:
+        passage = parse_passage(video.name, book_name)
+        if passage:
+            chapters.add(passage["chapter"])
+        decorated.append((video, passage))
+
+    selected_chapter = request.GET.get("chapter")
+    selected = int(selected_chapter) if (selected_chapter or "").isdigit() else None
+    if selected is not None:
+        decorated = [(v, p) for v, p in decorated if p and p["chapter"] == selected]
+
+    # Chapter first (None last), then most recent — a passage-ordered reading list
+    decorated.sort(key=lambda dp: (dp[1] is None, dp[1]["chapter"] if dp[1] else 0))
+
+    def card(video, passage):
+        props = video_card_props([video])[0]
+        props["reference"] = passage_label(passage)
+        return props
+
     return render(
         request,
-        "Browse",
+        "BookDetail",
         {
-            "title": f"Bible book: {bible_book.get_name_display()}",
-            "description": f"{bible_book.summary} (page {page_num} of {paginator.num_pages})",
-            "videos": video_card_props(paginated.object_list),
-            "has_prev_page": paginated.has_previous(),
-            "has_next_page": paginated.has_next(),
+            "book": {
+                "name": book_name,
+                "summary": bible_book.summary,
+                "section": bible_book.get_type_display(),
+                "videosCount": len(all_videos),
+            },
+            "chapters": sorted(chapters),
+            "selected_chapter": selected,
+            "videos": [card(v, p) for v, p in decorated],
         },
     )
 

--- a/catalogue/passages.py
+++ b/catalogue/passages.py
@@ -1,0 +1,54 @@
+"""Parse a Bible passage from a video title.
+
+Clayton TV's sermon titles overwhelmingly lead with the passage —
+"Luke 20:9-19 - ...", "1 Samuel 18-19 - ...", "Psalm 95 - ..." — so a
+chapter is recoverable for most expository teaching (conference talks, which
+are topical, simply don't match, which is correct). Used to order and group
+a book's teaching by chapter and to build the chapter-navigation strip.
+"""
+
+import re
+
+# Book display names whose titles use a different word, or a singular form.
+_NAME_VARIANTS = {
+    "Psalms": ["Psalms", "Psalm"],
+    "Song of Solomon": ["Song of Solomon", "Song of Songs", "Song of Sol"],
+    "Song of Songs": ["Song of Songs", "Song of Solomon"],
+}
+
+
+def variants(book_display_name):
+    return _NAME_VARIANTS.get(book_display_name, [book_display_name])
+
+
+def parse_passage(title, book_display_name):
+    """Return {chapter, verse_start, verse_end} for a title that opens with this
+    book's passage, else None. chapter is an int; verses may be None."""
+    if not title:
+        return None
+
+    for name in variants(book_display_name):
+        # <book> <chapter>[-<chapter2>][:|. <v1>[-<v2>]] at the start of the title
+        pattern = re.compile(
+            rf"^\s*{re.escape(name)}\s+(\d+)(?:\s*-\s*\d+)?(?:\s*[:.]\s*(\d+)(?:\s*-\s*(\d+))?)?",
+            re.IGNORECASE,
+        )
+        match = pattern.match(title)
+        if match:
+            chapter = int(match.group(1))
+            verse_start = int(match.group(2)) if match.group(2) else None
+            verse_end = int(match.group(3)) if match.group(3) else verse_start
+            return {"chapter": chapter, "verse_start": verse_start, "verse_end": verse_end}
+    return None
+
+
+def passage_label(passage):
+    """'12:1-13' / '12:1' / '12' from a parsed passage."""
+    if not passage:
+        return None
+    chapter = str(passage["chapter"])
+    if passage["verse_start"] is None:
+        return chapter
+    if passage["verse_end"] and passage["verse_end"] != passage["verse_start"]:
+        return f"{chapter}:{passage['verse_start']}-{passage['verse_end']}"
+    return f"{chapter}:{passage['verse_start']}"

--- a/resources/js/pages/BookDetail.vue
+++ b/resources/js/pages/BookDetail.vue
@@ -1,0 +1,91 @@
+<script setup>
+import VideoCardItem from '@/atoms/VideoCardItem.vue';
+import { Head, Link, router } from '@inertiajs/vue3';
+import { IconBook, IconX } from '@tabler/icons-vue';
+
+const props = defineProps({
+    book: { type: Object, required: true },
+    chapters: { type: Array, default: () => [] },
+    selected_chapter: { type: Number, default: null },
+    videos: { type: Array, default: () => [] },
+});
+
+const selectChapter = (chapter) => {
+    router.get(`/book/${encodeURIComponent(bookCode())}`, chapter === props.selected_chapter ? {} : { chapter }, {
+        preserveScroll: true,
+        preserveState: true,
+    });
+};
+
+// The route is keyed on the 3-letter code, which we don't carry in props;
+// derive it from the current path so chapter links stay on this book.
+const bookCode = () => decodeURIComponent(window.location.pathname.split('/').pop());
+</script>
+
+<template>
+    <Head :title="book.name" />
+    <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
+        <header class="flex items-start gap-5">
+            <div class="bg-primary/10 flex h-16 w-16 flex-none items-center justify-center rounded-2xl" aria-hidden="true">
+                <IconBook class="text-primary h-8 w-8 stroke-[1.5]" />
+            </div>
+            <div>
+                <p class="text-primary text-xs font-semibold tracking-[0.12em] uppercase">{{ book.section }}</p>
+                <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">{{ book.name }}</h1>
+                <p class="mt-1 text-sm text-gray-500 tabular-nums">{{ book.videosCount }} {{ book.videosCount === 1 ? 'talk' : 'talks' }}</p>
+            </div>
+        </header>
+
+        <!-- Chapter strip: jump straight to teaching on a chapter -->
+        <section v-if="chapters.length" class="mt-8" aria-label="Chapters">
+            <div class="flex items-center justify-between">
+                <h2 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">By chapter</h2>
+                <button
+                    v-if="selected_chapter"
+                    @click="selectChapter(selected_chapter)"
+                    class="focus-visible:ring-ring inline-flex items-center gap-1 rounded text-xs font-medium text-gray-400 outline-none hover:text-white focus-visible:ring-2"
+                >
+                    <IconX class="h-3.5 w-3.5" aria-hidden="true" /> Clear
+                </button>
+            </div>
+            <div class="mt-3 flex flex-wrap gap-2">
+                <button
+                    v-for="chapter in chapters"
+                    :key="chapter"
+                    @click="selectChapter(chapter)"
+                    :aria-pressed="chapter === selected_chapter"
+                    :class="
+                        chapter === selected_chapter
+                            ? 'bg-primary text-primary-foreground border-primary'
+                            : 'border-white/15 text-gray-300 hover:border-white/30 hover:text-white'
+                    "
+                    class="focus-visible:ring-ring inline-flex h-10 min-w-10 items-center justify-center rounded-lg border px-2 text-sm font-medium tabular-nums transition-colors duration-150 outline-none focus-visible:ring-2"
+                >
+                    {{ chapter }}
+                </button>
+            </div>
+        </section>
+
+        <section class="mt-10" aria-label="Teaching">
+            <ul class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+                <li v-for="video in videos" :key="video.id" class="relative isolate aspect-video">
+                    <Link
+                        :href="`/video/${video.id}`"
+                        prefetch
+                        class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                    >
+                        <VideoCardItem :video="video" />
+                        <span
+                            v-if="video.reference"
+                            class="bg-primary text-primary-foreground absolute top-2 left-2 z-10 rounded-md px-2 py-0.5 text-xs font-bold tabular-nums"
+                        >
+                            {{ book.name }} {{ video.reference }}
+                        </span>
+                        <span class="sr-only">View video for {{ video.name }}</span>
+                    </Link>
+                </li>
+            </ul>
+            <p v-if="!videos.length" class="mt-12 text-center text-sm text-gray-500">No teaching on {{ book.name }} {{ selected_chapter }} yet.</p>
+        </section>
+    </div>
+</template>

--- a/tests/test_book_detail.py
+++ b/tests/test_book_detail.py
@@ -1,0 +1,48 @@
+import pytest
+
+from tests.factories import BibleBookFactory, VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+
+def luke_with_videos(titles):
+    book = BibleBookFactory(name="LUK", order="42", type="GOS")
+    for title in titles:
+        video = VideoFactory(name=title)
+        video.bible_book.add(book)
+    return book
+
+
+def test_book_detail_builds_a_chapter_strip_and_references(client):
+    luke_with_videos(
+        [
+            "Luke 20:9-19 - If I Were God - JPC Service",
+            "Luke 5: 1-11 - A Life-Changing Encounter - JPC Sermon",
+            "Word Alive '10 - A topical talk",  # no chapter
+        ]
+    )
+
+    page = inertia_page(client.get("/book/LUK"))
+
+    assert page["component"] == "BookDetail"
+    props = page["props"]
+    assert props["book"]["name"] == "Luke"
+    assert props["book"]["section"] == "Gospel"
+    assert props["chapters"] == [5, 20]  # only chapters that have teaching, sorted
+    # Chapter-bearing teaching leads, ordered by chapter; topical talk trails
+    refs = [v.get("reference") for v in props["videos"]]
+    assert refs == ["5:1-11", "20:9-19", None]
+
+
+def test_chapter_filter_narrows_to_one_chapter(client):
+    luke_with_videos(["Luke 20:9-19 - A", "Luke 5: 1-11 - B"])
+
+    props = inertia_page(client.get("/book/LUK", {"chapter": 20}))["props"]
+
+    assert props["selected_chapter"] == 20
+    assert [v["reference"] for v in props["videos"]] == ["20:9-19"]
+
+
+def test_unknown_book_is_handled(client):
+    assert inertia_page(client.get("/book/ZZZ"))["props"]["title"].startswith("Bible book not found")

--- a/tests/test_passages.py
+++ b/tests/test_passages.py
@@ -1,0 +1,55 @@
+"""Passage parsing, tested against the real title patterns observed in the
+catalogue (see the per-book title samples in the Epic 6.6 session)."""
+
+import pytest
+
+from catalogue.passages import parse_passage, passage_label
+
+
+@pytest.mark.parametrize(
+    "title,book,expected",
+    [
+        ("Luke 20:9-19 - If I Were God - JPC Service", "Luke", {"chapter": 20, "verse_start": 9, "verse_end": 19}),
+        (
+            "Romans 12: 1-13 - Queen's Jubilee - JPC Sermon",
+            "Romans",
+            {"chapter": 12, "verse_start": 1, "verse_end": 13},
+        ),
+        ("Luke 19: 10 - Jesus Came to Save - JPC Sermon", "Luke", {"chapter": 19, "verse_start": 10, "verse_end": 10}),
+        (
+            "1 Samuel 12 - Here I Stand - JPC Sermon",
+            "1 Samuel",
+            {"chapter": 12, "verse_start": None, "verse_end": None},
+        ),
+        (
+            "1 Samuel 18-19 - David and Saul - JPC Sermon",
+            "1 Samuel",
+            {"chapter": 18, "verse_start": None, "verse_end": None},
+        ),
+        (
+            "Psalm 95 - The Reformation Revelation - JPC Sermon",
+            "Psalms",
+            {"chapter": 95, "verse_start": None, "verse_end": None},
+        ),
+    ],
+)
+def test_parses_real_sermon_title_patterns(title, book, expected):
+    assert parse_passage(title, book) == expected
+
+
+def test_topical_titles_do_not_match():
+    assert parse_passage("Word Alive '10 - Peter Baker: A Song of Revelation", "Psalms") is None
+    assert parse_passage("Keswick '10 - Alistair Begg 1: Bible Reading", "Romans") is None
+    assert parse_passage("Ask Phillip - Given the Holy Spirit Twice?", "Luke") is None
+
+
+def test_song_of_solomon_variants():
+    assert parse_passage("Song of Songs 2 - Love", "Song of Solomon")["chapter"] == 2
+    assert parse_passage("Song of Solomon 1:1 - Intro", "Song of Songs")["chapter"] == 1
+
+
+def test_passage_label_formats():
+    assert passage_label({"chapter": 12, "verse_start": 1, "verse_end": 13}) == "12:1-13"
+    assert passage_label({"chapter": 19, "verse_start": 10, "verse_end": 10}) == "19:10"
+    assert passage_label({"chapter": 95, "verse_start": None, "verse_end": None}) == "95"
+    assert passage_label(None) is None


### PR DESCRIPTION
## Summary
- Parses the passage from sermon titles (`catalogue/passages.py`) — `Luke 20:9-19`, `1 Samuel 18-19`, `Psalm 95` — topical talks correctly don't match
- BookDetail page: chapter strip (filters via `?chapter=`), teaching ordered by chapter, reference badge per card
- Pure derivation, no schema change

## Verification
72/72 tests (12 new: parser against real patterns + page contracts); browser-verified on Luke (chapters 1–24, in-place chapter-15 filter). The chapter/verse navigation the design spec flagged as novel for this niche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)