### PR TITLE
Epic 6.6c: speakers index pivot (lookup-first + featured voices)

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1,7 +1,7 @@
 from urllib.parse import unquote  # Import for URL decoding
 
 from django.core.paginator import Paginator
-from django.db.models import Count
+from django.db.models import Count, Q
 from inertia import defer, optional, render
 
 from catalogue.models.bible_book import Bible_Book
@@ -507,35 +507,52 @@ def topics_index(request):
 
 
 def speakers_index(request):
-    """Speaker directory: filterable, alphabetical, paginated."""
+    """Lookup-first speaker page (per docs/DESIGN_SPEC.md): a search hero for
+    "do you have X?", a curated featured tier for discovery, and the 600-name
+    long tail as a compact scroll-deferred A-Z list — never a card dump."""
     query = request.GET.get("q", "").strip()
-    speakers_qs = Speaker.objects.annotate(videos_count=Count("video")).filter(videos_count__gt=0).order_by("name")
-    if query:
-        speakers_qs = speakers_qs.filter(name__icontains=query)
+    base = Speaker.objects.annotate(videos_count=Count("video")).filter(videos_count__gt=0)
+    total = base.count()
 
-    paginator = Paginator(speakers_qs, 48)
-    try:
-        page_num = int(request.GET.get("page", 1))
-    except ValueError:
-        page_num = 1
-    paginated = paginator.page(page_num)
+    def entry(speaker):
+        return {"name": speaker.name, "videosCount": speaker.videos_count, "url": speaker.get_absolute_url()}
+
+    if query:
+        return render(
+            request,
+            "SpeakersIndex",
+            {
+                "query": query,
+                "total": total,
+                "results": [entry(s) for s in base.filter(name__icontains=query).order_by("name")[:60]],
+            },
+        )
+
+    featured = []
+    for speaker in base.order_by("-videos_count")[:8]:
+        top_series = (
+            Series.objects.filter(videos__speaker=speaker)
+            .annotate(n=Count("videos", filter=Q(videos__speaker=speaker)))
+            .order_by("-n")
+            .first()
+        )
+        featured.append({**entry(speaker), "knownFor": top_series.name if top_series else None})
+
+    def all_speakers():
+        groups = {}
+        for speaker in base.order_by("name"):
+            groups.setdefault(speaker.name[0].upper(), []).append(entry(speaker))
+        return [{"letter": letter, "speakers": speakers} for letter, speakers in sorted(groups.items())]
 
     return render(
         request,
         "SpeakersIndex",
         {
-            "speakers": [
-                {
-                    "name": s.name,
-                    "videosCount": s.videos_count,
-                    "url": s.get_absolute_url(),
-                }
-                for s in paginated.object_list
-            ],
-            "query": query,
-            "total": paginator.count,
-            "has_prev_page": paginated.has_previous(),
-            "has_next_page": paginated.has_next(),
+            "query": "",
+            "total": total,
+            "featured": featured,
+            # The full directory loads only when scrolled to (WhenVisible)
+            "all_speakers": optional(all_speakers),
         },
     )
 

--- a/resources/js/pages/SpeakersIndex.vue
+++ b/resources/js/pages/SpeakersIndex.vue
@@ -1,21 +1,27 @@
 <script setup>
-import PaginationNav from '@/molecules/PaginationNav.vue';
-import { Head, Link, router } from '@inertiajs/vue3';
-import { IconSearch } from '@tabler/icons-vue';
+import SectionHeading from '@/molecules/SectionHeading.vue';
+import { Skeleton } from '@/ui/skeleton';
+import { Head, Link, WhenVisible, router } from '@inertiajs/vue3';
+import { IconSearch, IconX } from '@tabler/icons-vue';
 import { ref } from 'vue';
 
 const props = defineProps({
-    speakers: { type: Array, default: () => [] },
     query: { type: String, default: '' },
     total: { type: Number, default: 0 },
-    has_prev_page: { type: Boolean },
-    has_next_page: { type: Boolean },
+    results: { type: Array, default: () => [] },
+    featured: { type: Array, default: () => [] },
+    all_speakers: { type: Array, default: null },
 });
 
 const filter = ref(props.query);
 
