### PR TITLE
Phase 7: app-feel & PWA (installable, native-feel, pinch-zoom safe)

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,30 @@
+{
+  "name": "Clayton TV",
+  "short_name": "Clayton TV",
+  "description": "Bible teaching, sermons and live services from Clayton TV.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#1a1a1a",
+  "theme_color": "#1a1a1a",
+  "icons": [
+    {
+      "src": "/static/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/static/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/static/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -183,3 +183,60 @@
         @apply h-full;
     }
 }
+
+/*
+  ---break---
+*/
+
+/* Phase 7 — native app-feel defaults. Remove jarring mobile-web behaviours
+   (zoom-on-input, long-press selection/callout, tap flash, scroll bounce)
+   WITHOUT ever disabling pinch-zoom — elderly users rely on it. */
+@layer base {
+    /* iOS zooms the page when focusing a control under 16px. Keep form controls
+       at ≥16px app-wide so we never need the a11y-hostile maximum-scale hack.
+       max(16px, 1rem) still lets the text-size control scale them up. */
+    input,
+    select,
+    textarea {
+        font-size: max(16px, 1rem);
+    }
+
+    /* Long-press on a control shouldn't select its label or pop the iOS callout;
+       prose (headings, paragraphs) stays selectable. */
+    button,
+    [role='button'],
+    label,
+    summary {
+        -webkit-touch-callout: none;
+        -webkit-user-select: none;
+        user-select: none;
+    }
+
+    /* Calm the blue tap flash on touch; focus-visible rings are unaffected. */
+    * {
+        -webkit-tap-highlight-color: transparent;
+    }
+
+    /* Stop whole-page rubber-band / pull-to-refresh; inner scrollers keep theirs. */
+    html,
+    body {
+        overscroll-behavior-y: none;
+    }
+}
+
+@layer utilities {
+    /* Safe-area insets for notched devices in standalone (needs viewport-fit=cover).
+       Zero in a normal browser, so harmless off-app. */
+    .pt-safe {
+        padding-top: env(safe-area-inset-top);
+    }
+
+    .pb-safe {
+        padding-bottom: env(safe-area-inset-bottom);
+    }
+
+    .px-safe {
+        padding-left: env(safe-area-inset-left);
+        padding-right: env(safe-area-inset-right);
+    }
+}

--- a/resources/js/components/layouts/AppHeader.vue
+++ b/resources/js/components/layouts/AppHeader.vue
@@ -68,7 +68,7 @@ const navLink = (active: boolean) =>
 </script>
 
 <template>
-    <header class="sticky top-0 z-40 border-b border-white/5 bg-gray-950/90 backdrop-blur-md">
+    <header class="pt-safe px-safe sticky top-0 z-40 border-b border-white/5 bg-gray-950/90 backdrop-blur-md">
         <div class="mx-auto flex h-16 max-w-6xl items-center gap-6 px-4 lg:px-8">
             <Link
                 href="/"

--- a/resources/js/components/organisms/PersistentPlayer.vue
+++ b/resources/js/components/organisms/PersistentPlayer.vue
@@ -140,7 +140,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
         :class="
             dock.mode.value === 'docked'
                 ? 'z-10 overflow-hidden rounded-xl border border-white/10'
-                : 'mini-in fixed right-4 bottom-4 z-50 w-[min(340px,calc(100vw-2rem))] overflow-hidden rounded-xl border border-white/15 bg-gray-900 shadow-2xl'
+                : 'mini-in fixed right-[calc(1rem+env(safe-area-inset-right))] bottom-[calc(1rem+env(safe-area-inset-bottom))] z-50 w-[min(340px,calc(100vw-2rem))] overflow-hidden rounded-xl border border-white/15 bg-gray-900 shadow-2xl'
         "
     >
         <div :class="dock.mode.value === 'docked' ? 'h-full w-full' : 'aspect-video w-full'">

--- a/templates/app.html
+++ b/templates/app.html
@@ -4,7 +4,10 @@
 <html class="h-full" lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta content="width=device-width, initial-scale=1, user-scalable=no" name="viewport">
+    {# viewport-fit=cover enables env(safe-area-inset-*) for notched devices. #}
+    {# Pinch-zoom is deliberately left enabled (no user-scalable=no / maximum-scale): #}
+    {# elderly users rely on it. Input-zoom is prevented via 16px controls in app.css. #}
+    <meta content="width=device-width, initial-scale=1, viewport-fit=cover" name="viewport">
 
     <script>
         // This script is used to detect the user's preferred color scheme and set the class on the html element.
@@ -35,7 +38,15 @@
     </style>
 
     <link rel="icon" href="{% static 'favicon.ico' %}" sizes="any" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png">
+    <link rel="apple-touch-icon" href="{% static 'apple-touch-icon.png' %}">
+
+    {# Installability: add-to-homescreen → full-screen, chromeless app. #}
+    <link rel="manifest" href="{% static 'manifest.webmanifest' %}">
+    <meta name="theme-color" content="#1a1a1a">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-title" content="Clayton TV">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/tests/test_pwa.py
+++ b/tests/test_pwa.py
@@ -1,0 +1,50 @@
+"""Phase 7 — app-feel & PWA guardrails.
+
+The hard accessibility rule: pinch-zoom must stay enabled (elderly users rely
+on it), so input-zoom is prevented via 16px font sizing in the design system,
+never via user-scalable=no / maximum-scale.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+MANIFEST = Path(__file__).resolve().parent.parent / "public" / "manifest.webmanifest"
+
+
+def head_html(client):
+    """The full first-load document (app.html), not an Inertia partial."""
+    return client.get("/").content.decode()
+
+
+def test_viewport_keeps_pinch_zoom_enabled(client):
+    html = head_html(client)
+    assert "width=device-width" in html
+    # Elderly users rely on pinch-zoom — these must never appear.
+    assert "user-scalable=no" not in html
+    assert "maximum-scale" not in html
+
+
+def test_viewport_opts_into_safe_area_insets(client):
+    # viewport-fit=cover is what makes env(safe-area-inset-*) non-zero.
+    assert "viewport-fit=cover" in head_html(client)
+
+
+def test_pwa_head_links_manifest_and_chrome(client):
+    html = head_html(client)
+    assert 'rel="manifest"' in html
+    assert 'name="theme-color"' in html
+    assert 'name="apple-mobile-web-app-capable"' in html
+
+
+def test_manifest_is_valid_and_installable():
+    data = json.loads(MANIFEST.read_text())
+    assert data["name"]
+    assert data["short_name"]
+    assert data["start_url"] == "/"
+    assert data["display"] == "standalone"
+    assert data["icons"], "needs at least one icon"
+    assert any("maskable" in icon.get("purpose", "") for icon in data["icons"])


### PR DESCRIPTION
## Phase 7 — App-feel & PWA (final overhaul polish)

Makes Clayton TV feel like a native app and installable to the homescreen, **without** sacrificing accessibility.

### Installability
- New `public/manifest.webmanifest` — `standalone`, theme/background colour, icons (incl. a maskable 512) — linked from the base template (reuses the existing icon set).
- `apple-mobile-web-app-*` + `mobile-web-app-capable` meta + `theme-color` for a chromeless, branded add-to-homescreen. `apple-touch-icon` now resolved via `{% static %}` (the old `/apple-touch-icon.png` path 404'd).

### Native-feel interaction defaults (`app.css` base layer)
- Form controls `≥16px` (`max(16px, 1rem)`) so **iOS never zooms on focus** — and the text-size control can still scale them up.
- `user-select` / `-webkit-touch-callout: none` on buttons/controls so long-press doesn't select labels or pop the iOS callout (**prose stays selectable**).
- `-webkit-tap-highlight-color: transparent`; `overscroll-behavior-y: none` to stop whole-page pull-to-refresh / bounce.

### Accessibility guardrail (hard rule)
- **Removed `user-scalable=no`** from the viewport — elderly users rely on pinch-zoom. Input-zoom is solved purely via 16px controls, never `maximum-scale`.

### Standalone polish
- `viewport-fit=cover` + `pt-safe`/`px-safe`/`pb-safe` utilities; the sticky header and the fixed mini-player now respect `env(safe-area-inset-*)` on notched devices.

### Deferred (flagged, not built)
- A minimal service worker for an offline app shell — PoC scope, future work.

### Tests / verification
- `tests/test_pwa.py`: viewport keeps pinch-zoom (no `user-scalable=no`/`maximum-scale`), opts into safe-area insets, links manifest + chrome meta; manifest is valid & installable (standalone, maskable icon).
- Verified live: input `font-size: 16px`, `body` `overscroll-behavior-y: none`, button `user-select: none`, manifest + icons serve 200, homepage shows no layout regression.
- Full suite **173 passed**; `npm run build-only` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)