### PR TITLE
Retry transient YouTube API 403s from datacenter IPs

### DIFF
--- a/catalogue/youtube_live.py
+++ b/catalogue/youtube_live.py
@@ -13,6 +13,7 @@ Clayton TV is who gets watched.
 
 import os
 import re
+import time
 
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -26,16 +27,27 @@ SEARCH_RESULTS_PER_TYPE = 10
 YOUTUBE_ID_REGEX = re.compile(r"(?:youtu\.be/|v/|embed/|watch\?v=|&v=)([^#&?/]+)")
 
 
+RETRY_ATTEMPTS = 3
+RETRY_DELAY_SECONDS = 3
+
+
 class YoutubeApiError(RuntimeError):
     pass
 
 
 def api_get(session, endpoint, **params):
+    """GET with retries: YouTube intermittently 403s requests from
+    datacenter IPs ("cannot act on behalf of the specified Google account"
+    — observed ~1 in 3 from app03 with a valid, unrestricted-IP key)."""
     params["key"] = os.environ["YOUTUBE_API_KEY"]
-    response = session.get(f"{API_BASE}/{endpoint}", params=params, timeout=20)
-    if response.status_code != 200:
-        raise YoutubeApiError(f"{endpoint} returned {response.status_code}: {getattr(response, 'text', '')[:300]}")
-    return response.json()
+    response = None
+    for attempt in range(RETRY_ATTEMPTS):
+        if attempt:
+            time.sleep(RETRY_DELAY_SECONDS * attempt)
+        response = session.get(f"{API_BASE}/{endpoint}", params=params, timeout=20)
+        if response.status_code == 200:
+            return response.json()
+    raise YoutubeApiError(f"{endpoint} returned {response.status_code}: {getattr(response, 'text', '')[:300]}")
 
 
 def youtube_id(url):

--- a/tests/test_youtube_live.py
+++ b/tests/test_youtube_live.py
@@ -157,6 +157,53 @@ def test_refresh_with_nothing_active_makes_no_api_call(monkeypatch):
     assert session.calls == []
 
 
+class FlakySession:
+    """First N calls 403, then defer to a FakeSession — models the
+    intermittent bot-heuristic 403s YouTube serves to datacenter IPs."""
+
+    def __init__(self, failures, then):
+        self.failures = failures
+        self.then = then
+        self.attempts = 0
+
+    def get(self, url, params=None, timeout=None):
+        self.attempts += 1
+        if self.attempts <= self.failures:
+
+            class Denied:
+                status_code = 403
+                text = "cannot act on behalf"
+
+            return Denied()
+        return self.then.get(url, params=params, timeout=timeout)
+
+
+def test_transient_api_403s_are_retried(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "k")
+    monkeypatch.setattr("catalogue.youtube_live.RETRY_DELAY_SECONDS", 0)
+    LiveStream.objects.create(video_id="vid12345678", title="Service", channel_id="UC1", status="upcoming")
+    recovered = FakeSession({"videos": {"items": [video_item("vid12345678", started="2026-06-14T10:30:00Z")]}})
+    session = FlakySession(2, recovered)
+
+    refresh_statuses(session)
+
+    assert LiveStream.objects.get(video_id="vid12345678").status == "live"
+    assert session.attempts == 3
+
+
+def test_persistent_api_failure_still_raises(monkeypatch):
+    import pytest as _pytest
+
+    from catalogue.youtube_live import YoutubeApiError
+
+    monkeypatch.setenv("YOUTUBE_API_KEY", "k")
+    monkeypatch.setattr("catalogue.youtube_live.RETRY_DELAY_SECONDS", 0)
+    LiveStream.objects.create(video_id="vid12345678", title="Service", channel_id="UC1", status="upcoming")
+
+    with _pytest.raises(YoutubeApiError):
+        refresh_statuses(FlakySession(99, FakeSession({})))
+
+
 def test_homepage_serves_live_and_next_service(client):
     LiveStream.objects.create(
         video_id="liveNow1234",


### PR DESCRIPTION
YouTube intermittently 403s identical requests from app03's IP (~1 in 3, curl-probed) — bot heuristics, not key or quota. `api_get` retries ×3 with linear backoff; persistent failures still raise. Tested with a flaky-then-recovering fake session and an always-failing one. 9 live-sync tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)