### PR TITLE
Epic 2 dedup: prune orphan + identical-twin series

### DIFF
--- a/catalogue/ingest/series_tree.py
+++ b/catalogue/ingest/series_tree.py
@@ -32,14 +32,76 @@ def all_nodes(trees):
         yield from walk(tree)
 
 
+def canonical_id(id_numbers):
+    """Pick the survivor among duplicate series: the lowest legacy id (oldest,
+    most stable). Numeric where possible, else lexical."""
+
+    def key(value):
+        return (0, int(value)) if str(value).isdigit() else (1, str(value))
+
+    return min(id_numbers, key=key)
+
+
+def deduplicate_series(node_ids, stats):
+    """Make the series set authoritative and free of legacy-taxonomy noise:
+
+    1. Drop orphans — series not present in the hierarchy at all (stale
+       CSV-pipeline rows, often with comma-mangled names).
+    2. Collapse same-name twins that carry the IDENTICAL video set — the legacy
+       site listed one series under several browse trees, creating real
+       duplicate rows. Distinct-content same-name series (e.g. several
+       "One-offs") are kept.
+
+    Safe: Series.videos is M2M (delete only unlinks), and no Channel FK points
+    at series (verified). Survivor is the lowest legacy id, so the choice is
+    stable across re-runs.
+    """
+    from collections import defaultdict
+
+    from django.db.models import Count
+
+    orphans = Series.objects.exclude(id_number__in=node_ids)
+    stats["orphans_removed"] = orphans.count()
+    orphans.delete()
+
+    by_name = defaultdict(list)
+    for series in Series.objects.annotate(n=Count("videos")).filter(n__gt=0):
+        by_name[series.name].append(series)
+
+    removable = []
+    for rows in by_name.values():
+        if len(rows) < 2:
+            continue
+        by_content = defaultdict(list)
+        for series in rows:
+            by_content[frozenset(series.videos.values_list("id", flat=True))].append(series.id_number)
+        for id_numbers in by_content.values():
+            if len(id_numbers) > 1:
+                keep = canonical_id(id_numbers)
+                removable += [i for i in id_numbers if i != keep]
+
+    stats["duplicates_merged"] = len(removable)
+    Series.objects.filter(id_number__in=removable).delete()
+
+
 def ingest_series_trees(trees):
-    stats = {"series_created": 0, "series_updated": 0, "memberships": 0, "live_flagged": 0, "live_demoted": 0}
+    stats = {
+        "series_created": 0,
+        "series_updated": 0,
+        "memberships": 0,
+        "live_flagged": 0,
+        "live_demoted": 0,
+        "orphans_removed": 0,
+        "duplicates_merged": 0,
+    }
 
     numbered = set()  # videos already given number_in_series by an earlier node
     mentioned_ids = set()
     live_ids = set()
+    node_ids = set()
 
     for node, path in all_nodes(trees):
+        node_ids.add(str(node["id"]))
         programme_ids = [str(p["id"]) for p in node.get("programmes") or []]
         mentioned_ids.update(programme_ids)
         if LIVE_STREAMS_TREE_ID in path or node["id"] == LIVE_STREAMS_TREE_ID:
@@ -70,4 +132,6 @@ def ingest_series_trees(trees):
     stats["live_demoted"] = Video.objects.filter(is_livestream=True, id__in=mentioned_ids - live_ids).update(
         is_livestream=False
     )
+
+    deduplicate_series(node_ids, stats)
     return stats

--- a/catalogue/management/commands/ingest_legacy_series.py
+++ b/catalogue/management/commands/ingest_legacy_series.py
@@ -26,6 +26,7 @@ class Command(BaseCommand):
             self.style.SUCCESS(
                 f"Series: {stats['series_created']} created, {stats['series_updated']} updated; "
                 f"{stats['memberships']} memberships; livestream flags: +{stats['live_flagged']} "
-                f"promoted, -{stats['live_demoted']} demoted."
+                f"promoted, -{stats['live_demoted']} demoted; "
+                f"deduped: -{stats['orphans_removed']} orphans, -{stats['duplicates_merged']} duplicate twins."
             )
         )

--- a/tests/test_ingest_series.py
+++ b/tests/test_ingest_series.py
@@ -127,3 +127,70 @@ def find_node(trees, node_id):
         if found:
             return found
     raise AssertionError(f"node {node_id} not in fixture")
+
+
+class TestSeriesDeduplication:
+    def trees_with(self, *nodes):
+        """A minimal browse root wrapping the given series nodes."""
+        return [{"id": 9000, "name": "BROWSE: ROOT", "subSeries": list(nodes)}]
+
+    def node(self, nid, name, programme_ids):
+        return {"id": nid, "name": name, "programmes": [{"id": p} for p in programme_ids]}
+
+    def test_orphan_series_not_in_hierarchy_are_removed(self):
+        from catalogue.models import Series
+
+        Series.objects.create(id_number="999", name="Shorts with Peter Orr,Psalms")  # CSV artifact
+        VideoFactory(id="1")
+
+        stats = ingest_series_trees(self.trees_with(self.node(1994, "JPC Services", ["1"])))
+
+        assert not Series.objects.filter(id_number="999").exists()
+        assert Series.objects.filter(id_number="1994").exists()
+        assert stats["orphans_removed"] == 1
+
+    def test_identical_content_twins_collapse_to_lowest_id(self):
+        from catalogue.models import Series
+
+        for pid in ("1", "2"):
+            VideoFactory(id=pid)
+        # Same name, same videos, under two browse paths → one survives (id 488)
+        trees = self.trees_with(
+            self.node(1994, "JPC Services", ["1", "2"]),
+            self.node(488, "JPC Services", ["1", "2"]),
+        )
+
+        stats = ingest_series_trees(trees)
+
+        survivors = list(Series.objects.filter(name="JPC Services").values_list("id_number", flat=True))
+        assert survivors == ["488"]
+        assert stats["duplicates_merged"] == 1
+
+    def test_same_name_distinct_content_is_kept(self):
+        from catalogue.models import Series
+
+        for pid in ("1", "2"):
+            VideoFactory(id=pid)
+        trees = self.trees_with(
+            self.node(10, "One-offs", ["1"]),
+            self.node(20, "One-offs", ["2"]),  # different video → genuinely separate
+        )
+
+        ingest_series_trees(trees)
+
+        assert Series.objects.filter(name="One-offs").count() == 2
+
+    def test_dedup_is_idempotent(self):
+        from catalogue.models import Series
+
+        for pid in ("1", "2"):
+            VideoFactory(id=pid)
+        trees = self.trees_with(
+            self.node(1994, "JPC Services", ["1", "2"]),
+            self.node(488, "JPC Services", ["1", "2"]),
+        )
+
+        ingest_series_trees(trees)
+        ingest_series_trees(trees)  # re-run: re-creates 1994 then re-collapses
+
+        assert list(Series.objects.filter(name="JPC Services").values_list("id_number", flat=True)) == ["488"]


### PR DESCRIPTION
## Summary
The /series page showed 2,667 series (509 duplicate names). Beta's 2.2 run created hierarchy series alongside the old CSV-era rows. The series ingestion's finalization now removes both noise sources:
- **341 orphans** — series in no hierarchy node (stale CSV rows, comma-mangled names)
- **333 identical-content twins** — the same series listed under multiple legacy browse trees (collapsed to lowest stable id; distinct-content same-name series kept)

Verified safe (M2M unlink only, no Channel FK), idempotent.

## Verification
82/82 tests (4 new). Will re-run `ingest_legacy_series` on beta after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)