### PR TITLE
Phase 4: durations everywhere

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1,7 +1,7 @@
 from urllib.parse import unquote  # Import for URL decoding
 
 from django.core.paginator import Paginator
-from django.db.models import Count, F, Q
+from django.db.models import Count, F, Q, Sum
 from django.http import JsonResponse
 from inertia import defer, optional, render
 
@@ -700,6 +700,8 @@ def browse_series(request, id):
     paginated = paginator.page(page_num)
 
     start_episode = episodes.first()
+    # Total runtime across the whole series (all pages), where durations exist.
+    total_runtime = series.videos.aggregate(total=Sum("duration_seconds"))["total"]
     return render(
         request,
         "SeriesDetail",
@@ -708,6 +710,7 @@ def browse_series(request, id):
                 "name": series.name,
                 "summary": series.summary,
                 "videosCount": series.videos_count,
+                "total_runtime": total_runtime,
                 "year_start": series.year_start,
                 "year_end": series.year_end,
             },
@@ -720,6 +723,7 @@ def browse_series(request, id):
                     "url": f"/video/{v.id}",
                     "date": v.date_recorded.isoformat() if v.date_recorded else None,
                     "thumbnail": v.thumbnail,
+                    "duration_seconds": v.duration_seconds,
                 }
                 for v in paginated.object_list
             ],

--- a/resources/js/components/molecules/EpisodeRow.vue
+++ b/resources/js/components/molecules/EpisodeRow.vue
@@ -2,6 +2,7 @@
 import { Link } from '@inertiajs/vue3';
 import { IconCheck, IconPlayerPlayFilled } from '@tabler/icons-vue';
 import { useWatchHistory } from '~/composables/useWatchHistory';
+import { formatDuration } from '~/lib/duration';
 
 defineProps({
     episode: { type: Object, required: true },
@@ -39,6 +40,12 @@ const thumb = (episode) => {
                 aria-hidden="true"
             >
                 <IconPlayerPlayFilled class="h-7 w-7 text-white drop-shadow" />
+            </span>
+            <span
+                v-if="formatDuration(episode.duration_seconds)"
+                class="absolute right-1 bottom-1 rounded bg-black/75 px-1 py-0.5 text-[10px] font-semibold text-white tabular-nums"
+            >
+                {{ formatDuration(episode.duration_seconds) }}
             </span>
         </span>
         <span class="min-w-0 flex-1">

--- a/resources/js/pages/SeriesDetail.vue
+++ b/resources/js/pages/SeriesDetail.vue
@@ -13,6 +13,15 @@ const props = defineProps({
     has_next_page: { type: Boolean },
 });
 
+// Whole-series runtime as a rounded "Xh Ym" / "Ym" — a course-length cue.
+const totalRuntime = () => {
+    const seconds = props.series_meta.total_runtime;
+    if (!seconds) return null;
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.round((seconds % 3600) / 60);
+    return hours ? `${hours}h ${minutes}m` : `${minutes}m`;
+};
+
 const looksLikeYear = (value) => /^\d{4}$/.test(String(value ?? '').trim());
 
 const years = () => {
@@ -37,6 +46,7 @@ const positionFor = (episode, index) => episode.number ?? props.page_start + ind
                 <h1 class="font-display mt-1 text-2xl leading-tight font-bold text-gray-50 sm:text-3xl">{{ series_meta.name }}</h1>
                 <p class="mt-2 text-sm text-gray-500 tabular-nums">
                     {{ series_meta.videosCount }} {{ series_meta.videosCount === 1 ? 'episode' : 'episodes' }}
+                    <template v-if="totalRuntime()"> · {{ totalRuntime() }}</template>
                     <template v-if="years()"> · {{ years() }}</template>
                 </p>
                 <p v-if="series_meta.summary" class="mt-3 max-w-prose text-[15px] leading-relaxed text-gray-400">

--- a/resources/js/pages/WatchVideo.vue
+++ b/resources/js/pages/WatchVideo.vue
@@ -8,6 +8,7 @@ import { IconBook, IconFileText, IconHeadphones, IconRotateClockwise } from '@ta
 import { onBeforeUnmount, onMounted, ref, watch as vueWatch } from 'vue';
 import { usePlayerDock } from '~/composables/usePlayerDock';
 import { useWatchHistory } from '~/composables/useWatchHistory';
+import { formatDuration } from '~/lib/duration';
 
 const props = defineProps({
     video: { type: Object, required: true },
@@ -116,6 +117,7 @@ const entries = (key) => {
             <div class="mt-2 flex flex-wrap items-center justify-between gap-3">
                 <p class="text-sm text-gray-500 tabular-nums">
                     {{ video.date_recorded ? `Recorded ${video.date_recorded}` : `Added ${video.date_created}` }}
+                    <template v-if="formatDuration(video.duration_seconds)"> · {{ formatDuration(video.duration_seconds) }}</template>
                 </p>
                 <ShareButton :title="video.name" />
             </div>


### PR DESCRIPTION
Surfaces harvested runtimes beyond cards: per-episode badges on episode rows, **series total runtime** ("5 episodes · 51m") in the header, and duration on the watch page — all graceful when a video lacks one (so the hashless-Vimeo gap shows nothing rather than a blank badge).

Browser-verified on a duration-rich series and the null case. 160 backend tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)