### PR TITLE
Sync hardening: self-sizing depth, per-page ingest, real media resolution

### DIFF
--- a/catalogue/ingest/live_admin.py
+++ b/catalogue/ingest/live_admin.py
@@ -21,6 +21,7 @@ from bs4 import BeautifulSoup
 
 BASE_URL = os.environ.get("LEGACY_ADMIN_BASE_URL", "https://clayton.tv/adminsection")
 PAGE_SIZE = 50
+MAX_AUTO_PAGES = 200  # auto-depth runaway stop: 10,000 programmes
 
 
 class AdminAuthError(Exception):
@@ -85,18 +86,49 @@ def fetch(session, path, _retried=False):
     return response.text
 
 
-def list_programme_ids(session, pages=1):
-    """Newest-modified programme ids from the paginated list."""
-    ids = []
-    for page in range(pages):
+def iter_programme_id_pages(session, pages=1):
+    """Yield one list of programme ids per newest-modified list page.
+
+    pages=N scans a fixed depth (the hourly cron). pages=None is the
+    self-sizing catch-up: keep paging until an entire page is ids we already
+    hold (a modified programme always floats to page 0, so known territory
+    means caught up). The stopping page is still yielded — its programmes
+    are the newest-modified known ones, worth a refresh.
+    """
+    auto = pages is None
+    # Snapshot once: ids ingested *during* this run must not look "known"
+    known_before_run = set(_video_model().objects.values_list("id", flat=True)) if auto else set()
+    seen = set()
+    for page in range(MAX_AUTO_PAGES if auto else pages):
         html = fetch(session, f"mediaProgramme.asp?order=mdate&direc=up&offset={page * PAGE_SIZE}")
         page_ids = re.findall(r"mediaProgramme\w*\.asp\?ID=(\d+)", html)
-        for pid in page_ids:
-            if pid not in ids:
-                ids.append(pid)
+        if page == 0 and not page_ids:
+            raise RuntimeError(
+                "Legacy admin list returned no programme links — layout change or error page? "
+                "Refusing to report a silent empty sync."
+            )
         if not page_ids:
             break
-    return ids
+        fresh = []
+        for pid in page_ids:
+            if pid not in seen:  # pages repeat ids (meta + timeline links)
+                seen.add(pid)
+                fresh.append(pid)
+        if fresh:
+            yield fresh
+        if auto and all(pid in known_before_run for pid in page_ids):
+            break
+
+
+def _video_model():
+    from catalogue.models import Video
+
+    return Video
+
+
+def list_programme_ids(session, pages=1):
+    """Newest-modified programme ids from the paginated list (flat)."""
+    return [pid for page_ids in iter_programme_id_pages(session, pages=pages) for pid in page_ids]
 
 
 def parse_meta_page(html):
@@ -137,6 +169,24 @@ def parse_meta_page(html):
     }
 
 
