### PR TITLE
Epic 6.8: skip-to-content link + accessible palette input

### DIFF
--- a/resources/js/components/layouts/AppLayout.vue
+++ b/resources/js/components/layouts/AppLayout.vue
@@ -7,8 +7,15 @@ import PersistentPlayer from '@/organisms/PersistentPlayer.vue';
 <template>
     <!-- relative: PersistentPlayer's docked mode positions in document coords -->
     <div class="relative flex min-h-full flex-col bg-gray-950">
+        <!-- Keyboard users skip the nav straight to content -->
+        <a
+            href="#main"
+            class="bg-primary text-primary-foreground sr-only z-50 rounded-md px-4 py-2 text-sm font-semibold focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:outline-none focus:ring-2 focus:ring-white"
+        >
+            Skip to content
+        </a>
         <AppHeader />
-        <main class="flex-1">
+        <main id="main" tabindex="-1" class="flex-1 outline-none">
             <slot />
         </main>
         <AppFooter />

--- a/resources/js/components/organisms/CommandPalette.vue
+++ b/resources/js/components/organisms/CommandPalette.vue
@@ -81,7 +81,7 @@ const navShortcuts = [
 
 <template>
     <CommandDialog v-model:open="paletteOpen" title="Search" description="Search teaching, series, speakers and more">
-        <CommandInput placeholder="Search teaching, series, speakers…" @update:model-value="onQuery" />
+        <CommandInput aria-label="Search teaching, series, speakers" placeholder="Search teaching, series, speakers…" @update:model-value="onQuery" />
         <CommandList>
             <CommandEmpty v-if="query.trim()">No matches for “{{ query }}”</CommandEmpty>
 


### PR DESCRIPTION
Keyboard/screen-reader wins toward WCAG AA:
- **Skip to content** link (first focusable, sr-only until focused) → focusable `<main id="main">`.
- **aria-label** on the command-palette input (no longer placeholder-only).

Light-mode contrast + theme toggle deferred to a dedicated reviewed PR (large hardcoded-colour repaint of the signature dark surface — flagged for your eyes). 146 backend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)