### PR TITLE
Homepage hero: Starting-soon state embeds the stream waiting room

### DIFF
--- a/catalogue/youtube_live.py
+++ b/catalogue/youtube_live.py
@@ -14,6 +14,7 @@ Clayton TV is who gets watched.
 import os
 import re
 import time
+from datetime import timedelta
 
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -21,6 +22,7 @@ from django.utils.dateparse import parse_datetime
 from catalogue.models import LiveStream, Video
 
 API_BASE = "https://youtube.googleapis.com/youtube/v3"
+STARTS_SOON_WINDOW = timedelta(minutes=30)
 CHANNEL_SAMPLE = 50  # recent livestream videos to derive channels from
 SEARCH_RESULTS_PER_TYPE = 10
 
@@ -166,6 +168,10 @@ def homepage_live_props():
             "title": upcoming.title,
             "url": upcoming.url,
             "scheduled_start": upcoming.scheduled_start,
+            # Inside the pre-service window the card embeds the stream's
+            # waiting room (countdown; starts by itself when live) instead
+            # of a static schedule
+            "starts_soon": upcoming.scheduled_start <= timezone.now() + STARTS_SOON_WINDOW,
         }
         if upcoming
         else None

--- a/resources/js/components/molecules/NextServiceCard.vue
+++ b/resources/js/components/molecules/NextServiceCard.vue
@@ -64,6 +64,29 @@ const formatSchedule = (iso: string) => {
         </div>
     </div>
 
+    <!-- Service starts within the half-hour: embed the stream's own waiting
+         room — it shows the countdown and begins by itself when live -->
+    <div v-else-if="nextService?.starts_soon" class="border-primary/40 overflow-hidden rounded-xl border bg-white/[0.03]">
+        <div class="aspect-video w-full bg-black">
+            <iframe
+                class="h-full w-full"
+                :src="getEmbedUrl(nextService.url) || undefined"
+                allow="autoplay; clipboard-write; fullscreen; picture-in-picture"
+                referrerpolicy="strict-origin-when-cross-origin"
+                allowfullscreen
+                :title="nextService.title"
+            ></iframe>
+        </div>
+        <div class="p-4">
+            <div class="flex items-center gap-2">
+                <span class="bg-primary inline-block h-2 w-2 rounded-full" aria-hidden="true"></span>
+                <p class="text-primary text-xs font-bold tracking-wider uppercase">Starting soon</p>
+            </div>
+            <p class="font-display mt-2 text-lg leading-snug font-bold text-gray-50">{{ nextService.title }}</p>
+            <p class="mt-1 text-sm text-gray-400 tabular-nums">{{ formatSchedule(nextService.scheduled_start) }} — the stream will begin here.</p>
+        </div>
+    </div>
+
     <!-- A real scheduled service: honest date and time, no countdown theatre -->
     <div v-else-if="nextService" class="rounded-xl border border-white/10 bg-white/[0.03] p-5 sm:p-6">
         <div class="flex items-center gap-2">

--- a/tests/test_youtube_live.py
+++ b/tests/test_youtube_live.py
@@ -229,6 +229,36 @@ def test_homepage_serves_live_and_next_service(client):
     assert props["next_service"]["title"] == "Evening Service"
 
 
+def test_next_service_starting_soon_is_flagged(client):
+    """Within the pre-service window the card offers the stream's waiting
+    room (countdown, auto-starts) instead of a static schedule."""
+    from django.utils import timezone
+
+    LiveStream.objects.create(
+        video_id="soonNow1234",
+        title="Morning Service",
+        channel_id="UC1",
+        status="upcoming",
+        scheduled_start=timezone.now() + datetime.timedelta(minutes=10),
+    )
+
+    next_service = inertia_page(client.get("/"))["props"]["next_service"]
+
+    assert next_service["starts_soon"] is True
+
+
+def test_next_service_well_ahead_is_not_soon(client):
+    LiveStream.objects.create(
+        video_id="later1234567",
+        title="Evening Service",
+        channel_id="UC1",
+        status="upcoming",
+        scheduled_start=datetime.datetime(2099, 1, 1, tzinfo=datetime.UTC),
+    )
+
+    assert inertia_page(client.get("/"))["props"]["next_service"]["starts_soon"] is False
+
+
 def test_homepage_next_service_ignores_past_schedules(client):
     LiveStream.objects.create(
         video_id="past1234567",


### PR DESCRIPTION
Within 30 min of a scheduled service, the next-service card embeds the broadcast's own waiting room (countdown, auto-starts when live) under a STARTING SOON label — zero taps for a congregant arriving just before 10.30. Preview-verified against the real Sunday broadcast; `starts_soon` window pinned by 2 new tests (117 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)