+def resolve_media(session, programme_id):
+    """The current admin's meta form carries no video link (observed live
+    2026-06-12, ID 12408): the URL lives on the media-item editor. The
+    programme's image-picker options encode "<thumbnail>|<media id>" — follow
+    the media id to mediaUpdate.asp, whose vimeoLink holds the actual URL
+    (YouTube or Vimeo, despite the name)."""
+    html = fetch(session, f"mediaProgrammeImage.asp?ID={programme_id}")
+    option = re.search(r'value="([^"|]*)\|(\d+)"', html)
+    if not option:
+        return None
+    thumbnail, media_id = option.group(1), option.group(2)
+    media_html = fetch(session, f"mediaUpdate.asp?ID={media_id}")
+    link = re.search(r'name="vimeoLink"[^>]*value="([^"]+)"', media_html)
+    if not link:
+        return None
+    return {"url": link.group(1), "thumbnail": thumbnail}
+
+
 def to_dump_record(programme_id, meta):
     """Shape a live-admin programme exactly like a legacy-dump record so the
     standard ingest path handles it (same normalization, same collisions,
@@ -173,13 +223,33 @@ def to_dump_record(programme_id, meta):
 
 
 def sync(pages=1, delay_seconds=1.0, session=None):
+    """Fetch and ingest page by page, so a crash mid-catch-up (network blip,
+    session lapse on the dying legacy server) keeps everything already
+    fetched — the rerun then starts from a smaller gap."""
     from .legacy import ingest_programmes
 
     session = session or session_from_env()
+    stats = {}
     records = []
-    for programme_id in list_programme_ids(session, pages=pages):
-        meta = parse_meta_page(fetch(session, f"mediaProgrammeMeta.asp?ID={programme_id}"))
-        records.append(to_dump_record(programme_id, meta))
-        time.sleep(delay_seconds)  # be gentle: the legacy server is dying as it is
+    for page_ids in iter_programme_id_pages(session, pages=pages):
+        page_records = []
+        for programme_id in page_ids:
+            meta = parse_meta_page(fetch(session, f"mediaProgrammeMeta.asp?ID={programme_id}"))
+            if not meta.get("url"):
+                # Current admin layout: the link lives on the media editor
+                time.sleep(delay_seconds)
+                media = resolve_media(session, programme_id)
+                if media:
+                    meta["url"] = media["url"]
+                    meta["thumbnail"] = meta.get("thumbnail") or media["thumbnail"]
+            page_records.append(to_dump_record(programme_id, meta))
+            time.sleep(delay_seconds)  # be gentle: the legacy server is dying as it is
+        page_stats = ingest_programmes(page_records)
+        records.extend(page_records)
+        for key, value in page_stats.items():
+            if isinstance(value, list):
+                stats.setdefault(key, []).extend(value)
+            else:
+                stats[key] = stats.get(key, 0) + value
 
-    return ingest_programmes(records), records
+    return stats, records

--- a/catalogue/management/commands/sync_live_admin.py
+++ b/catalogue/management/commands/sync_live_admin.py
@@ -11,7 +11,14 @@ class Command(BaseCommand):
     help = "Pull the newest-modified programmes from the legacy admin and upsert them"
 
     def add_arguments(self, parser):
-        parser.add_argument("--pages", type=int, default=2, help="List pages to scan (50 programmes each)")
+        parser.add_argument(
+            "--pages",
+            type=int,
+            default=None,
+            help="List pages to scan (50 programmes each). Default: keep paging "
+            "until a whole page is already-known programmes — backlogs of any "
+            "size catch up by themselves.",
+        )
 
     def handle(self, *args, **options):
         try:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -61,7 +61,16 @@ sessions and re-logins automatically when they lapse. Fallback: paste a
 logged-in browser's Cookie header as `LEGACY_ADMIN_COOKIE` (expires; fails
 loudly when it does). Cron (dev user):
 
-    17 * * * * cd /srv/beta-claytontv/current && .venv/bin/python manage.py sync_live_admin --pages 2 >> /srv/beta-claytontv/shared/logs/sync.log 2>&1
+    17 * * * * cd /srv/beta-claytontv/current && .venv/bin/python manage.py sync_live_admin >> /srv/beta-claytontv/shared/logs/sync.log 2>&1
+
+With no --pages flag the sync sizes itself: it pages the newest-modified
+list until a whole page is programmes we already hold, so backlogs of any
+size (including a first-ever catch-up) self-heal — at ~2-3s per programme
+a big catch-up can take a couple of hours. Each page ingests as it
+completes, so an interrupted run keeps its progress. Note the meta form
+no longer carries the video link; the sync follows the programme's
+image-picker media id to mediaUpdate.asp for it (layout observed
+2026-06-12).
 
 ## YouTube live-stream sync (Epic 4)
 

--- a/tests/test_live_admin_sync.py
+++ b/tests/test_live_admin_sync.py
@@ -70,6 +70,161 @@ def test_list_page_yields_unique_ids_in_order():
     assert list_programme_ids(session, pages=1) == ["12404", "12403"]
 
 
+def list_html(*ids):
+    rows = "".join(f'<tr><td><a href="mediaProgrammeMeta.asp?ID={i}">x</a></td></tr>' for i in ids)
+    return f"<table>{rows}</table>"
+
+
+class PagedSession(FakeSession):
+    """Serves a different list page per offset, so depth behaviour is testable."""
+
+    def __init__(self, list_pages, metas=None):
+        super().__init__(metas or {})
+        self.list_pages = list_pages
+        self.offsets_requested = []
+
+    def get(self, url, **kwargs):
+        if "mediaProgramme.asp" in url:
+            import re
+
+            offset = int(re.search(r"offset=(\d+)", url).group(1))
+            self.offsets_requested.append(offset)
+            page = offset // 50
+            body = self.list_pages[page] if page < len(self.list_pages) else ""
+
+            class R:
+                status_code = 200
+
+                def __init__(self):
+                    self.text = body
+                    self.url = url
+
+                def raise_for_status(self):
+                    pass
+
+            return R()
+        return super().get(url, **kwargs)
+
+
+def test_auto_depth_crawls_until_a_page_holds_no_new_programmes():
+    """pages=None: keep paging the newest-modified list until a whole page is
+    already-known ids — the catch-up backfill sizes itself, no --pages guess."""
+    from tests.factories import VideoFactory
+
+    for known in ("100", "101"):
+        VideoFactory(id=known)
+    session = PagedSession(
+        [list_html("300", "301"), list_html("302", "100"), list_html("100", "101"), list_html("999")]
+    )
+
+    ids = list_programme_ids(session, pages=None)
+
+    assert ids == ["300", "301", "302", "100", "101"]
+    # Stopped after the all-known page; never fetched page 3
+    assert session.offsets_requested == [0, 50, 100]
+
+
+def test_auto_depth_is_capped():
+    from catalogue.ingest import live_admin
+
+    endless = PagedSession([list_html(str(1000 + n)) for n in range(500)])
+
+    list_programme_ids(endless, pages=None)
+
+    assert len(endless.offsets_requested) == live_admin.MAX_AUTO_PAGES
+
+
+def test_an_empty_first_page_fails_loudly():
+    """Zero programme links on page 0 means the admin's HTML changed or an
+    ASP error page came back — a silent 0-synced success would hide it."""
+    session = PagedSession([""])
+
+    with pytest.raises(RuntimeError, match="no programme links"):
+        list_programme_ids(session, pages=1)
+
+
+def test_sync_ingests_page_by_page_so_a_crash_loses_nothing():
+    """A mid-backfill crash (network, session lapse) must keep everything
+    already fetched — ingest happens per page, not once at the end."""
+    from catalogue.ingest import live_admin
+
+    class CrashySession(PagedSession):
+        def get(self, url, **kwargs):
+            if "mediaProgrammeMeta.asp" in url and "ID=12403" in url:
+                raise OSError("network died")
+            return super().get(url, **kwargs)
+
+    session = CrashySession(
+        [list_html("12404"), list_html("12403"), list_html("12404")],
+        metas={"mediaProgrammeMeta.asp": META_HTML},
+    )
+
+    with pytest.raises(OSError):
+        live_admin.sync(pages=None, delay_seconds=0, session=session)
+
+    # Page 0's programme was ingested before page 1 crashed
+    assert Video.objects.filter(id="12404").exists()
+
+
+# Current admin layout: the meta form has NO vimeoLink — the video URL lives
+# on the media item editor, reached via the programme's image-picker options
+# (value = "<thumbnail>|<media id>"). Observed live 2026-06-12 on ID 12408.
+_LINK_INPUT = '<input name="vimeoLink" value="https://www.youtube.com/watch?v=oCivERk8ZWQ">'
+_THUMB_INPUT = '<input name="ThumbnailURL" value="https://i.ytimg.com/vi/oCivERk8ZWQ/mqdefault.jpg">'
+META_HTML_NO_MEDIA = META_HTML.replace(_LINK_INPUT, "").replace(_THUMB_INPUT, "")
+
+IMAGE_HTML = """
+<select name="ddlThumbnail">
+  <option value="https://img.youtube.com/vi/EJ2WLlPuBQ8/mqdefault.jpg|13838" selected>thumb</option>
+</select>
+"""
+
+MEDIA_UPDATE_HTML = """
+<form><input name="MediaName" value="YT6336SermonPM31.05.26">
+<input name="vimeoLink" value="https://youtu.be/EJ2WLlPuBQ8">
+<input name="MediaDuration" value="1730000"></form>
+"""
+
+
+def test_media_url_is_resolved_via_the_media_item_editor():
+    """Meta form without vimeoLink → follow image-picker media id to
+    mediaUpdate.asp and take the link from there."""
+    from catalogue.ingest import live_admin
+
+    session = PagedSession(
+        [list_html("12408")],
+        metas={
+            "mediaProgrammeMeta.asp": META_HTML_NO_MEDIA,
+            "mediaProgrammeImage.asp": IMAGE_HTML,
+            "mediaUpdate.asp": MEDIA_UPDATE_HTML,
+        },
+    )
+
+    stats, _records = live_admin.sync(pages=1, delay_seconds=0, session=session)
+
+    assert stats["created"] == 1
+    video = Video.objects.get(id="12408")
+    assert video.url == "https://youtu.be/EJ2WLlPuBQ8"
+    assert video.thumbnail == "https://img.youtube.com/vi/EJ2WLlPuBQ8/mqdefault.jpg"
+
+
+def test_programmes_with_no_media_anywhere_stay_skipped():
+    from catalogue.ingest import live_admin
+
+    session = PagedSession(
+        [list_html("12409")],
+        metas={
+            "mediaProgrammeMeta.asp": META_HTML_NO_MEDIA,
+            "mediaProgrammeImage.asp": "<select name='ddlThumbnail'></select>",
+        },
+    )
+
+    stats, _ = live_admin.sync(pages=1, delay_seconds=0, session=session)
+
+    assert stats["skipped_no_media"] == 1
+    assert not Video.objects.filter(id="12409").exists()
+
+
 def test_meta_page_parses_to_a_dump_shaped_record():
     record = to_dump_record("12404", parse_meta_page(META_HTML))
 


### PR DESCRIPTION
## Summary
First authenticated run against the live admin (creds landed today) exposed a real layout gap plus the hardening this PR adds:

- **Media resolution fix (the root cause of "0 created")**: the admin's meta form no longer carries the video link — it lives on `mediaUpdate.asp?ID=<media id>`, reached via the programme's image-picker option values (`<thumbnail>|<media id>`). Observed live on ID 12408; the sync follows the hop when the meta form lacks a link. Live re-run: **49/50 created**, local newest video 2024-10-16 → **2026-06-07**.
- **Self-sizing depth** (`--pages` defaults to auto): page the newest-modified list until a whole page is already-known programmes. Backfills of any size self-heal; capped at 200 pages.
- **Per-page ingest**: mid-run crashes keep all fetched progress.
- **Loud zero-page failure**: empty page 0 raises instead of a silent 0-sync success.

## Verification
6 new tests (auto-depth stop + cap, crash injection, media-hop fixtures, empty-page raise); 115 green. Validated against the live legacy admin locally. Beta backfill to follow merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)