### PR TITLE
Chapter grid fill + watch page enrichment (passage badge, transcript/audio)

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -225,6 +225,21 @@ def video(request, id):
                 else:
                     video_metadata[p] = {"name": props[p][0].name, "url": props[p][0].get_absolute_url()}
 
+        # Passage badge: the first linked book whose chapter we can read from
+        # the title (e.g. "Luke 15:11-24"), linking to that chapter's teaching.
+        passage_badge = None
+        for book in video_object.bible_book.all():
+            parsed = parse_passage(video_object.name, book.get_name_display())
+            if parsed:
+                passage_badge = {
+                    "label": f"{book.get_name_display()} {passage_label(parsed)}",
+                    "url": f"{book.get_absolute_url()}?chapter={parsed['chapter']}",
+                }
+                break
+
+        # Rescued related resources (transcript/audio reference links)
+        resources = [{"kind": r.kind, "url": r.url} for r in video_object.related_resources.order_by("kind")]
+
         def up_next():
             # Series→video links live on the Series.videos M2M (no reverse
             # accessor from Video: related_name="+"), so filter by membership.
@@ -242,6 +257,8 @@ def video(request, id):
             {
                 "video": video_object,
                 "video_metadata": video_metadata,
+                "passage": passage_badge,
+                "resources": resources,
                 # Deferred: the player paints immediately; the rail streams in
                 # right after via the Inertia v3 deferred-props round trip.
                 "up_next": defer(up_next),

--- a/resources/js/pages/BookDetail.vue
+++ b/resources/js/pages/BookDetail.vue
@@ -48,7 +48,9 @@ const bookCode = () => decodeURIComponent(window.location.pathname.split('/').po
                     <IconX class="h-3.5 w-3.5" aria-hidden="true" /> Clear
                 </button>
             </div>
-            <div class="mt-3 flex flex-wrap gap-2">
+            <!-- auto-fill 1fr: equal columns that fill the row edge-to-edge and
+                 wrap into filled rows (calendar-style), instead of ragged flex-wrap -->
+            <div class="mt-3 grid grid-cols-[repeat(auto-fill,minmax(2.5rem,1fr))] gap-2">
                 <button
                     v-for="chapter in chapters"
                     :key="chapter"
@@ -59,7 +61,7 @@ const bookCode = () => decodeURIComponent(window.location.pathname.split('/').po
                             ? 'bg-primary text-primary-foreground border-primary'
                             : 'border-white/15 text-gray-300 hover:border-white/30 hover:text-white'
                     "
-                    class="focus-visible:ring-ring inline-flex h-10 min-w-10 items-center justify-center rounded-lg border px-2 text-sm font-medium tabular-nums transition-colors duration-150 outline-none focus-visible:ring-2"
+                    class="focus-visible:ring-ring flex h-10 items-center justify-center rounded-lg border text-sm font-medium tabular-nums transition-colors duration-150 outline-none focus-visible:ring-2"
                 >
                     {{ chapter }}
                 </button>

--- a/resources/js/pages/WatchVideo.vue
+++ b/resources/js/pages/WatchVideo.vue
@@ -4,12 +4,21 @@ import SectionHeading from '@/molecules/SectionHeading.vue';
 import VideoViewer from '@/organisms/VideoViewer.vue';
 import { Skeleton } from '@/ui/skeleton';
 import { Deferred, Head, Link } from '@inertiajs/vue3';
+import { IconBook, IconFileText, IconHeadphones } from '@tabler/icons-vue';
 
 const props = defineProps({
     video: { type: Object, required: true },
     video_metadata: { type: Object, required: false, default: () => ({}) },
+    passage: { type: Object, required: false, default: null },
+    resources: { type: Array, required: false, default: () => [] },
     up_next: { type: Object, required: false, default: null },
 });
+
+const resourceMeta = {
+    transcript: { label: 'Read the transcript', icon: IconFileText },
+    audio: { label: 'Listen to the audio', icon: IconHeadphones },
+    other: { label: 'Related resource', icon: IconFileText },
+};
 
 // Ordered, labelled metadata groups; absent keys simply don't render.
 const metaGroups = [
@@ -36,6 +45,15 @@ const entries = (key) => {
         <div class="mt-6">
             <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
                 <h1 class="font-display text-2xl leading-tight font-bold text-gray-50 sm:text-3xl">{{ video.name }}</h1>
+                <Link
+                    v-if="passage"
+                    :href="passage.url"
+                    prefetch
+                    class="bg-primary/15 text-primary focus-visible:ring-ring hover:bg-primary/25 inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-sm font-semibold tabular-nums transition-colors duration-150 outline-none focus-visible:ring-2"
+                >
+                    <IconBook class="h-4 w-4" aria-hidden="true" />
+                    {{ passage.label }}
+                </Link>
                 <span v-if="video.is_livestream" class="rounded bg-white/10 px-2 py-0.5 text-xs font-bold tracking-wide text-gray-300 uppercase">
                     Streamed
                 </span>
@@ -62,6 +80,21 @@ const entries = (key) => {
             </div>
 
             <p v-if="video.description" class="mt-6 max-w-prose text-[15px] leading-relaxed text-gray-400" v-html="video.description"></p>
+
+            <!-- Rescued companion links (transcripts/audio on partner sites) -->
+            <div v-if="resources.length" class="mt-6 flex flex-wrap gap-3">
+                <a
+                    v-for="resource in resources"
+                    :key="resource.url"
+                    :href="resource.url"
+                    rel="noopener"
+                    target="_blank"
+                    class="focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-lg border border-white/15 px-4 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2"
+                >
+                    <component :is="(resourceMeta[resource.kind] || resourceMeta.other).icon" class="h-4 w-4" aria-hidden="true" />
+                    {{ (resourceMeta[resource.kind] || resourceMeta.other).label }}
+                </a>
+            </div>
         </div>
 
         <Deferred data="up_next">

--- a/tests/test_watch_enrichment.py
+++ b/tests/test_watch_enrichment.py
@@ -1,0 +1,47 @@
+import pytest
+
+from catalogue.models import RelatedResource
+from tests.factories import BibleBookFactory, VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+
+def test_passage_badge_links_to_the_chapter(client):
+    luke = BibleBookFactory(name="LUK", order="42", type="GOS")
+    video = VideoFactory(name="Luke 15:11-24 - The Prodigal Son - JPC Sermon")
+    video.bible_book.add(luke)
+
+    props = inertia_page(client.get(f"/video/{video.id}"))["props"]
+
+    assert props["passage"]["label"] == "Luke 15:11-24"
+    assert props["passage"]["url"] == "/book/LUK?chapter=15"
+
+
+def test_no_passage_badge_for_topical_titles(client):
+    luke = BibleBookFactory(name="LUK", order="42", type="GOS")
+    video = VideoFactory(name="Word Alive - A topical talk")
+    video.bible_book.add(luke)
+
+    props = inertia_page(client.get(f"/video/{video.id}"))["props"]
+
+    assert props["passage"] is None
+
+
+def test_related_resources_are_surfaced(client):
+    video = VideoFactory()
+    RelatedResource.objects.create(video=video, kind="transcript", url="https://printandaudio.org.uk/x")
+    RelatedResource.objects.create(video=video, kind="audio", url="https://printandaudio.org.uk/y")
+
+    props = inertia_page(client.get(f"/video/{video.id}"))["props"]
+
+    kinds = {r["kind"] for r in props["resources"]}
+    assert kinds == {"transcript", "audio"}
+
+
+def test_no_resources_when_none_exist(client):
+    video = VideoFactory()
+
+    props = inertia_page(client.get(f"/video/{video.id}"))["props"]
+
+    assert props["resources"] == []


### PR DESCRIPTION
## Summary
- **Book page**: chapter strip becomes an `auto-fill` `1fr` grid — equal squares filling the row edge-to-edge, wrapping calendar-style (was ragged flex-wrap)
- **Watch page**: passage badge beside the title (links to that chapter) + rescued "Read the transcript"/"Listen to the audio" companion links — surfacing the Epic 2 data on the page people use most

## Verification
76/76 tests (4 new); browser-verified the grid fill on mobile and the badge + resource buttons on a real 1 Samuel sermon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)