### PR TITLE
Phase 2: Services destination + one-click Live nav

### DIFF
--- a/app/http/middleware/handle_inertia_requests.py
+++ b/app/http/middleware/handle_inertia_requests.py
@@ -2,6 +2,8 @@ import os
 
 from inertia import share
 
+from catalogue.youtube_live import is_live_now
+
 # from .models import User
 
 
@@ -22,6 +24,10 @@ class HandleInertiaRequests:
                 }
             },
             sidebarOpen=request.COOKIES.get("sidebar_state", "false") == "true",
+            # Global flag for the "Live" nav indicator (one cheap exists()).
+            # Skipped for JSON /api/ endpoints (e.g. the keystroke-hot palette)
+            # which never render the nav, so they pay nothing for it.
+            live_now=False if request.path.startswith("/api/") else is_live_now(),
         )
 
         response = self.get_response(request)

--- a/app/views.py
+++ b/app/views.py
@@ -16,7 +16,7 @@ from catalogue.models.speaker import Speaker
 from catalogue.models.topic import Topic
 from catalogue.models.video import Video
 from catalogue.passages import parse_passage, passage_label
-from catalogue.youtube_live import homepage_live_props
+from catalogue.youtube_live import homepage_live_props, live_streams, upcoming_streams
 
 pagination_per_page = 24
 
@@ -81,21 +81,25 @@ def index(request):
 
 
 def browse_all_livestreams(request):
-    paginator = Paginator(Video.objects.filter(is_livestream=True).order_by(RECENT_FIRST), pagination_per_page)
-    page_num = 1
+    """The Services destination: live now + upcoming scheduled services + the
+    past-services archive in one place (Epic 4). One obvious page for the
+    Sunday service, calm when nothing is on."""
     try:
         page_num = int(request.GET.get("page", 1))
     except ValueError:
         page_num = 1
