### PR TITLE
Phase 5: audiences area + nav restructure

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -20,6 +20,7 @@ from django.urls import path
 from django.views.generic import RedirectView
 
 from .views import (
+    audiences_index,
     books_index,
     browse_all_latest,
     browse_all_livestreams,
@@ -55,7 +56,9 @@ urlpatterns = [
     path("video/<int:id>", video, name="video"),
     path("book/<str:id>", browse_bible_book, name="browse_bible_book"),
     path("channel/<str:id>", browse_channel, name="browse_channel"),
-    path("demographic/<str:id>", browse_demographic, name="browse_demographic"),
+    path("audience/", audiences_index, name="audiences_index"),
+    path("audience/<str:id>", browse_demographic, name="browse_audience"),
+    path("demographic/<str:id>", browse_demographic, name="browse_demographic"),  # legacy links
     path("ministry/<str:id>", browse_ministry, name="browse_ministry"),
     path("series/<str:id>", browse_series, name="browse_series"),
     path("speaker/<str:id>", browse_speaker, name="browse_speaker"),
@@ -63,7 +66,7 @@ urlpatterns = [
     path("book/", books_index, name="browse_categories_book"),
     path("channel/", browse_categories, name="browse_categories_channel"),
     # Audiences live on the Topics page now; the standalone landing is gone
-    path("demographic/", RedirectView.as_view(url="/topic/"), name="browse_categories_demographic"),
+    path("demographic/", RedirectView.as_view(url="/audience/"), name="browse_categories_demographic"),
     path("ministry/", ministries_index, name="browse_categories_ministry"),
     path("series/", series_index, name="browse_categories_series"),
     path("speaker/", speakers_index, name="browse_categories_speaker"),

--- a/app/views.py
+++ b/app/views.py
@@ -550,24 +550,34 @@ def topics_index(request):
             }
         )
 
-    audiences = [
-        {
-            "name": d.name,
-            "videosCount": d.videos_count,
-            "url": d.get_absolute_url(),
-        }
-        for d in Demographic.objects.annotate(videos_count=Count("video")).order_by("name")
-    ]
-
     return render(
         request,
         "TopicsIndex",
         {
-            "audiences": audiences,
+            # Audiences moved to their own /audience/ area (TopicsIndex shows a
+            # pointer link instead of folding them in here).
             "topic_groups": [{"category": category, "topics": topics} for category, topics in sorted(groups.items())],
             "total": Topic.objects.count(),
         },
     )
+
+
+def audiences_index(request):
+    """Dedicated audiences landing (Kids/Youth/Adults) — image-led tiles for
+    the parent/kids persona, its own nav area rather than buried in Topics."""
+    audiences = [
+        {
+            "name": d.name,
+            "summary": d.summary,
+            "thumbnail": d.thumbnail,
+            "videosCount": d.videos_count,
+            "url": d.get_absolute_url(),
+        }
+        for d in Demographic.objects.annotate(videos_count=Count("video"))
+        .filter(videos_count__gt=0)
+        .order_by("-videos_count")
+    ]
+    return render(request, "AudiencesIndex", {"audiences": audiences})
 
 
 def speakers_index(request):

--- a/catalogue/models/demograpic.py
+++ b/catalogue/models/demograpic.py
@@ -43,6 +43,7 @@ class Demographic(models.Model):
         return self.name
 
     def get_absolute_url(self):
-        """Returns the URL to access a detailed record for the demographic"""
+        """URL for this audience. Audiences now have their own /audience/ area
+        (own nav item), no longer reached via the Topics page."""
         encoded_name = quote(self.name, safe="")  # Encode the name, escaping all special characters
-        return reverse("browse_demographic", args=[encoded_name])
+        return reverse("browse_audience", args=[encoded_name])

--- a/resources/js/components/layouts/AppHeader.vue
+++ b/resources/js/components/layouts/AppHeader.vue
@@ -3,26 +3,31 @@ import LogoMark from '@/atoms/LogoMark.vue';
 import ShortcutsHelp from '@/molecules/ShortcutsHelp.vue';
 import TextSizeControl from '@/molecules/TextSizeControl.vue';
 import CommandPalette from '@/organisms/CommandPalette.vue';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/ui/dropdown-menu';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/ui/sheet';
 import { Link, usePage } from '@inertiajs/vue3';
-import { IconMenu2, IconSearch } from '@tabler/icons-vue';
+import { IconChevronDown, IconMenu2, IconSearch } from '@tabler/icons-vue';
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { usePalette } from '~/composables/usePalette';
 
-const navOptions = [
-    { name: 'Home', href: '/' },
-    { name: 'Browse', href: '/browse' },
-    { name: 'Series', href: '/series' },
-    { name: 'Topics', href: '/topic' },
-    { name: 'Speakers', href: '/speaker' },
-    { name: 'Latest', href: '/latest' },
-    { name: 'Live', href: '/livestreams', live: true },
+// Calm primary bar for the elderly-first audience: Home · Browse · Latest ·
+// Live. Everything directory-shaped folds under "Browse" so the top stays
+// scannable; the command palette (⌘K) is the power-user fast path.
+const browseLinks = [
+    { name: 'All teaching', href: '/browse', hint: 'Filter by speaker, book, length…' },
+    { name: 'Series', href: '/series', hint: 'Courses & sermon series' },
+    { name: 'Topics', href: '/topic', hint: 'Browse by subject' },
+    { name: 'Speakers', href: '/speaker', hint: 'Find a preacher' },
+    { name: 'Bible books', href: '/book', hint: 'Teaching by passage' },
+    { name: 'For every age', href: '/audience', hint: 'Kids, youth & adults' },
 ];
+const BROWSE_PREFIXES = ['/browse', '/series', '/topic', '/speaker', '/book', '/audience', '/ministry'];
 
 const page = usePage();
 const mobileNavOpen = ref(false);
 
 const isCurrent = (href: string) => (href === '/' ? page.url === '/' : page.url.startsWith(href));
+const isBrowseSection = () => BROWSE_PREFIXES.some((p) => page.url.startsWith(p));
 // Global "a service is on air" flag (shared from the Inertia middleware)
 const liveNow = computed(() => page.props.live_now === true);
 
@@ -57,6 +62,9 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
 
 // Roughly: Mac keyboards show ⌘, everything else Ctrl
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
+
+const navLink = (active: boolean) =>
+    `${active ? 'bg-white/10 text-white' : 'text-gray-400'} focus-visible:ring-ring inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2`;
 </script>
 
 <template>
@@ -72,17 +80,36 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigat
             </Link>
 
             <nav class="hidden items-center gap-1 lg:flex" aria-label="Primary">
-                <Link
-                    v-for="option in navOptions"
-                    :key="option.name"
-                    :href="option.href"
-                    prefetch
-                    :class="isCurrent(option.href) ? 'bg-white/10 text-white' : 'text-gray-400'"
-                    class="focus-visible:ring-ring inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2"
-                    :aria-current="isCurrent(option.href) ? 'page' : undefined"
+                <Link href="/" prefetch :class="navLink(isCurrent('/'))" :aria-current="isCurrent('/') ? 'page' : undefined">Home</Link>
+
+                <!-- Browse: click-triggered panel of the directories (not a hover mega-menu) -->
+                <DropdownMenu>
+                    <DropdownMenuTrigger :class="navLink(isBrowseSection())" :aria-current="isBrowseSection() ? 'page' : undefined">
+                        Browse
+                        <IconChevronDown class="h-4 w-4 opacity-70" aria-hidden="true" />
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" class="w-64">
+                        <DropdownMenuItem v-for="link in browseLinks" :key="link.href" as-child>
+                            <Link :href="link.href" prefetch class="flex cursor-pointer flex-col items-start gap-0.5 py-2">
+                                <span class="text-sm font-medium">{{ link.name }}</span>
+                                <span class="text-muted-foreground text-xs">{{ link.hint }}</span>
+                            </Link>
+                        </DropdownMenuItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
+
+                <Link href="/latest" prefetch :class="navLink(isCurrent('/latest'))" :aria-current="isCurrent('/latest') ? 'page' : undefined"
+                    >Latest</Link
                 >
-                    {{ option.name }}
-                    <span v-if="option.live && liveNow" class="relative flex h-2 w-2" :title="'A service is live now'">
+
+                <Link
+                    href="/livestreams"
+                    prefetch
+                    :class="navLink(isCurrent('/livestreams'))"
+                    :aria-current="isCurrent('/livestreams') ? 'page' : undefined"
+                >
+                    Live
+                    <span v-if="liveNow" class="relative flex h-2 w-2" title="A service is live now">
                         <span
                             class="bg-primary absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 motion-reduce:animate-none"
                         ></span>
@@ -109,11 +136,11 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigat
                 >
                     <IconMenu2 class="h-6 w-6" aria-hidden="true" />
                 </SheetTrigger>
-                <SheetContent side="right" class="border-white/10 bg-gray-950 text-gray-100">
+                <SheetContent side="right" class="overflow-y-auto border-white/10 bg-gray-950 text-gray-100">
                     <SheetHeader>
                         <SheetTitle class="font-display text-left text-gray-50">Clayton TV</SheetTitle>
                     </SheetHeader>
-                    <div class="px-4 pb-2 sm:hidden">
+                    <div class="px-4 pb-2">
                         <button
                             @click="openPalette"
                             class="focus-visible:ring-ring flex h-11 w-full cursor-pointer items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 text-base text-gray-500 outline-none focus-visible:ring-2"
@@ -124,16 +151,43 @@ const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigat
                     </div>
                     <nav class="flex flex-col gap-1 px-2" aria-label="Mobile">
                         <Link
-                            v-for="option in navOptions"
-                            :key="option.name"
-                            :href="option.href"
+                            href="/"
                             @click="mobileNavOpen = false"
-                            :class="isCurrent(option.href) ? 'bg-white/10 text-white' : 'text-gray-300'"
-                            class="focus-visible:ring-ring inline-flex items-center gap-2 rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
-                            :aria-current="isCurrent(option.href) ? 'page' : undefined"
+                            :class="isCurrent('/') ? 'bg-white/10 text-white' : 'text-gray-300'"
+                            class="focus-visible:ring-ring rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
                         >
-                            {{ option.name }}
-                            <span v-if="option.live && liveNow" class="relative flex h-2 w-2">
+                            Home
+                        </Link>
+
+                        <p class="px-4 pt-3 pb-1 text-xs font-semibold tracking-wider text-gray-500 uppercase">Browse</p>
+                        <Link
+                            v-for="link in browseLinks"
+                            :key="link.href"
+                            :href="link.href"
+                            @click="mobileNavOpen = false"
+                            :class="isCurrent(link.href) ? 'bg-white/10 text-white' : 'text-gray-300'"
+                            class="focus-visible:ring-ring rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
+                        >
+                            {{ link.name }}
+                        </Link>
+
+                        <p class="px-4 pt-3 pb-1 text-xs font-semibold tracking-wider text-gray-500 uppercase">Watch</p>
+                        <Link
+                            href="/latest"
+                            @click="mobileNavOpen = false"
+                            :class="isCurrent('/latest') ? 'bg-white/10 text-white' : 'text-gray-300'"
+                            class="focus-visible:ring-ring rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
+                        >
+                            Latest
+                        </Link>
+                        <Link
+                            href="/livestreams"
+                            @click="mobileNavOpen = false"
+                            :class="isCurrent('/livestreams') ? 'bg-white/10 text-white' : 'text-gray-300'"
+                            class="focus-visible:ring-ring inline-flex items-center gap-2 rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
+                        >
+                            Live
+                            <span v-if="liveNow" class="relative flex h-2 w-2">
                                 <span
                                     class="bg-primary absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 motion-reduce:animate-none"
                                 ></span>

--- a/resources/js/components/organisms/CommandPalette.vue
+++ b/resources/js/components/organisms/CommandPalette.vue
@@ -71,11 +71,14 @@ watch(paletteOpen, (open) => {
 });
 
 const navShortcuts = [
+    { name: 'Browse & filter all teaching', url: '/browse/' },
     { name: 'Latest teaching', url: '/latest/' },
+    { name: 'Live & services', url: '/livestreams/' },
     { name: 'Series', url: '/series/' },
     { name: 'Topics', url: '/topic/' },
     { name: 'Speakers', url: '/speaker/' },
     { name: 'Bible books', url: '/book/' },
+    { name: 'For every age (Kids, Youth, Adults)', url: '/audience/' },
 ];
 </script>
 

--- a/resources/js/pages/AudiencesIndex.vue
+++ b/resources/js/pages/AudiencesIndex.vue
@@ -1,0 +1,54 @@
+<script setup>
+import { Head, Link } from '@inertiajs/vue3';
+import { IconMoodKid } from '@tabler/icons-vue';
+import { useEntrance } from '~/composables/useEntrance';
+
+// Image-led Kids/Youth/Adults tiles for the parent/kids persona — one tap to
+// a friendly, clearly-labelled page. Thumbnail with a warm colour fallback so
+// a tile is never broken when the (often-empty) thumbnail is missing.
+defineProps({
+    audiences: { type: Array, default: () => [] },
+});
+
+const { entrance } = useEntrance();
+
+const thumb = (audience) => (audience.thumbnail?.startsWith('http') ? audience.thumbnail : null);
+</script>
+
+<template>
+    <Head title="For every age" />
+    <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
+        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">For every age</h1>
+        <p class="mt-2 text-sm text-gray-500">Teaching chosen for children, young people and adults.</p>
+
+        <div v-bind="entrance(80)" class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            <Link
+                v-for="audience in audiences"
+                :key="audience.url"
+                :href="audience.url"
+                prefetch
+                class="group focus-visible:ring-ring block overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] transition-colors duration-150 outline-none hover:border-white/25 focus-visible:ring-2"
+            >
+                <div class="from-primary/30 relative flex aspect-[16/9] items-center justify-center bg-gradient-to-br to-gray-900">
+                    <img
+                        v-if="thumb(audience)"
+                        :src="thumb(audience)"
+                        alt=""
+                        loading="lazy"
+                        decoding="async"
+                        class="absolute inset-0 h-full w-full object-cover transition-transform duration-300 ease-out group-hover:scale-[1.03] motion-reduce:transition-none motion-reduce:group-hover:scale-100"
+                        onerror="this.style.opacity='0'"
+                    />
+                    <IconMoodKid class="h-12 w-12 text-white/80" aria-hidden="true" />
+                </div>
+                <div class="p-5">
+                    <p class="font-display text-xl font-bold text-gray-50">{{ audience.name }}</p>
+                    <p v-if="audience.summary" class="mt-1 line-clamp-2 text-sm leading-relaxed text-gray-400">{{ audience.summary }}</p>
+                    <p class="mt-3 text-sm text-gray-500 tabular-nums">
+                        {{ audience.videosCount }} {{ audience.videosCount === 1 ? 'video' : 'videos' }}
+                    </p>
+                </div>
+            </Link>
+        </div>
+    </div>
+</template>

--- a/resources/js/pages/TopicsIndex.vue
+++ b/resources/js/pages/TopicsIndex.vue
@@ -1,8 +1,8 @@
 <script setup>
 import { Head, Link } from '@inertiajs/vue3';
+import { IconArrowRight } from '@tabler/icons-vue';
 
 defineProps({
-    audiences: { type: Array, default: () => [] },
     topic_groups: { type: Array, default: () => [] },
     total: { type: Number, default: 0 },
 });
@@ -17,23 +17,17 @@ const prettify = (category) => category.toLowerCase();
         <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Topics</h1>
         <p class="mt-2 text-sm text-gray-500 tabular-nums">{{ total }} topics across {{ topic_groups.length }} areas</p>
 
-        <section v-if="audiences.length" class="mt-8" aria-label="Audiences">
-            <h2 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">For every age</h2>
-            <div class="mt-3 flex flex-wrap gap-2.5">
-                <Link
-                    v-for="audience in audiences"
-                    :key="audience.url"
-                    :href="audience.url"
-                    prefetch
-                    class="border-primary/40 text-primary hover:border-primary focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-full border px-4 text-[13px] font-medium transition-colors duration-150 outline-none focus-visible:ring-2"
-                >
-                    <span>{{ audience.name }}</span>
-                    <span v-if="audience.videosCount" class="rounded-full bg-white/10 px-1.5 py-0.5 text-[11px] tabular-nums">
-                        {{ audience.videosCount }}
-                    </span>
-                </Link>
-            </div>
-        </section>
+        <!-- Audiences have their own area now; a calm pointer, not the old fold-in -->
+        <Link
+            href="/audience/"
+            class="focus-visible:ring-ring mt-6 flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-5 py-4 transition-colors duration-150 outline-none hover:border-white/20 focus-visible:ring-2"
+        >
+            <span>
+                <span class="font-display block text-base font-bold text-gray-100">Looking for Kids, Youth or Adults?</span>
+                <span class="mt-0.5 block text-sm text-gray-400">Browse teaching for every age</span>
+            </span>
+            <IconArrowRight class="text-primary h-5 w-5 shrink-0" aria-hidden="true" />
+        </Link>
 
         <section v-for="group in topic_groups" :key="group.category" class="mt-10" :aria-label="group.category">
             <h2 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">{{ prettify(group.category) }}</h2>

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -5,8 +5,17 @@ import SectionHeading from '@/molecules/SectionHeading.vue';
 import SeriesCard from '@/molecules/SeriesCard.vue';
 import { Skeleton } from '@/ui/skeleton';
 import { Link, WhenVisible } from '@inertiajs/vue3';
-import { IconArrowRight } from '@tabler/icons-vue';
+import { IconAdjustmentsHorizontal, IconArrowRight, IconBook, IconLayoutGrid, IconMicrophone, IconMoodKid, IconTag } from '@tabler/icons-vue';
 import { useEntrance } from '~/composables/useEntrance';
+
+const findBy = [
+    { label: 'Filter all', href: '/browse', icon: IconAdjustmentsHorizontal },
+    { label: 'Series', href: '/series', icon: IconLayoutGrid },
+    { label: 'Topics', href: '/topic', icon: IconTag },
+    { label: 'Speakers', href: '/speaker', icon: IconMicrophone },
+    { label: 'Bible books', href: '/book', icon: IconBook },
+    { label: 'For every age', href: '/audience', icon: IconMoodKid },
+];
 
 const props = defineProps({
     livestreams: { type: Array, default: () => [] },
@@ -70,6 +79,24 @@ const { entrance } = useEntrance();
                     </Link>
                 </li>
             </ul>
+        </section>
+
+        <!-- Discoverable on-ramp to the directories (so the "Browse" dropdown
+             is never the only way in for the primary persona). -->
+        <section v-bind="entrance(180)" class="mt-14" aria-label="Find teaching by">
+            <SectionHeading title="Find teaching by…" />
+            <div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+                <Link
+                    v-for="tile in findBy"
+                    :key="tile.href"
+                    :href="tile.href"
+                    prefetch
+                    class="group focus-visible:ring-ring flex flex-col items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-6 text-center transition-colors duration-150 outline-none hover:border-white/25 hover:bg-white/[0.06] focus-visible:ring-2"
+                >
+                    <component :is="tile.icon" class="text-primary h-7 w-7" aria-hidden="true" />
+                    <span class="text-sm font-medium text-gray-200">{{ tile.label }}</span>
+                </Link>
+            </div>
         </section>
 
         <!-- Below the fold: props are optional() server-side; WhenVisible

--- a/tests/test_audiences.py
+++ b/tests/test_audiences.py
@@ -1,0 +1,47 @@
+"""Dedicated audiences area (/audience), decoupled from Topics — the user
+disliked reaching Kids/Youth/Adults via the Topics page."""
+
+import pytest
+
+from tests.factories import DemographicFactory, VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+
+def test_audiences_index_lists_populated_demographics(client):
+    kids = DemographicFactory(name="Kids", summary="Teaching for children")
+    VideoFactory().demographic.add(kids)
+    DemographicFactory(name="Empty")  # no videos → excluded
+
+    page = inertia_page(client.get("/audience/"))
+
+    assert page["component"] == "AudiencesIndex"
+    tiles = {a["name"]: a for a in page["props"]["audiences"]}
+    assert "Kids" in tiles
+    assert "Empty" not in tiles
+    assert tiles["Kids"]["videosCount"] == 1
+    assert tiles["Kids"]["summary"] == "Teaching for children"
+    assert tiles["Kids"]["url"] == "/audience/Kids"
+
+
+def test_demographic_url_points_at_audience():
+    assert DemographicFactory(name="Kids").get_absolute_url() == "/audience/Kids"
+
+
+def test_audience_detail_shows_its_videos(client):
+    kids = DemographicFactory(name="Kids")
+    wanted = VideoFactory(name="Kids talk")
+    wanted.demographic.add(kids)
+
+    page = inertia_page(client.get("/audience/Kids"))
+
+    assert "Kids talk" in [v["name"] for v in page["props"]["videos"]]
+
+
+def test_topics_index_no_longer_lists_audiences(client):
+    DemographicFactory(name="Kids")
+
+    page = inertia_page(client.get("/topic/"))
+
+    assert "audiences" not in page["props"]

--- a/tests/test_directory_pages.py
+++ b/tests/test_directory_pages.py
@@ -102,22 +102,21 @@ class TestMinistriesIndex:
         assert [m["name"] for m in page["props"]["ministries"]] == ["Jesmond Parish Church"]
 
 
-def test_demographic_landing_redirects_to_topics(client):
+def test_demographic_landing_redirects_to_audiences(client):
+    # Audiences now have their own /audience/ area (Phase 5), not folded into Topics.
     response = client.get("/demographic/")
     assert response.status_code == 302
-    assert response.headers["Location"] == "/topic/"
+    assert response.headers["Location"] == "/audience/"
 
 
-def test_topics_page_includes_audiences(client):
+def test_topics_page_no_longer_folds_in_audiences(client):
+    # Superseded by the dedicated /audience/ area — see tests/test_audiences.py.
     kids = DemographicFactory(name="Kids")
-    video = VideoFactory()
-    video.demographic.add(kids)
+    VideoFactory().demographic.add(kids)
 
     props = inertia_page(client.get("/topic/"))["props"]
 
-    (audience,) = props["audiences"]
-    assert audience["name"] == "Kids"
-    assert audience["videosCount"] == 1
+    assert "audiences" not in props
 
 
 def test_catalogue_stub_is_gone(client):


### PR DESCRIPTION
**Audiences decoupled from Topics** + **calm nav**.

- **/audience/** index (image-led Kids/Youth/Adults tiles, uses the unused `Demographic.thumbnail` w/ fallback); detail reuses `browse_demographic`; `get_absolute_url` → `/audience/`; `/demographic/` redirects there; TopicsIndex shows a pointer instead of folding audiences in.
- **Nav → Home · Browse · Latest · Live.** "Browse" is a click-triggered dropdown exposing all six directories (finally surfacing **Books** and **Audiences**, which had no nav entry). Mobile Sheet flattens them. Home gains a "Find teaching by…" tile row as the discoverable on-ramp. Palette gains directory entries.

TDD: 4 new audience tests; 2 superseded directory tests updated. 164 green. Browser-verified (4-item nav, Browse menu, /audience tiles, navigation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)