### PR TITLE
Epic 6.8: empty states + text-size control

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -168,6 +168,13 @@
         @apply border-border outline-ring/50;
     }
 
+    /* User text-size preference (useTextScale): multiplies the browser's own
+       root font-size, so every rem-based size scales proportionally. Defaults
+       to 1 when unset; never disables pinch-zoom. */
+    html {
+        font-size: calc(100% * var(--text-scale, 1));
+    }
+
     body {
         @apply bg-background text-foreground;
     }

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -5,6 +5,7 @@ import { createApp, createSSRApp, DefineComponent, h } from 'vue';
 import { initializeAnalytics } from '~/lib/analytics';
 import { resolvePageComponent } from '~/lib/inertia-helper';
 import { initializeTheme } from './composables/useAppearance';
+import { initializeTextScale } from './composables/useTextScale';
 
 import AppLayout from '@/layouts/AppLayout.vue';
 
@@ -43,4 +44,5 @@ createInertiaApp({
 });
 
 initializeTheme();
+initializeTextScale();
 initializeAnalytics();

--- a/resources/js/components/layouts/AppFooter.vue
+++ b/resources/js/components/layouts/AppFooter.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import LogoMark from '@/atoms/LogoMark.vue';
+import TextSizeControl from '@/molecules/TextSizeControl.vue';
 import { Link } from '@inertiajs/vue3';
 import { IconBrandGithub, IconBrandVimeo, IconBrandYoutube } from '@tabler/icons-vue';
 