+    paginator = Paginator(Video.objects.filter(is_livestream=True).order_by(RECENT_FIRST), pagination_per_page)
     paginated = paginator.page(page_num)
     return render(
         request,
-        "Browse",
+        "Services",
         {
-            "title": "Past Live Streams",
-            "description": f"Recordings of previous live services, most recent first "
-            f"(page {page_num} of {paginator.num_pages})",
-            "videos": video_card_props(paginated.object_list),
+            "title": "Services",
+            "live": live_streams(),
+            "upcoming": upcoming_streams(),
+            "past": video_card_props(paginated.object_list),
+            "page": page_num,
+            "num_pages": paginator.num_pages,
             "has_prev_page": paginated.has_previous(),
             "has_next_page": paginated.has_next(),
         },

--- a/catalogue/youtube_live.py
+++ b/catalogue/youtube_live.py
@@ -150,30 +150,50 @@ def _parse(value):
     return parse_datetime(value) if value else None
 
 
+def _serialize_live(stream):
+    return {
+        "video_id": stream.video_id,
+        "title": stream.title,
+        "url": stream.url,
+        "thumbnail": stream.thumbnail,
+        "channel": stream.channel_title,
+    }
+
+
+def _serialize_upcoming(stream):
+    return {
+        "video_id": stream.video_id,
+        "title": stream.title,
+        "url": stream.url,
+        "channel": stream.channel_title,
+        "scheduled_start": stream.scheduled_start,
+        # Inside the pre-service window the card embeds the stream's waiting
+        # room (countdown; starts by itself when live) instead of a static
+        # schedule.
+        "starts_soon": stream.scheduled_start <= timezone.now() + STARTS_SOON_WINDOW,
+    }
+
+
+def live_streams():
+    return [_serialize_live(s) for s in LiveStream.objects.filter(status="live").order_by("-actual_start")]
+
+
+def upcoming_streams():
+    return [
+        _serialize_upcoming(s)
+        for s in LiveStream.objects.filter(status="upcoming", scheduled_start__gte=timezone.now()).order_by(
+            "scheduled_start"
+        )
+    ]
+
+
+def is_live_now():
+    """Cheap existence check for the global "live" nav indicator."""
+    return LiveStream.objects.filter(status="live").exists()
+
+
 def homepage_live_props():
     """What the homepage hero slot needs: anything live right now, and the
     next scheduled service."""
-    live = [
-        {"video_id": s.video_id, "title": s.title, "url": s.url, "thumbnail": s.thumbnail, "channel": s.channel_title}
-        for s in LiveStream.objects.filter(status="live").order_by("-actual_start")
-    ]
-    upcoming = (
-        LiveStream.objects.filter(status="upcoming", scheduled_start__gte=timezone.now())
-        .order_by("scheduled_start")
-        .first()
-    )
-    next_service = (
-        {
-            "video_id": upcoming.video_id,
-            "title": upcoming.title,
-            "url": upcoming.url,
-            "scheduled_start": upcoming.scheduled_start,
-            # Inside the pre-service window the card embeds the stream's
-            # waiting room (countdown; starts by itself when live) instead
-            # of a static schedule
-            "starts_soon": upcoming.scheduled_start <= timezone.now() + STARTS_SOON_WINDOW,
-        }
-        if upcoming
-        else None
-    )
-    return live, next_service
+    upcoming = upcoming_streams()
+    return live_streams(), (upcoming[0] if upcoming else None)

--- a/resources/js/components/layouts/AppFooter.vue
+++ b/resources/js/components/layouts/AppFooter.vue
@@ -18,7 +18,7 @@ const columns = [
         links: [
             { name: 'Latest', href: '/latest' },
             { name: 'Series', href: '/series' },
-            { name: 'Past live streams', href: '/livestreams' },
+            { name: 'Services', href: '/livestreams' },
         ],
     },
     {

--- a/resources/js/components/layouts/AppHeader.vue
+++ b/resources/js/components/layouts/AppHeader.vue
@@ -6,7 +6,7 @@ import CommandPalette from '@/organisms/CommandPalette.vue';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/ui/sheet';
 import { Link, usePage } from '@inertiajs/vue3';
 import { IconMenu2, IconSearch } from '@tabler/icons-vue';
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { usePalette } from '~/composables/usePalette';
 
 const navOptions = [
@@ -15,12 +15,15 @@ const navOptions = [
     { name: 'Topics', href: '/topic' },
     { name: 'Speakers', href: '/speaker' },
     { name: 'Latest', href: '/latest' },
+    { name: 'Live', href: '/livestreams', live: true },
 ];
 
 const page = usePage();
 const mobileNavOpen = ref(false);
 
 const isCurrent = (href: string) => (href === '/' ? page.url === '/' : page.url.startsWith(href));
+// Global "a service is on air" flag (shared from the Inertia middleware)
+const liveNow = computed(() => page.props.live_now === true);
 
 const { paletteOpen, helpOpen } = usePalette();
 
@@ -74,10 +77,17 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigat
                     :href="option.href"
                     prefetch
                     :class="isCurrent(option.href) ? 'bg-white/10 text-white' : 'text-gray-400'"
-                    class="focus-visible:ring-ring rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2"
                     :aria-current="isCurrent(option.href) ? 'page' : undefined"
                 >
                     {{ option.name }}
+                    <span v-if="option.live && liveNow" class="relative flex h-2 w-2" :title="'A service is live now'">
+                        <span
+                            class="bg-primary absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 motion-reduce:animate-none"
+                        ></span>
+                        <span class="bg-primary relative inline-flex h-2 w-2 rounded-full"></span>
+                        <span class="sr-only">live now</span>
+                    </span>
                 </Link>
             </nav>
 
@@ -118,10 +128,17 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigat
                             :href="option.href"
                             @click="mobileNavOpen = false"
                             :class="isCurrent(option.href) ? 'bg-white/10 text-white' : 'text-gray-300'"
-                            class="focus-visible:ring-ring rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
+                            class="focus-visible:ring-ring inline-flex items-center gap-2 rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
                             :aria-current="isCurrent(option.href) ? 'page' : undefined"
                         >
                             {{ option.name }}
+                            <span v-if="option.live && liveNow" class="relative flex h-2 w-2">
+                                <span
+                                    class="bg-primary absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 motion-reduce:animate-none"
+                                ></span>
+                                <span class="bg-primary relative inline-flex h-2 w-2 rounded-full"></span>
+                                <span class="sr-only">live now</span>
+                            </span>
                         </Link>
                     </nav>
                     <div class="mt-4 flex items-center justify-between border-t border-white/10 px-4 pt-4">

--- a/resources/js/pages/Services.vue
+++ b/resources/js/pages/Services.vue
@@ -1,0 +1,116 @@
+<script setup>
+import VideoCardGrid from '@/organisms/VideoCardGrid.vue';
+import { Head } from '@inertiajs/vue3';
+import { IconBroadcast } from '@tabler/icons-vue';
+import { ref } from 'vue';
+import { useEntrance } from '~/composables/useEntrance';
+import { getEmbedUrl } from '~/lib/embeds';
+
+// Live now + upcoming scheduled services + the past-services archive.
+// Calm when nothing is on: just the archive.
+const props = defineProps({
+    title: { type: String, required: true },
+    live: { type: Array, default: () => [] },
+    upcoming: { type: Array, default: () => [] },
+    past: { type: Array, default: () => [] },
+    has_prev_page: { type: Boolean, default: false },
+    has_next_page: { type: Boolean, default: false },
+});
+
+const { entrance } = useEntrance();
+
+// Which live/upcoming embeds the viewer has opened (lazy: thumbnail until tap)
+const watching = ref(new Set());
+const watch = (id) => (watching.value = new Set(watching.value).add(id));
+
+const embed = (url, autoplay) => getEmbedUrl(url, { autoplay }) || undefined;
+
+const formatSchedule = (iso) => {
+    const date = new Date(iso);
+    const day = date.toLocaleDateString('en-GB', { weekday: 'long', day: 'numeric', month: 'long' });
+    const time = date.toLocaleTimeString('en-GB', { hour: 'numeric', minute: '2-digit' });
+    return `${day}, ${time}`;
+};
+</script>
+
+<template>
+    <Head :title="title" />
+    <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
+        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Services</h1>
+        <p class="mt-2 text-sm text-gray-500">Watch live, see what's coming up, or catch up on a past service.</p>
+
+        <!-- LIVE NOW — the most important thing on the page when present -->
+        <section v-if="live.length" v-bind="entrance(0)" class="mt-8" aria-label="Live now">
+            <h2 class="text-primary flex items-center gap-2 text-sm font-bold tracking-wider uppercase">
+                <span class="relative flex h-2.5 w-2.5" aria-hidden="true">
+                    <span
+                        class="bg-primary absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 motion-reduce:animate-none"
+                    ></span>
+                    <span class="bg-primary relative inline-flex h-2.5 w-2.5 rounded-full"></span>
+                </span>
+                Live now
+            </h2>
+            <div class="mt-4 grid gap-6" :class="live.length > 1 ? 'lg:grid-cols-2' : ''">
+                <div v-for="stream in live" :key="stream.video_id" class="border-primary/40 overflow-hidden rounded-xl border bg-white/[0.03]">
+                    <div v-if="watching.has(stream.video_id)" class="aspect-video w-full bg-black">
+                        <iframe
+                            class="h-full w-full"
+                            :src="embed(stream.url, true)"
+                            allow="autoplay; clipboard-write; fullscreen; picture-in-picture"
+                            referrerpolicy="strict-origin-when-cross-origin"
+                            allowfullscreen
+                            :title="stream.title"
+                        ></iframe>
+                    </div>
+                    <button
+                        v-else
+                        @click="watch(stream.video_id)"
+                        class="group relative block aspect-video w-full cursor-pointer bg-black"
+                        aria-label="Watch live"
+                    >
+                        <img v-if="stream.thumbnail" :src="stream.thumbnail" alt="" class="absolute inset-0 h-full w-full object-cover opacity-80" />
+                        <span class="absolute inset-0 flex items-center justify-center">
+                            <span
+                                class="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-bold transition-transform duration-150 ease-out group-hover:scale-105 motion-reduce:transition-none"
+                            >
+                                <IconBroadcast class="h-5 w-5" aria-hidden="true" /> Watch live
+                            </span>
+                        </span>
+                    </button>
+                    <div class="p-4">
+                        <p class="font-display text-lg leading-snug font-bold text-gray-50">{{ stream.title }}</p>
+                        <p v-if="stream.channel" class="mt-1 text-sm text-gray-400">{{ stream.channel }}</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- UPCOMING — real scheduled services -->
+        <section v-if="upcoming.length" v-bind="entrance(80)" class="mt-12" aria-label="Upcoming services">
+            <h2 class="text-sm font-semibold tracking-wider text-gray-400 uppercase">Coming up</h2>
+            <ul class="mt-4 grid gap-4 sm:grid-cols-2">
+                <li v-for="stream in upcoming" :key="stream.video_id" class="rounded-xl border border-white/10 bg-white/[0.03] p-5">
+                    <p class="font-display text-base leading-snug font-bold text-gray-50">{{ stream.title }}</p>
+                    <p class="mt-1.5 text-sm text-gray-300 tabular-nums">{{ formatSchedule(stream.scheduled_start) }}</p>
+                    <p class="mt-1 text-xs text-gray-500">The stream will appear here when it starts.</p>
+                </li>
+            </ul>
+        </section>
+
+        <!-- PAST — the archive, lower down / "catch up" -->
+        <section v-bind="entrance(160)" class="mt-12" aria-label="Past services">
+            <h2 class="text-sm font-semibold tracking-wider text-gray-400 uppercase">
+                {{ live.length || upcoming.length ? 'Catch up on past services' : 'Past services' }}
+            </h2>
+            <div class="mt-4">
+                <VideoCardGrid
+                    :videos="past"
+                    :has_prev_page
+                    :has_next_page
+                    empty-title="No past services yet"
+                    empty-message="Recorded services will appear here after they've been streamed."
+                />
+            </div>
+        </section>
+    </div>
+</template>

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -108,7 +108,9 @@ def test_homepage_query_count_does_not_grow_with_catalogue_size(client, django_a
     for series in SeriesFactory.create_batch(20):
         series.videos.add(VideoFactory())
 
-    with django_assert_max_num_queries(6):
+    # 6 for the page + 1 constant global "live now" nav flag (cheap exists()
+    # on the small LiveStream table, shared by the Inertia middleware).
+    with django_assert_max_num_queries(7):
         response = client.get("/")
 
     assert response.status_code == 200

--- a/tests/test_latest_feed.py
+++ b/tests/test_latest_feed.py
@@ -130,5 +130,6 @@ def test_feed_query_count_does_not_grow_with_catalogue_size(client, django_asser
     for n in range(40):
         VideoFactory(date_recorded=datetime.date(2026, 5, 1) - datetime.timedelta(days=n))
 
-    with django_assert_max_num_queries(6):
+    # +1 for the constant global "live now" nav flag (Inertia middleware).
+    with django_assert_max_num_queries(7):
         client.get("/latest/")

--- a/tests/test_services_page.py
+++ b/tests/test_services_page.py
@@ -1,0 +1,74 @@
+"""The Services destination (/livestreams) — live now + upcoming services +
+past-services archive in one place — and the global "live now" nav flag.
+Elderly-critical: one obvious place for Sunday's service."""
+
+import datetime
+
+import pytest
+
+from catalogue.models import LiveStream
+from tests.factories import VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+
+def test_services_page_shows_live_upcoming_and_past(client):
+    LiveStream.objects.create(
+        video_id="liveNow1234",
+        title="Morning Service",
+        channel_id="UC1",
+        channel_title="Jesmond",
+        status="live",
+        actual_start=datetime.datetime(2026, 6, 14, 10, 30, tzinfo=datetime.UTC),
+    )
+    LiveStream.objects.create(
+        video_id="upNext56789",
+        title="Evening Service",
+        channel_id="UC1",
+        status="upcoming",
+        scheduled_start=datetime.datetime(2099, 1, 1, tzinfo=datetime.UTC),
+    )
+    VideoFactory(is_livestream=True, name="Old recorded service")
+    VideoFactory(is_livestream=False, name="A regular sermon")
+
+    page = inertia_page(client.get("/livestreams/"))
+    props = page["props"]
+
+    assert page["component"] == "Services"
+    assert [s["video_id"] for s in props["live"]] == ["liveNow1234"]
+    assert props["live"][0]["url"] == "https://www.youtube.com/watch?v=liveNow1234"
+    assert [s["title"] for s in props["upcoming"]] == ["Evening Service"]
+    past_names = [v["name"] for v in props["past"]]
+    assert "Old recorded service" in past_names
+    assert "A regular sermon" not in past_names
+
+
+def test_services_page_is_quiet_when_nothing_is_on(client):
+    VideoFactory(is_livestream=True, name="Old service")
+
+    props = inertia_page(client.get("/livestreams/"))["props"]
+
+    assert props["live"] == []
+    assert props["upcoming"] == []
+    assert len(props["past"]) == 1
+
+
+def test_upcoming_excludes_past_schedules(client):
+    LiveStream.objects.create(
+        video_id="past1234567",
+        title="Past",
+        channel_id="UC1",
+        status="upcoming",
+        scheduled_start=datetime.datetime(2020, 1, 1, tzinfo=datetime.UTC),
+    )
+
+    assert inertia_page(client.get("/livestreams/"))["props"]["upcoming"] == []
+
+
+def test_live_now_nav_flag_reflects_a_live_broadcast(client):
+    assert inertia_page(client.get("/"))["props"].get("live_now") in (False, None)
+
+    LiveStream.objects.create(video_id="liveNow1234", title="x", channel_id="UC1", status="live")
+
+    assert inertia_page(client.get("/"))["props"]["live_now"] is True


### PR DESCRIPTION
Makes the live service the easiest thing on the site to reach, calm when idle.

- **/livestreams → a real Services page**: Live now (prominent embed) → Coming up (real scheduled services) → Catch up (past-services archive). Quiet (just archive) when nothing's on.
- **Standalone "Live" nav item** with a pulsing indicator that shows **only when a service is on air** — global `live_now` flag from the Inertia middleware (one cheap `exists()`; skipped for `/api/` so the palette pays nothing).
- Reusable `live_streams()/upcoming_streams()/is_live_now()` in `youtube_live`; `homepage_live_props` refactored onto them.

TDD (`test_services_page.py`), query guards +1 (documented), browser-verified live + idle + nav dot. 150 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)