-const submitFilter = () => {
+const submit = () => {
     router.get('/speaker/', filter.value ? { q: filter.value } : {}, { preserveState: true });
+};
+
+const clear = () => {
+    filter.value = '';
+    router.get('/speaker/');
 };
 
 // "Surname, First" → initials for the avatar tile
@@ -31,52 +37,119 @@ const initials = (name) =>
 <template>
     <Head title="Speakers" />
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
-        <div class="flex flex-wrap items-end justify-between gap-4">
-            <div>
-                <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Speakers</h1>
-                <p class="mt-2 text-sm text-gray-500 tabular-nums">{{ total }} speakers{{ query ? ` matching “${query}”` : '' }}</p>
-            </div>
-            <form @submit.prevent="submitFilter" class="w-full sm:w-72">
-                <label class="sr-only" for="speaker-filter">Filter speakers</label>
+        <!-- Lookup-first: the search IS the hero. Nobody scans 662 names. -->
+        <div class="mx-auto max-w-xl text-center">
+            <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Speakers</h1>
+            <p class="mt-2 text-sm text-gray-500 tabular-nums">Find any of the {{ total }} speakers on Clayton TV</p>
+            <form @submit.prevent="submit" class="mt-5">
+                <label class="sr-only" for="speaker-search">Search speakers</label>
                 <div class="relative">
-                    <IconSearch class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-500" aria-hidden="true" />
+                    <IconSearch class="pointer-events-none absolute top-1/2 left-4 h-5 w-5 -translate-y-1/2 text-gray-500" aria-hidden="true" />
                     <input
-                        id="speaker-filter"
+                        id="speaker-search"
                         v-model="filter"
                         type="search"
-                        placeholder="Filter speakers…"
-                        class="focus:ring-ring h-11 w-full rounded-lg border border-white/10 bg-white/5 pr-3 pl-9 text-base text-gray-100 transition-colors duration-150 placeholder:text-gray-500 focus:bg-white/10 focus:ring-2 focus:outline-none"
+                        placeholder="Search by name…"
+                        class="focus:ring-ring h-13 w-full rounded-xl border border-white/10 bg-white/5 pr-4 pl-12 text-base text-gray-100 transition-colors duration-150 placeholder:text-gray-500 focus:bg-white/10 focus:ring-2 focus:outline-none"
                     />
                 </div>
             </form>
         </div>
 
-        <ul class="mt-8 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            <li v-for="speaker in speakers" :key="speaker.url">
-                <Link
-                    :href="speaker.url"
-                    prefetch
-                    class="focus-visible:ring-ring flex items-center gap-3.5 rounded-xl border border-white/10 bg-white/[0.03] p-3.5 transition-colors duration-150 outline-none hover:border-white/20 hover:bg-white/[0.06] focus-visible:ring-2"
+        <!-- Lookup results -->
+        <section v-if="query" class="mt-10" aria-label="Results">
+            <div class="flex items-baseline justify-between">
+                <h2 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">
+                    {{ results.length }} {{ results.length === 1 ? 'match' : 'matches' }} for “{{ query }}”
+                </h2>
+                <button
+                    @click="clear"
+                    class="focus-visible:ring-ring inline-flex items-center gap-1 rounded text-xs font-medium text-gray-400 outline-none hover:text-white focus-visible:ring-2"
                 >
-                    <span
-                        class="bg-primary/10 text-primary flex h-11 w-11 flex-none items-center justify-center rounded-full text-sm font-semibold"
-                        aria-hidden="true"
+                    <IconX class="h-3.5 w-3.5" aria-hidden="true" /> Clear
+                </button>
+            </div>
+            <ul class="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                <li v-for="speaker in results" :key="speaker.url">
+                    <Link
+                        :href="speaker.url"
+                        prefetch
+                        class="focus-visible:ring-ring flex items-center gap-3.5 rounded-xl border border-white/10 bg-white/[0.03] p-3.5 transition-colors duration-150 outline-none hover:border-white/20 hover:bg-white/[0.06] focus-visible:ring-2"
                     >
-                        {{ initials(speaker.name) }}
-                    </span>
-                    <span class="min-w-0">
-                        <span class="block truncate text-[15px] font-medium text-gray-100">{{ speaker.name }}</span>
-                        <span class="block text-xs text-gray-500 tabular-nums">
-                            {{ speaker.videosCount }} {{ speaker.videosCount === 1 ? 'talk' : 'talks' }}
+                        <span
+                            class="bg-primary/10 text-primary flex h-11 w-11 flex-none items-center justify-center rounded-full text-sm font-semibold"
+                            aria-hidden="true"
+                        >
+                            {{ initials(speaker.name) }}
                         </span>
-                    </span>
-                </Link>
-            </li>
-        </ul>
-        <p v-if="!speakers.length" class="mt-12 text-center text-sm text-gray-500">No speakers match “{{ query }}”.</p>
+                        <span class="min-w-0">
+                            <span class="block truncate text-[15px] font-medium text-gray-100">{{ speaker.name }}</span>
+                            <span class="block text-xs text-gray-500 tabular-nums">
+                                {{ speaker.videosCount }} {{ speaker.videosCount === 1 ? 'talk' : 'talks' }}
+                            </span>
+                        </span>
+                    </Link>
+                </li>
+            </ul>
+            <p v-if="!results.length" class="mt-10 text-center text-sm text-gray-500">No speakers match “{{ query }}”.</p>
+        </section>
 
-        <div class="mt-10">
-            <PaginationNav :has-prev-page="has_prev_page" :has-next-page="has_next_page" />
-        </div>
+        <template v-else>
+            <!-- Curated tier: the voices with the deepest catalogues -->
+            <section class="mt-12" aria-label="Featured voices">
+                <SectionHeading title="Featured voices" />
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <Link
+                        v-for="speaker in featured"
+                        :key="speaker.url"
+                        :href="speaker.url"
+                        prefetch
+                        class="focus-visible:ring-ring flex items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-4 transition-colors duration-150 outline-none hover:border-white/20 hover:bg-white/[0.06] focus-visible:ring-2"
+                    >
+                        <span
+                            class="bg-primary/10 text-primary flex h-14 w-14 flex-none items-center justify-center rounded-full text-lg font-semibold"
+                            aria-hidden="true"
+                        >
+                            {{ initials(speaker.name) }}
+                        </span>
+                        <span class="min-w-0">
+                            <span class="block truncate text-[15px] font-semibold text-gray-50">{{ speaker.name }}</span>
+                            <span class="block text-xs text-gray-500 tabular-nums">
+                                {{ speaker.videosCount }} talks<template v-if="speaker.knownFor"> · known for {{ speaker.knownFor }}</template>
+                            </span>
+                        </span>
+                    </Link>
+                </div>
+            </section>
+
+            <!-- The long tail: present, honest, compact — and only loaded on scroll -->
+            <WhenVisible data="all_speakers" :buffer="300">
+                <template #fallback>
+                    <section class="mt-14" aria-label="All speakers">
+                        <Skeleton class="h-7 w-48 bg-white/5" />
+                        <div class="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                            <Skeleton v-for="n in 12" :key="n" class="h-5 w-36 bg-white/5" />
+                        </div>
+                    </section>
+                </template>
+                <section class="mt-14" aria-label="All speakers">
+                    <SectionHeading title="All speakers A–Z" />
+                    <div v-for="group in all_speakers || []" :key="group.letter" class="mt-6">
+                        <h3 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">{{ group.letter }}</h3>
+                        <ul class="mt-2 grid grid-cols-1 gap-x-6 gap-y-1.5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                            <li v-for="speaker in group.speakers" :key="speaker.url" class="min-w-0">
+                                <Link
+                                    :href="speaker.url"
+                                    class="focus-visible:ring-ring inline-flex max-w-full items-baseline gap-1.5 rounded text-sm text-gray-300 outline-none hover:text-white hover:underline focus-visible:ring-2"
+                                >
+                                    <span class="truncate">{{ speaker.name }}</span>
+                                    <span class="shrink-0 text-xs text-gray-600 tabular-nums">{{ speaker.videosCount }}</span>
+                                </Link>
+                            </li>
+                        </ul>
+                    </div>
+                </section>
+            </WhenVisible>
+        </template>
     </div>
 </template>

--- a/tests/test_directory_pages.py
+++ b/tests/test_directory_pages.py
@@ -1,35 +1,76 @@
 import pytest
 
-from tests.factories import BibleBookFactory, DemographicFactory, MinistryFactory, SpeakerFactory, VideoFactory
+from tests.factories import (
+    BibleBookFactory,
+    DemographicFactory,
+    MinistryFactory,
+    SeriesFactory,
+    SpeakerFactory,
+    VideoFactory,
+)
 from tests.utils import inertia_page
 
 pytestmark = pytest.mark.django_db
 
 
 class TestSpeakersIndex:
-    def test_lists_speakers_with_counts_alphabetically(self, client):
-        zeb = SpeakerFactory(name="Zebedee, Z")
-        amy = SpeakerFactory(name="Amos, A")
-        SpeakerFactory(name="Silent, S")  # no videos → hidden
-        for speaker in (zeb, amy):
-            video = VideoFactory()
-            video.speaker.add(speaker)
+    """Lookup-first pivot (docs/DESIGN_SPEC.md): featured tier + search,
+    long tail scroll-deferred — never a 662-card dump."""
+
+    def speakers_with_talks(self, spec):
+        for name, talks in spec:
+            speaker = SpeakerFactory(name=name)
+            for _ in range(talks):
+                video = VideoFactory()
+                video.speaker.add(speaker)
+
+    def test_featured_voices_are_the_deepest_catalogues(self, client):
+        self.speakers_with_talks([("Minor, M", 1), ("Major, M", 3), ("Middle, M", 2)])
+        SpeakerFactory(name="Silent, S")  # no videos → hidden everywhere
 
         page = inertia_page(client.get("/speaker/"))
 
         assert page["component"] == "SpeakersIndex"
-        assert [s["name"] for s in page["props"]["speakers"]] == ["Amos, A", "Zebedee, Z"]
-        assert page["props"]["total"] == 2
+        props = page["props"]
+        assert [s["name"] for s in props["featured"]] == ["Major, M", "Middle, M", "Minor, M"]
+        assert props["total"] == 3
+        assert "all_speakers" not in props  # long tail loads on scroll
 
-    def test_filters_by_query(self, client):
-        for name in ("Keller, Tim", "Piper, John"):
-            speaker = SpeakerFactory(name=name)
+    def test_featured_includes_known_for_series(self, client):
+        speaker = SpeakerFactory(name="Steele, Dominic")
+        series = SeriesFactory(name="The Pastor's Heart")
+        for _ in range(2):
             video = VideoFactory()
             video.speaker.add(speaker)
+            series.videos.add(video)
+
+        props = inertia_page(client.get("/speaker/"))["props"]
+
+        assert props["featured"][0]["knownFor"] == "The Pastor's Heart"
+
+    def test_all_speakers_load_on_scroll_grouped_a_to_z(self, client):
+        import json
+
+        self.speakers_with_talks([("Zebedee, Z", 1), ("Amos, A", 1), ("Abel, A", 1)])
+
+        response = client.get(
+            "/speaker/",
+            HTTP_X_INERTIA="true",
+            HTTP_X_INERTIA_PARTIAL_COMPONENT="SpeakersIndex",
+            HTTP_X_INERTIA_PARTIAL_DATA="all_speakers",
+        )
+
+        groups = json.loads(response.content)["props"]["all_speakers"]
+        assert [g["letter"] for g in groups] == ["A", "Z"]
+        assert [s["name"] for s in groups[0]["speakers"]] == ["Abel, A", "Amos, A"]
+
+    def test_lookup_returns_matches(self, client):
+        self.speakers_with_talks([("Keller, Tim", 1), ("Piper, John", 1)])
 
         props = inertia_page(client.get("/speaker/", {"q": "piper"}))["props"]
 
-        assert [s["name"] for s in props["speakers"]] == ["Piper, John"]
+        assert [s["name"] for s in props["results"]] == ["Piper, John"]
+        assert props["query"] == "piper"
 
 
 class TestBooksIndex:


### PR DESCRIPTION
## Summary
Closes the destinations round. The 662-card dump becomes: search hero (lookup-first), "Featured voices" with *known for <series>* context, and the A–Z long tail as a compact scroll-deferred text directory (optional + WhenVisible).

## Verification
78/78 tests; browser-verified featured tier, scroll-loaded directory, and lookup ("begg" → Begg, Alistair) on the real data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)