### PR TITLE
Phase 6: clean category duplicates + topic-name mojibake

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from urllib.parse import unquote  # Import for URL decoding
 
 from django.core.paginator import Paginator
@@ -8,6 +9,7 @@ from inertia import defer, optional, render
 from app.browse import browse_props
 from app.cards import video_card_props
 from app.feed import latest_feed
+from catalogue.ingest.normalize import clean_name, clean_topic_name
 from catalogue.models.bible_book import Bible_Book
 from catalogue.models.channel import Channel
 from catalogue.models.demograpic import Demographic
@@ -170,8 +172,11 @@ def palette(request):
         # Series videos live on the Series.videos M2M, not the FK reverse
         count_relation = "videos" if model is Series else "video"
         matches = model.objects.filter(name__icontains=query).annotate(n=Count(count_relation)).order_by("-n")
+        # Topic names carry depth-prefix mojibake; others just stray whitespace.
+        clean_label = clean_topic_name if model is Topic else clean_name
         categories += [
-            {"kind": kind, "name": m.name, "url": m.get_absolute_url(), "count": m.n} for m in matches[:PALETTE_LIMIT]
+            {"kind": kind, "name": clean_label(m.name), "url": m.get_absolute_url(), "count": m.n}
+            for m in matches[:PALETTE_LIMIT]
         ]
     # Book names are choice codes; the display name lives in summary
     categories += [
@@ -214,10 +219,12 @@ def search(request):
             # Series videos live on the Series.videos M2M, not the FK reverse
             count_relation = "videos" if model is Series else "video"
             matches = matches.annotate(n=Count(count_relation))
+            # Topic names carry depth-prefix mojibake; others just stray whitespace.
+            clean_label = clean_topic_name if model is Topic else clean_name
             category_results += [
                 {
                     "category": model_name,
-                    "name": x.name,
+                    "name": clean_label(x.name),
                     "videosCount": x.n,
                     "url": x.get_absolute_url(),
                 }
@@ -538,17 +545,31 @@ def series_index(request):
 
 
 def topics_index(request):
-    """All topics grouped under the legacy taxonomy's parent categories,
-    headed by the three audiences (the old /demographic landing folded in)."""
-    groups = {}
+    """All topics grouped under the legacy taxonomy's parent categories.
+
+    The legacy data leaks two blemishes here (Phase 6): category strings have
+    case-typo and whitespace near-duplicates ('Christian Life' vs the typo
+    'Christian LIfe'), and topic names carry depth-prefix mojibake. Merge
+    categories on a case-folded key (showing the most common spelling) and
+    strip the prefixes from names."""
+    groups = {}  # folded key -> {"labels": Counter, "topics": [...]}
     for topic in Topic.objects.annotate(videos_count=Count("video")).order_by("name"):
-        groups.setdefault(topic.category or "Other", []).append(
+        category = clean_name(topic.category) or "Other"
+        group = groups.setdefault(category.casefold(), {"labels": Counter(), "topics": []})
+        group["labels"][category] += 1
+        group["topics"].append(
             {
-                "name": topic.name,
+                "name": clean_topic_name(topic.name),
                 "videosCount": topic.videos_count,
                 "url": topic.get_absolute_url(),
             }
         )
+
+    topic_groups = []
+    for group in groups.values():
+        group["topics"].sort(key=lambda topic: topic["name"].casefold())
+        topic_groups.append({"category": group["labels"].most_common(1)[0][0], "topics": group["topics"]})
+    topic_groups.sort(key=lambda group: group["category"].casefold())
 
     return render(
         request,
@@ -556,7 +577,7 @@ def topics_index(request):
         {
             # Audiences moved to their own /audience/ area (TopicsIndex shows a
             # pointer link instead of folding them in here).
-            "topic_groups": [{"category": category, "topics": topics} for category, topics in sorted(groups.items())],
+            "topic_groups": topic_groups,
             "total": Topic.objects.count(),
         },
     )

--- a/catalogue/ingest/normalize.py
+++ b/catalogue/ingest/normalize.py
@@ -9,8 +9,11 @@ import re
 from datetime import date
 
 # Topic names arrive with tree-depth prefixes of MINUS SIGN (U+2212) or
-# hyphens; categories arrive SHOUTING with stray whitespace.
-_DEPTH_PREFIX = re.compile(r"^[\s−\-]+")  # noqa: RUF001 — U+2212 is what the data contains
+# hyphens; categories arrive SHOUTING with stray whitespace. Some prefixes are
+# the MINUS SIGN double-encoded (UTF-8 bytes E2 88 92 read as Latin-1 →
+# U+00E2 U+0088 U+0092) — strip that exact triplet too, but not a lone "â"
+# (a name may legitimately begin with it).
+_DEPTH_PREFIX = re.compile("^(?:[\\s\u2212\\-]|\u00e2\u0088\u0092)+")  # U+2212 MINUS, or its double-encoding (E2 88 92)
 _WHITESPACE = re.compile(r"\s+")
 # programmeRef trailing date: "...CINews25.10.24" → 25 Oct 2024 (DD.MM.YY)
 _REF_DATE = re.compile(r"(\d{2})\.(\d{2})\.(\d{2})")

--- a/tests/test_directory_pages.py
+++ b/tests/test_directory_pages.py
@@ -6,6 +6,7 @@ from tests.factories import (
     MinistryFactory,
     SeriesFactory,
     SpeakerFactory,
+    TopicFactory,
     VideoFactory,
 )
 from tests.utils import inertia_page
@@ -121,3 +122,39 @@ def test_topics_page_no_longer_folds_in_audiences(client):
 
 def test_catalogue_stub_is_gone(client):
     assert client.get("/catalogue/").status_code == 404
+
+
+class TestTopicsIndexDataBlemishes:
+    """Phase 6: the legacy taxonomy leaks case-typo category duplicates and
+    depth-prefix mojibake into topic names — clean both at the view layer."""
+
+    def test_case_typo_category_variants_merge_into_one_group(self, client):
+        # Real blemish: 'Christian Life' (16 topics) vs the typo 'Christian LIfe' (1).
+        TopicFactory(name="Prayer", category="Christian Life")
+        TopicFactory(name="Suffering", category="Christian LIfe")
+
+        props = inertia_page(client.get("/topic/"))["props"]
+        groups = {g["category"]: g for g in props["topic_groups"]}
+
+        assert "Christian LIfe" not in groups
+        assert "Christian Life" in groups  # the majority spelling wins
+        names = {t["name"] for t in groups["Christian Life"]["topics"]}
+        assert names == {"Prayer", "Suffering"}
+
+    def test_whitespace_category_variants_merge(self, client):
+        TopicFactory(name="Grace", category="Doctrine")
+        TopicFactory(name="Glory", category="Doctrine ")  # trailing space
+
+        props = inertia_page(client.get("/topic/"))["props"]
+        categories = [g["category"] for g in props["topic_groups"]]
+
+        assert categories.count("Doctrine") == 1
+
+    def test_depth_prefix_mojibake_stripped_from_topic_names(self, client):
+        # MINUS SIGN (U+2212) double-encoded as bytes E2 88 92 → U+00E2 U+0088 U+0092.
+        TopicFactory(name="â" * 3 + " The Grace of God", category="Doctrine")
+
+        props = inertia_page(client.get("/topic/"))["props"]
+        names = [t["name"] for g in props["topic_groups"] for t in g["topics"]]
+
+        assert "The Grace of God" in names

--- a/tests/test_ingest_normalize.py
+++ b/tests/test_ingest_normalize.py
@@ -35,6 +35,15 @@ def test_clean_name_collapses_the_whitespace_that_made_duplicates():
 def test_clean_topic_name_strips_dropdown_depth_prefixes():
     assert clean_topic_name("−−− The Sovereignty of God") == "The Sovereignty of God"  # noqa: RUF001
     assert clean_topic_name("--- Prayer") == "Prayer"
+
+
+def test_clean_topic_name_strips_mojibake_depth_prefix():
+    # The depth-marker MINUS SIGN (U+2212) double-encoded: UTF-8 bytes E2 88 92 read
+    # as Latin-1 → U+00E2 U+0088 U+0092. Real data: "The Grace of God".
+    mojibake = "âââ The Grace of God"
+    assert clean_topic_name(mojibake) == "The Grace of God"
+    # A name legitimately starting with â must NOT be stripped.
+    assert clean_topic_name("âccent on grace") == "âccent on grace"
     assert clean_topic_name("Apologetics") == "Apologetics"
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -31,3 +31,14 @@ def test_search_first_page_includes_matching_categories(client):
     assert ("Topics", "Grace") in categories
     assert ("Speakers", "Grace Jones") in categories
     assert ("Series", "Amazing Grace") in categories
+
+
+def test_search_category_labels_are_cleaned(client):
+    # Phase 6: depth-prefix mojibake leaked into search category chips.
+    video = VideoFactory()
+    video.topic.add(TopicFactory(name="â\x88\x92â\x88\x92â\x88\x92 Grace abounds"))
+
+    page = inertia_page(client.get("/search", {"search": "grace"}))
+
+    topic_names = [c["name"] for c in page["props"]["categories"] if c["category"] == "Topics"]
+    assert "Grace abounds" in topic_names


### PR DESCRIPTION
## Phase 6 — Data-quality blemishes (Functionality Overhaul)

The live UX audit flagged two legacy-data blemishes leaking into the UI. Both are fixed at the read/view layer (no destructive data migration).

### Fixed
- **Duplicate topic category group.** The taxonomy stores case-typo (`Christian Life` vs `Christian LIfe`) and trailing-whitespace variants of the same parent category, so `/topic/` rendered two groups. Now grouped on a case-folded, whitespace-collapsed key, displaying the most common spelling. Verified on the full catalogue: 9 groups, one `Christian Life`.
- **Topic-name mojibake.** Depth-prefix markers — some the MINUS SIGN (U+2212) **double-encoded** as bytes `E2 88 92` → `âââ` — leaked into topic labels on the topics page, search category chips, and the ⌘K palette. `normalize.clean_topic_name` now strips that exact triplet (preserving a legitimate lone `â`), applied at every topic-label read site. Verified: zero `U+00E2` in topic labels or search categories for `?search=grace`.

### Out of scope (intentional)
Duplicate series name-variants in search are **genuinely distinct rows**, not a normalization artefact — left untouched.

### Tests
- `clean_topic_name` strips the double-encoded triplet but not a lone `â` (normalize ledger).
- `/topic/` merges case-typo + whitespace category variants; strips mojibake from names.
- Search category labels are cleaned.
- Full suite: **169 passed**; `npm run build-only` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)