### PR TITLE
Epic 6 quick wins: share button + watched memory

### DIFF
--- a/resources/js/components/atoms/VideoCardItem.vue
+++ b/resources/js/components/atoms/VideoCardItem.vue
@@ -1,6 +1,7 @@
 <script setup>
 import LogoMark from '@/atoms/LogoMark.vue';
-import { IconPlayerPlay } from '@tabler/icons-vue';
+import { IconCheck, IconPlayerPlay } from '@tabler/icons-vue';
+import { useWatchHistory } from '~/composables/useWatchHistory';
 
 defineProps({
     video: {
@@ -8,6 +9,8 @@ defineProps({
         required: true,
     },
 });
+
+const { hasWatched } = useWatchHistory();
 
 const getVideoThumbnail = (video) => {
     if (video.thumbnail?.startsWith('http')) {
@@ -40,6 +43,14 @@ const getVideoThumbnail = (video) => {
 
         <!-- Bottom scrim keeps the play glyph and title legible over any thumbnail -->
         <div class="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" aria-hidden="true"></div>
+
+        <!-- Courtesy "watched" tick from localStorage history -->
+        <span
+            v-if="hasWatched(video.id)"
+            class="bg-primary text-primary-foreground absolute top-2 right-2 z-10 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-semibold"
+        >
+            <IconCheck class="h-3 w-3" aria-hidden="true" /> Watched
+        </span>
 
         <div
             class="absolute inset-0 flex h-min w-min items-center justify-center place-self-center rounded-full bg-black/30 p-2 opacity-90 backdrop-blur-[2px] transition-opacity duration-200 ease-out group-hover:opacity-100"

--- a/resources/js/components/molecules/EpisodeRow.vue
+++ b/resources/js/components/molecules/EpisodeRow.vue
@@ -1,12 +1,15 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
-import { IconPlayerPlayFilled } from '@tabler/icons-vue';
+import { IconCheck, IconPlayerPlayFilled } from '@tabler/icons-vue';
+import { useWatchHistory } from '~/composables/useWatchHistory';
 
 defineProps({
     episode: { type: Object, required: true },
     // Display position: episode number where the data has one, else row index
     position: { type: Number, required: true },
 });
+
+const { hasWatched } = useWatchHistory();
 
 const thumb = (episode) => {
     if (episode.thumbnail?.startsWith('http')) return episode.thumbnail;
@@ -41,6 +44,13 @@ const thumb = (episode) => {
         <span class="min-w-0 flex-1">
             <span class="block truncate text-[15px] font-medium text-gray-100">{{ episode.name }}</span>
             <span v-if="episode.date" class="mt-0.5 block text-xs text-gray-500 tabular-nums">{{ episode.date }}</span>
+        </span>
+        <span
+            v-if="hasWatched(episode.id)"
+            class="text-primary mr-1 inline-flex shrink-0 items-center gap-1 text-xs font-medium"
+            title="You've watched this"
+        >
+            <IconCheck class="h-3.5 w-3.5" aria-hidden="true" /> Watched
         </span>
     </Link>
 </template>

--- a/resources/js/components/molecules/ShareButton.vue
+++ b/resources/js/components/molecules/ShareButton.vue
@@ -1,0 +1,81 @@
+<script setup>
+import { IconBrandWhatsapp, IconCheck, IconLink, IconShare } from '@tabler/icons-vue';
+import { computed, ref } from 'vue';
+
+const props = defineProps({
+    title: { type: String, required: true },
+});
+
+const copied = ref(false);
+const menuOpen = ref(false);
+
+// navigator.share isn't reactive, but it's stable per device; compute once
+const canNativeShare = computed(() => typeof navigator !== 'undefined' && !!navigator.share);
+
+const shareUrl = () => (typeof window !== 'undefined' ? window.location.href : '');
+
+const nativeShare = async () => {
+    try {
+        await navigator.share({ title: props.title, url: shareUrl() });
+    } catch {
+        // user cancelled — nothing to do
+    }
+};
+
+const copyLink = async () => {
+    try {
+        await navigator.clipboard.writeText(shareUrl());
+        copied.value = true;
+        setTimeout(() => (copied.value = false), 2000);
+    } catch {
+        copied.value = false;
+    }
+};
+
+const whatsappUrl = computed(() => `https://wa.me/?text=${encodeURIComponent(`${props.title} ${shareUrl()}`)}`);
+
+const onClick = () => {
+    if (canNativeShare.value) {
+        nativeShare();
+    } else {
+        menuOpen.value = !menuOpen.value;
+    }
+};
+</script>
+
+<template>
+    <div class="relative">
+        <button
+            @click="onClick"
+            class="focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-lg border border-white/15 px-4 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2"
+            aria-label="Share this video"
+        >
+            <IconShare class="h-4 w-4" aria-hidden="true" />
+            Share
+        </button>
+
+        <!-- Fallback menu for desktop browsers without the native share sheet -->
+        <div
+            v-if="menuOpen && !canNativeShare"
+            class="absolute top-full left-0 z-20 mt-2 w-56 rounded-xl border border-white/10 bg-gray-900 p-1.5 shadow-xl"
+        >
+            <button
+                @click="copyLink"
+                class="focus-visible:ring-ring flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-gray-200 outline-none hover:bg-white/5 focus-visible:ring-2"
+            >
+                <IconCheck v-if="copied" class="text-primary h-4 w-4" aria-hidden="true" />
+                <IconLink v-else class="h-4 w-4 text-gray-400" aria-hidden="true" />
+                {{ copied ? 'Link copied' : 'Copy link' }}
+            </button>
+            <a
+                :href="whatsappUrl"
+                target="_blank"
+                rel="noopener"
+                class="focus-visible:ring-ring flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-gray-200 outline-none hover:bg-white/5 focus-visible:ring-2"
+            >
+                <IconBrandWhatsapp class="h-4 w-4 text-gray-400" aria-hidden="true" />
+                Share on WhatsApp
+            </a>
+        </div>
+    </div>
+</template>

--- a/resources/js/composables/useWatchHistory.ts
+++ b/resources/js/composables/useWatchHistory.ts
@@ -1,0 +1,47 @@
+import { ref } from 'vue';
+
+/**
+ * Lightweight "have I seen this?" memory in localStorage — no accounts, no
+ * tracking, just a courtesy for the viewer (especially older members catching
+ * up across visits). Records which videos have been opened; the player APIs
+ * needed for exact resume positions are a later addition.
+ */
+const STORAGE_KEY = 'ctv:watched';
+const MAX_ENTRIES = 200;
+
+type History = Record<string, number>; // videoId -> last-opened epoch ms
+
+function read(): History {
+    if (typeof window === 'undefined') return {};
+    try {
+        return JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '{}');
+    } catch {
+        return {};
+    }
+}
+
+function write(history: History) {
+    // Keep only the most recent MAX_ENTRIES to bound storage growth
+    const trimmed = Object.fromEntries(
+        Object.entries(history)
+            .sort((a, b) => b[1] - a[1])
+            .slice(0, MAX_ENTRIES),
+    );
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+}
+
+// Shared reactive snapshot so cards update without a reload
+const watched = ref<History>(read());
+
+export function useWatchHistory() {
+    const markWatched = (videoId: string | number) => {
+        if (typeof window === 'undefined') return;
+        const id = String(videoId);
+        watched.value = { ...watched.value, [id]: Date.now() };
+        write(watched.value);
+    };
+
+    const hasWatched = (videoId: string | number) => String(videoId) in watched.value;
+
+    return { watched, markWatched, hasWatched };
+}

--- a/resources/js/pages/WatchVideo.vue
+++ b/resources/js/pages/WatchVideo.vue
@@ -1,10 +1,13 @@
 <script setup>
 import VideoCardItem from '@/atoms/VideoCardItem.vue';
 import SectionHeading from '@/molecules/SectionHeading.vue';
+import ShareButton from '@/molecules/ShareButton.vue';
 import VideoViewer from '@/organisms/VideoViewer.vue';
 import { Skeleton } from '@/ui/skeleton';
 import { Deferred, Head, Link } from '@inertiajs/vue3';
 import { IconBook, IconFileText, IconHeadphones } from '@tabler/icons-vue';
+import { watch as vueWatch } from 'vue';
+import { useWatchHistory } from '~/composables/useWatchHistory';
 
 const props = defineProps({
     video: { type: Object, required: true },
@@ -13,6 +16,15 @@ const props = defineProps({
     resources: { type: Array, required: false, default: () => [] },
     up_next: { type: Object, required: false, default: null },
 });
+
+// Remember that this video has been opened (localStorage; no accounts).
+// Re-fires on SPA navigation between watch pages, where the component is reused.
+const { markWatched } = useWatchHistory();
+markWatched(props.video.id);
+vueWatch(
+    () => props.video.id,
+    (id) => markWatched(id),
+);
 
 const resourceMeta = {
     transcript: { label: 'Read the transcript', icon: IconFileText },
@@ -58,9 +70,12 @@ const entries = (key) => {
                     Streamed
                 </span>
             </div>
-            <p class="mt-2 text-sm text-gray-500 tabular-nums">
-                {{ video.date_recorded ? `Recorded ${video.date_recorded}` : `Added ${video.date_created}` }}
-            </p>
+            <div class="mt-2 flex flex-wrap items-center justify-between gap-3">
+                <p class="text-sm text-gray-500 tabular-nums">
+                    {{ video.date_recorded ? `Recorded ${video.date_recorded}` : `Added ${video.date_created}` }}
+                </p>
+                <ShareButton :title="video.name" />
+            </div>
 
             <div class="mt-5 space-y-3">
                 <template v-for="group in metaGroups" :key="group.key">


### PR DESCRIPTION
## Summary
Two design-spec cross-cutting wins, client-side, no accounts:
- **Share** on the watch page — native share sheet (mobile) + copy/WhatsApp fallback (desktop). The church's sermon-forwarding growth loop, made one tap.
- **Watched memory** — `useWatchHistory` (localStorage, capped 200); watch page marks-on-open; video cards and episode rows show a "Watched" tick. Helps older members catch up across visits.

True resume positions need the player postMessage APIs — deferred; this is the watched-state slice.

## Verification
Browser-verified the native share sheet and the watched tick (watched a trailer → its episode row shows ✓ Watched, siblings don't). 82 backend tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)