@@ -59,20 +60,26 @@ const columns = [
             </nav>
         </div>
         <div class="border-t border-white/5">
-            <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-5 lg:px-8">
+            <div class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-5 lg:px-8">
                 <p class="text-xs text-gray-600">© {{ year }} Clayton TV</p>
-                <div class="flex gap-1">
-                    <a
-                        v-for="social in socials"
-                        :key="social.name"
-                        :href="social.href"
-                        :aria-label="social.name"
-                        rel="noopener"
-                        target="_blank"
-                        class="focus-visible:ring-ring inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-gray-500 transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2"
-                    >
-                        <component :is="social.icon" class="h-5 w-5 stroke-[1.5]" aria-hidden="true" />
-                    </a>
+                <div class="flex items-center gap-3">
+                    <div class="flex items-center gap-2">
+                        <span class="text-xs text-gray-600">Text size</span>
+                        <TextSizeControl />
+                    </div>
+                    <div class="flex gap-1">
+                        <a
+                            v-for="social in socials"
+                            :key="social.name"
+                            :href="social.href"
+                            :aria-label="social.name"
+                            rel="noopener"
+                            target="_blank"
+                            class="focus-visible:ring-ring inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-gray-500 transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2"
+                        >
+                            <component :is="social.icon" class="h-5 w-5 stroke-[1.5]" aria-hidden="true" />
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/resources/js/components/layouts/AppHeader.vue
+++ b/resources/js/components/layouts/AppHeader.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import LogoMark from '@/atoms/LogoMark.vue';
 import ShortcutsHelp from '@/molecules/ShortcutsHelp.vue';
+import TextSizeControl from '@/molecules/TextSizeControl.vue';
 import CommandPalette from '@/organisms/CommandPalette.vue';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/ui/sheet';
 import { Link, usePage } from '@inertiajs/vue3';
@@ -123,6 +124,10 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigat
                             {{ option.name }}
                         </Link>
                     </nav>
+                    <div class="mt-4 flex items-center justify-between border-t border-white/10 px-4 pt-4">
+                        <span class="text-sm text-gray-400">Text size</span>
+                        <TextSizeControl />
+                    </div>
                 </SheetContent>
             </Sheet>
         </div>

--- a/resources/js/components/molecules/EmptyState.vue
+++ b/resources/js/components/molecules/EmptyState.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { Link } from '@inertiajs/vue3';
+import { IconMoodSearch } from '@tabler/icons-vue';
+
+// A calm, reusable "nothing here" panel — icon, heading, a reassuring line,
+// and an optional way forward. Used for empty grids, no search results, and
+// not-found pages so a non-technical user is never left staring at a blank.
+defineProps({
+    icon: { type: [Object, Function], default: () => IconMoodSearch },
+    title: { type: String, required: true },
+    message: { type: String, default: '' },
+    ctaHref: { type: String, default: '' },
+    ctaLabel: { type: String, default: '' },
+});
+</script>
+
+<template>
+    <div class="flex flex-col items-center justify-center rounded-xl border border-white/10 bg-white/[0.02] px-6 py-16 text-center">
+        <component :is="icon" class="h-12 w-12 text-gray-600" aria-hidden="true" />
+        <p class="font-display mt-4 text-xl font-bold text-gray-100">{{ title }}</p>
+        <p v-if="message" class="mt-2 max-w-md text-sm leading-relaxed text-gray-400">{{ message }}</p>
+        <Link
+            v-if="ctaHref && ctaLabel"
+            :href="ctaHref"
+            class="bg-primary text-primary-foreground focus-visible:ring-ring hover:bg-primary/90 mt-6 inline-flex min-h-11 items-center rounded-lg px-5 text-sm font-semibold transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+        >
+            {{ ctaLabel }}
+        </Link>
+        <!-- Lets callers add extra actions (e.g. "Clear filters") -->
+        <div v-if="$slots.actions" class="mt-6"><slot name="actions" /></div>
+    </div>
+</template>

--- a/resources/js/components/molecules/TextSizeControl.vue
+++ b/resources/js/components/molecules/TextSizeControl.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { IconLetterA } from '@tabler/icons-vue';
+import { useTextScale } from '~/composables/useTextScale';
+
+// A−/A+ text resizing for the elderly-first audience. Adds to (never replaces)
+// browser pinch-zoom. Persists via useTextScale.
+const { increase, decrease, reset, canIncrease, canDecrease, isDefault } = useTextScale();
+</script>
+
+<template>
+    <div class="flex items-center gap-1" role="group" aria-label="Text size">
+        <button
+            @click="decrease()"
+            :disabled="!canDecrease()"
+            aria-label="Decrease text size"
+            class="focus-visible:ring-ring inline-flex min-h-9 min-w-9 cursor-pointer items-center justify-center rounded-md text-gray-400 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
+        >
+            <IconLetterA class="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+        <button
+            @click="reset()"
+            :disabled="isDefault()"
+            aria-label="Reset text size"
+            class="focus-visible:ring-ring inline-flex min-h-9 min-w-9 cursor-pointer items-center justify-center rounded-md text-gray-400 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
+        >
+            <IconLetterA class="h-5 w-5" aria-hidden="true" />
+        </button>
+        <button
+            @click="increase()"
+            :disabled="!canIncrease()"
+            aria-label="Increase text size"
+            class="focus-visible:ring-ring inline-flex min-h-9 min-w-9 cursor-pointer items-center justify-center rounded-md text-gray-400 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
+        >
+            <IconLetterA class="h-6 w-6" aria-hidden="true" />
+        </button>
+    </div>
+</template>

--- a/resources/js/components/organisms/VideoCardGrid.vue
+++ b/resources/js/components/organisms/VideoCardGrid.vue
@@ -1,5 +1,6 @@
 <script setup>
 import VideoCardItem from '@/atoms/VideoCardItem.vue';
+import EmptyState from '@/molecules/EmptyState.vue';
 import { Link, router } from '@inertiajs/vue3';
 defineProps({
     videos: {
@@ -19,6 +20,14 @@ defineProps({
     },
     has_next_page: {
         type: Boolean,
+    },
+    emptyTitle: {
+        type: String,
+        default: 'Nothing here yet',
+    },
+    emptyMessage: {
+        type: String,
+        default: 'There are no videos to show. Try browsing the latest teaching or another part of the library.',
     },
 });
 
@@ -44,7 +53,9 @@ const nextPage = () => {
             <p v-if="description" class="mt-2 text-sm text-gray-500" v-html="description"></p>
         </div>
 
-        <ul class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
+        <EmptyState v-if="!videos.length" :title="emptyTitle" :message="emptyMessage" cta-href="/latest" cta-label="Browse the latest teaching" />
+
+        <ul v-else class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
             <li v-for="video in videos" :key="video.id" class="relative isolate aspect-video">
                 <Link
                     :href="`/video/` + video.id"

--- a/resources/js/composables/useTextScale.ts
+++ b/resources/js/composables/useTextScale.ts
@@ -1,0 +1,54 @@
+import { ref } from 'vue';
+
+/**
+ * User-controlled text size for the elderly-first audience. Scales the root
+ * font size, so every rem-based size (text + spacing) grows proportionally —
+ * a genuinely bigger, still-balanced UI, not just bigger glyphs. Persisted in
+ * localStorage; no account needed. Pinch-zoom remains untouched (this is an
+ * addition to, not a replacement for, browser zoom).
+ */
+const STORAGE_KEY = 'ctv:textScale';
+const MIN = 0.9;
+const MAX = 1.5;
+const STEP = 0.1;
+const DEFAULT = 1;
+
+const scale = ref(DEFAULT);
+
+const clamp = (value: number) => Math.min(MAX, Math.max(MIN, Math.round(value * 10) / 10));
+
+function apply(value: number) {
+    if (typeof document === 'undefined') return;
+    // Root font-size as a percentage of the browser default (so a user's own
+    // browser font-size preference is still respected and multiplied).
+    document.documentElement.style.setProperty('--text-scale', String(value));
+}
+
+export function initializeTextScale() {
+    if (typeof window === 'undefined') return;
+    const stored = parseFloat(window.localStorage.getItem(STORAGE_KEY) || '');
+    scale.value = Number.isFinite(stored) ? clamp(stored) : DEFAULT;
+    apply(scale.value);
+}
+
+export function useTextScale() {
+    const set = (value: number) => {
+        scale.value = clamp(value);
+        apply(scale.value);
+        try {
+            window.localStorage.setItem(STORAGE_KEY, String(scale.value));
+        } catch {
+            // private mode — the size still applies for this session
+        }
+    };
+
+    const increase = () => set(scale.value + STEP);
+    const decrease = () => set(scale.value - STEP);
+    const reset = () => set(DEFAULT);
+
+    const canIncrease = () => scale.value < MAX;
+    const canDecrease = () => scale.value > MIN;
+    const isDefault = () => scale.value === DEFAULT;
+
+    return { scale, increase, decrease, reset, canIncrease, canDecrease, isDefault, MIN, MAX };
+}

--- a/resources/js/pages/Search.vue
+++ b/resources/js/pages/Search.vue
@@ -53,7 +53,13 @@ const props = defineProps({
         </section>
 
         <div class="mt-10">
-            <VideoCardGrid :videos :has_prev_page :has_next_page />
+            <VideoCardGrid
+                :videos
+                :has_prev_page
+                :has_next_page
+                empty-title="No matching videos"
+                empty-message="We couldn't find any videos for that search. Try a different word, a speaker's name, or a Bible book."
+            />
         </div>
     </div>
 </template>


### PR DESCRIPTION
First slice of closing Epic 6 — two elderly-first accessibility wins.

- **`EmptyState.vue`** (reusable: icon, heading, reassuring copy, CTA) wired into `VideoCardGrid` so every empty list/search/relation shows a calm panel instead of a blank. Search passes contextual copy.
- **Text-size control** (`useTextScale` + `TextSizeControl` A−/reset/A+ in footer + mobile menu): scales root font-size via a `--text-scale` CSS var (all rem sizing grows proportionally), persisted. **Adds to** browser zoom — pinch-zoom untouched (no `maximum-scale` lockdown), per the elderly-first guardrail.

Browser-verified (no-result search → empty state w/ CTA; A+ → 16px→19.2px, persists). 146 backend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)