### PR TITLE
Epic 6.7: motion pass — generalised page entrances

### DIFF
--- a/resources/js/components/organisms/VideoCardGrid.vue
+++ b/resources/js/components/organisms/VideoCardGrid.vue
@@ -2,6 +2,9 @@
 import VideoCardItem from '@/atoms/VideoCardItem.vue';
 import EmptyState from '@/molecules/EmptyState.vue';
 import { Link, router } from '@inertiajs/vue3';
+import { useEntrance } from '~/composables/useEntrance';
+
+const { entrance } = useEntrance();
 defineProps({
     videos: {
         type: Array,
@@ -45,7 +48,7 @@ const nextPage = () => {
 </script>
 
 <template>
-    <section class="flex flex-col gap-y-6">
+    <section v-bind="entrance()" class="flex flex-col gap-y-6">
         <div v-if="title || description">
             <h1 v-if="title" class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">
                 {{ title }}

--- a/resources/js/composables/useEntrance.ts
+++ b/resources/js/composables/useEntrance.ts
@@ -1,0 +1,17 @@
+/**
+ * One quiet entrance per page-load, staggered top-to-bottom in reading order —
+ * information hierarchy, not decoration. CSS-driven (tw-animate-css), so it
+ * costs no runtime JS and collapses entirely under prefers-reduced-motion.
+ *
+ * Usage:  <section v-bind="entrance(140)"> … </section>
+ */
+export function entrance(delayMs = 0) {
+    return {
+        class: 'animate-in fade-in-0 slide-in-from-bottom-3 fill-mode-both duration-300 ease-out motion-reduce:animate-none',
+        style: { animationDelay: `${delayMs}ms` },
+    };
+}
+
+export function useEntrance() {
+    return { entrance };
+}

--- a/resources/js/pages/LatestFeed.vue
+++ b/resources/js/pages/LatestFeed.vue
@@ -4,7 +4,10 @@ import PaginationNav from '@/molecules/PaginationNav.vue';
 import SeriesFloodRow from '@/molecules/SeriesFloodRow.vue';
 import { Head, Link } from '@inertiajs/vue3';
 import { computed } from 'vue';
+import { useEntrance } from '~/composables/useEntrance';
 import { useLastVisit } from '~/composables/useLastVisit';
+
+const { entrance } = useEntrance();
 
 const props = defineProps({
     title: { type: String, required: true },
@@ -36,7 +39,7 @@ const dividerBeforeId = computed(() => {
         <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Latest</h1>
         <p class="mt-2 text-sm text-gray-500">New teaching and recent series, most recent first.</p>
 
-        <section v-for="group in groups" :key="group.label" class="mt-10" :aria-label="group.label">
+        <section v-for="(group, i) in groups" :key="group.label" v-bind="entrance(80 + i * 70)" class="mt-10" :aria-label="group.label">
             <h2 class="flex items-center gap-3 text-sm font-semibold tracking-wider text-gray-400 uppercase">
                 {{ group.label }}
                 <span class="h-px flex-1 bg-white/10" aria-hidden="true"></span>

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -6,6 +6,7 @@ import SeriesCard from '@/molecules/SeriesCard.vue';
 import { Skeleton } from '@/ui/skeleton';
 import { Link, WhenVisible } from '@inertiajs/vue3';
 import { IconArrowRight } from '@tabler/icons-vue';
+import { useEntrance } from '~/composables/useEntrance';
 
 const props = defineProps({
     livestreams: { type: Array, default: () => [] },
@@ -18,13 +19,9 @@ const props = defineProps({
 
 const latestVideoUrl = props.latest_videos.length ? `/video/${props.latest_videos[0].id}` : '/latest';
 
-// One quiet entrance per page-load, staggered top-to-bottom as reading order —
-// information hierarchy, not decoration. CSS animation via tw-animate-css;
-// motion-reduce collapses it entirely.
-const entrance = (delayMs) => ({
-    class: 'animate-in fade-in-0 slide-in-from-bottom-3 fill-mode-both duration-300 ease-out motion-reduce:animate-none',
-    style: { animationDelay: `${delayMs}ms` },
-});
+// Shared staggered page entrance (see useEntrance) — information hierarchy,
+// reduced-motion safe.
+const { entrance } = useEntrance();
 </script>
 
 <template>


### PR DESCRIPTION
- **`useEntrance`** composable extracts Welcome's staggered fade/slide-up into one reusable, reduced-motion-safe helper (CSS-driven).
- Applied to **Welcome**, **LatestFeed** (groups stagger), and **`VideoCardGrid`** — which backs ~8 list pages, so they all gain a consistent entrance from a single edit.
- Mini-player keeps its existing reduced-motion-safe slide-in (already within spec).

**Plan deviations (transparent):** (1) didn't add `@vueuse/motion` — CSS sufficed, honouring minimal-abstraction; (2) deferred the dock↔mini **FLIP** — it coincides with an Inertia navigation, making a true FLIP fragile for little gain over the reliable slide-in.

Browser-verified (entrance classes + stagger apply, no errors, reduced-motion collapses). 146 backend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)