### PR TITLE
Light mode + theme toggle (default = system) — cool-grey palette

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -80,72 +80,76 @@
     }
 }
 
+/* Cohesive cool-grey theme on a single hue (264 — a modern blue-grey) with
+   deliberate chroma so surfaces read cool, not flat-neutral, and pair with the
+   warm red brand. Authored in OKLCH: on P3 / wide-gamut displays the browser
+   renders the fuller gamut automatically; on sRGB it clamps gracefully. */
 :root {
     --radius: 0.5rem;
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.141 0.005 285.823);
+    --background: oklch(0.985 0.004 264);
+    --foreground: oklch(0.21 0.024 264);
     --card: oklch(1 0 0);
-    --card-foreground: oklch(0.141 0.005 285.823);
+    --card-foreground: oklch(0.21 0.024 264);
     --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.141 0.005 285.823);
+    --popover-foreground: oklch(0.21 0.024 264);
     --primary: oklch(0.637 0.237 25.331);
     --primary-foreground: oklch(0.971 0.013 17.38);
-    --secondary: oklch(0.967 0.001 286.375);
-    --secondary-foreground: oklch(0.21 0.006 285.885);
-    --muted: oklch(0.967 0.001 286.375);
-    --muted-foreground: oklch(0.552 0.016 285.938);
-    --accent: oklch(0.967 0.001 286.375);
-    --accent-foreground: oklch(0.21 0.006 285.885);
+    --secondary: oklch(0.968 0.006 264);
+    --secondary-foreground: oklch(0.24 0.022 264);
+    --muted: oklch(0.968 0.006 264);
+    --muted-foreground: oklch(0.552 0.032 264);
+    --accent: oklch(0.958 0.009 264);
+    --accent-foreground: oklch(0.24 0.022 264);
     --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.92 0.004 286.32);
-    --input: oklch(0.92 0.004 286.32);
+    --border: oklch(0.916 0.011 264);
+    --input: oklch(0.9 0.013 264);
     --ring: oklch(0.637 0.237 25.331);
     --chart-1: oklch(0.646 0.222 41.116);
     --chart-2: oklch(0.6 0.118 184.704);
     --chart-3: oklch(0.398 0.07 227.392);
     --chart-4: oklch(0.828 0.189 84.429);
     --chart-5: oklch(0.769 0.188 70.08);
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.141 0.005 285.823);
+    --sidebar: oklch(0.985 0.004 264);
+    --sidebar-foreground: oklch(0.21 0.024 264);
     --sidebar-primary: oklch(0.637 0.237 25.331);
     --sidebar-primary-foreground: oklch(0.971 0.013 17.38);
-    --sidebar-accent: oklch(0.967 0.001 286.375);
-    --sidebar-accent-foreground: oklch(0);
-    --sidebar-border: oklch(0.92 0.004 286.32);
+    --sidebar-accent: oklch(0.958 0.009 264);
+    --sidebar-accent-foreground: oklch(0.24 0.022 264);
+    --sidebar-border: oklch(0.916 0.011 264);
     --sidebar-ring: oklch(0.637 0.237 25.331);
 }
 
 .dark {
-    --background: oklch(0.141 0.005 285.823);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.21 0.006 285.885);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.21 0.006 285.885);
-    --popover-foreground: oklch(0.985 0 0);
+    --background: oklch(0.17 0.018 264);
+    --foreground: oklch(0.97 0.006 264);
+    --card: oklch(0.215 0.021 264);
+    --card-foreground: oklch(0.97 0.006 264);
+    --popover: oklch(0.215 0.021 264);
+    --popover-foreground: oklch(0.97 0.006 264);
     --primary: oklch(0.637 0.237 25.331);
     --primary-foreground: oklch(0.971 0.013 17.38);
-    --secondary: oklch(0.274 0.006 286.033);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.274 0.006 286.033);
-    --muted-foreground: oklch(0.705 0.015 286.067);
-    --accent: oklch(0.274 0.006 286.033);
-    --accent-foreground: oklch(0.985 0 0);
+    --secondary: oklch(0.265 0.024 264);
+    --secondary-foreground: oklch(0.97 0.006 264);
+    --muted: oklch(0.265 0.024 264);
+    --muted-foreground: oklch(0.72 0.028 264);
+    --accent: oklch(0.295 0.027 264);
+    --accent-foreground: oklch(0.97 0.006 264);
     --destructive: oklch(0.704 0.191 22.216);
-    --border: oklch(1 0 0 / 10%);
-    --input: oklch(1 0 0 / 15%);
+    --border: oklch(0.32 0.02 264);
+    --input: oklch(0.36 0.022 264);
     --ring: oklch(0.637 0.237 25.331);
     --chart-1: oklch(0.488 0.243 264.376);
     --chart-2: oklch(0.696 0.17 162.48);
     --chart-3: oklch(0.769 0.188 70.08);
     --chart-4: oklch(0.627 0.265 303.9);
     --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.21 0.006 285.885);
-    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar: oklch(0.215 0.021 264);
+    --sidebar-foreground: oklch(0.97 0.006 264);
     --sidebar-primary: oklch(0.637 0.237 25.331);
     --sidebar-primary-foreground: oklch(0.971 0.013 17.38);
-    --sidebar-accent: oklch(0.274 0.006 286.033);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-accent: oklch(0.295 0.027 264);
+    --sidebar-accent-foreground: oklch(0.97 0.006 264);
+    --sidebar-border: oklch(0.32 0.02 264);
     --sidebar-ring: oklch(0.637 0.237 25.331);
 }
 
@@ -238,5 +242,25 @@
     .px-safe {
         padding-left: env(safe-area-inset-left);
         padding-right: env(safe-area-inset-right);
+    }
+
+    /* A slim, always-present scrollbar so overflow containers read as
+       scrollable (macOS overlay scrollbars otherwise hide until you scroll). */
+    .ctv-scroll {
+        scrollbar-width: thin;
+        scrollbar-color: var(--border) transparent;
+    }
+
+    .ctv-scroll::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    .ctv-scroll::-webkit-scrollbar-thumb {
+        background-color: var(--border);
+        border-radius: 9999px;
+    }
+
+    .ctv-scroll::-webkit-scrollbar-thumb:hover {
+        background-color: var(--muted-foreground);
     }
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -98,7 +98,9 @@
     --secondary-foreground: oklch(0.24 0.022 264);
     --muted: oklch(0.968 0.006 264);
     --muted-foreground: oklch(0.552 0.032 264);
-    --accent: oklch(0.958 0.009 264);
+    /* accent is the hover/active surface — kept distinctly darker than muted so
+       bg-muted → hover:bg-accent reads clearly in light mode. */
+    --accent: oklch(0.93 0.014 264);
     --accent-foreground: oklch(0.24 0.022 264);
     --destructive: oklch(0.577 0.245 27.325);
     --border: oklch(0.916 0.011 264);
@@ -113,7 +115,7 @@
     --sidebar-foreground: oklch(0.21 0.024 264);
     --sidebar-primary: oklch(0.637 0.237 25.331);
     --sidebar-primary-foreground: oklch(0.971 0.013 17.38);
-    --sidebar-accent: oklch(0.958 0.009 264);
+    --sidebar-accent: oklch(0.93 0.014 264);
     --sidebar-accent-foreground: oklch(0.24 0.022 264);
     --sidebar-border: oklch(0.916 0.011 264);
     --sidebar-ring: oklch(0.637 0.237 25.331);

--- a/resources/js/components/atoms/CardSkeleton.vue
+++ b/resources/js/components/atoms/CardSkeleton.vue
@@ -14,12 +14,12 @@ const props = defineProps({
 
 <template>
     <div role="status" class="animate-pulse rounded-md p-4 shadow-sm md:p-6" :class="customClasses">
-        <div class="mb-4 h-2.5 w-[80%] rounded-full" :class="darkText ? 'bg-gray-950' : 'bg-gray-400'"></div>
+        <div class="mb-4 h-2.5 w-[80%] rounded-full" :class="darkText ? 'bg-muted' : 'bg-muted'"></div>
         <div
             v-for="rowIndex in rowCount"
             :key="`card-row-${rowIndex}`"
             class="mb-2.5 h-2 w-full rounded-full"
-            :class="darkText ? 'bg-gray-950' : 'bg-gray-400'"
+            :class="darkText ? 'bg-muted' : 'bg-muted'"
         ></div>
         <span class="sr-only">Loading...</span>
     </div>

--- a/resources/js/components/atoms/CardSkeleton.vue
+++ b/resources/js/components/atoms/CardSkeleton.vue
@@ -1,26 +1,18 @@
 <script setup>
-const props = defineProps({
+defineProps({
     rowCount: {
         type: Number,
     },
     customClasses: {
         type: String,
     },
-    darkText: {
-        type: Boolean,
-    },
 });
 </script>
 
 <template>
     <div role="status" class="animate-pulse rounded-md p-4 shadow-sm md:p-6" :class="customClasses">
-        <div class="mb-4 h-2.5 w-[80%] rounded-full" :class="darkText ? 'bg-muted' : 'bg-muted'"></div>
-        <div
-            v-for="rowIndex in rowCount"
-            :key="`card-row-${rowIndex}`"
-            class="mb-2.5 h-2 w-full rounded-full"
-            :class="darkText ? 'bg-muted' : 'bg-muted'"
-        ></div>
+        <div class="bg-muted mb-4 h-2.5 w-[80%] rounded-full"></div>
+        <div v-for="rowIndex in rowCount" :key="`card-row-${rowIndex}`" class="bg-muted mb-2.5 h-2 w-full rounded-full"></div>
         <span class="sr-only">Loading...</span>
     </div>
 </template>

--- a/resources/js/components/atoms/LoadingSpinner.vue
+++ b/resources/js/components/atoms/LoadingSpinner.vue
@@ -2,7 +2,7 @@
     <div role="status">
         <svg
             aria-hidden="true"
-            class="fill-claytonRed py-auto text-muted mx-auto h-8 w-8 animate-spin"
+            class="fill-claytonRed py-auto text-border mx-auto h-8 w-8 animate-spin"
             viewBox="0 0 100 101"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"

--- a/resources/js/components/atoms/LoadingSpinner.vue
+++ b/resources/js/components/atoms/LoadingSpinner.vue
@@ -2,7 +2,7 @@
     <div role="status">
         <svg
             aria-hidden="true"
-            class="fill-claytonRed py-auto mx-auto h-8 w-8 animate-spin text-gray-200 dark:text-gray-600"
+            class="fill-claytonRed py-auto text-muted mx-auto h-8 w-8 animate-spin"
             viewBox="0 0 100 101"
             fill="none"
             xmlns="http://www.w3.org/2000/svg"

--- a/resources/js/components/atoms/VideoBrowseByLinks.vue
+++ b/resources/js/components/atoms/VideoBrowseByLinks.vue
@@ -20,7 +20,7 @@ defineProps({
             <div class="contents" v-if="video_metadata.channel">
                 <div class="py-2">Channel</div>
                 <div class="flex flex-wrap gap-y-2">
-                    <Link :href="video_metadata.channel.url" class="rounded-full bg-gray-700 px-4 py-2 font-bold text-white hover:bg-red-400">{{
+                    <Link :href="video_metadata.channel.url" class="bg-muted text-foreground rounded-full px-4 py-2 font-bold hover:bg-red-400">{{
                         video_metadata.channel.name
                     }}</Link>
                 </div>
@@ -29,7 +29,7 @@ defineProps({
             <div class="contents" v-if="video_metadata.series">
                 <div class="py-2">Series</div>
                 <div class="flex flex-wrap gap-y-2">
-                    <Link :href="video_metadata.series.url" class="rounded-full bg-gray-700 px-4 py-2 font-bold text-white hover:bg-red-400">{{
+                    <Link :href="video_metadata.series.url" class="bg-muted text-foreground rounded-full px-4 py-2 font-bold hover:bg-red-400">{{
                         video_metadata.series.name
                     }}</Link>
                 </div>
@@ -42,7 +42,7 @@ defineProps({
                         v-for="x in video_metadata.topic"
                         :href="x.url"
                         :key="x.name"
-                        class="mr-2 rounded-full bg-gray-700 px-4 py-2 font-bold text-white hover:bg-red-400"
+                        class="bg-muted text-foreground mr-2 rounded-full px-4 py-2 font-bold hover:bg-red-400"
                         >{{ x.name }}</Link
                     >
                 </div>
@@ -55,7 +55,7 @@ defineProps({
                         v-for="x in video_metadata.ministry"
                         :href="x.url"
                         :key="x.name"
-                        class="mr-2 rounded-full bg-gray-700 px-4 py-2 font-bold text-white hover:bg-red-400"
+                        class="bg-muted text-foreground mr-2 rounded-full px-4 py-2 font-bold hover:bg-red-400"
                         >{{ x.name }}</Link
                     >
                 </div>
@@ -68,7 +68,7 @@ defineProps({
                         v-for="x in video_metadata.speaker"
                         :href="x.url"
                         :key="x.name"
-                        class="mr-2 rounded-full bg-gray-700 px-4 py-2 font-bold text-white hover:bg-red-400"
+                        class="bg-muted text-foreground mr-2 rounded-full px-4 py-2 font-bold hover:bg-red-400"
                         >{{ x.name }}</Link
                     >
                 </div>
@@ -81,7 +81,7 @@ defineProps({
                         v-for="x in video_metadata.bible_book"
                         :href="x.url"
                         :key="x.name"
-                        class="mr-2 rounded-full bg-gray-700 px-4 py-2 font-bold whitespace-nowrap text-white hover:bg-red-400"
+                        class="bg-muted text-foreground mr-2 rounded-full px-4 py-2 font-bold whitespace-nowrap hover:bg-red-400"
                         >{{ x.name }}</Link
                     >
                 </div>
@@ -94,7 +94,7 @@ defineProps({
                         v-for="x in video_metadata.demographic"
                         :href="x.url"
                         :key="x.name"
-                        class="mr-2 rounded-full bg-gray-700 px-4 py-2 font-bold text-white hover:bg-red-400"
+                        class="bg-muted text-foreground mr-2 rounded-full px-4 py-2 font-bold hover:bg-red-400"
                         >{{ x.name }}</Link
                     >
                 </div>

--- a/resources/js/components/layouts/AppFooter.vue
+++ b/resources/js/components/layouts/AppFooter.vue
@@ -35,7 +35,7 @@ const columns = [
 </script>
 
 <template>
-    <footer class="border-border mt-16 border-t">
+    <footer class="border-border border-t">
         <div class="mx-auto grid max-w-6xl gap-10 px-4 py-12 sm:grid-cols-[1.2fr_1fr_1fr] lg:px-8">
             <div>
                 <div class="flex items-center gap-2.5">

--- a/resources/js/components/layouts/AppFooter.vue
+++ b/resources/js/components/layouts/AppFooter.vue
@@ -35,7 +35,7 @@ const columns = [
 </script>
 
 <template>
-    <footer class="border-border border-t">
+    <footer class="border-border mt-16 border-t">
         <div class="mx-auto grid max-w-6xl gap-10 px-4 py-12 sm:grid-cols-[1.2fr_1fr_1fr] lg:px-8">
             <div>
                 <div class="flex items-center gap-2.5">

--- a/resources/js/components/layouts/AppFooter.vue
+++ b/resources/js/components/layouts/AppFooter.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import LogoMark from '@/atoms/LogoMark.vue';
 import TextSizeControl from '@/molecules/TextSizeControl.vue';
+import ThemeToggle from '@/molecules/ThemeToggle.vue';
 import { Link } from '@inertiajs/vue3';
 import { IconBrandGithub, IconBrandVimeo, IconBrandYoutube } from '@tabler/icons-vue';
 
@@ -34,24 +35,24 @@ const columns = [
 </script>
 
 <template>
-    <footer class="mt-16 border-t border-white/5">
+    <footer class="border-border mt-16 border-t">
         <div class="mx-auto grid max-w-6xl gap-10 px-4 py-12 sm:grid-cols-[1.2fr_1fr_1fr] lg:px-8">
             <div>
                 <div class="flex items-center gap-2.5">
                     <LogoMark class="fill-primary h-6 w-auto" />
-                    <span class="font-display text-sm font-bold tracking-wide text-gray-50">Clayton&nbsp;TV</span>
+                    <span class="font-display text-foreground text-sm font-bold tracking-wide">Clayton&nbsp;TV</span>
                 </div>
-                <p class="mt-3 max-w-xs text-sm leading-relaxed text-gray-500">
+                <p class="text-muted-foreground mt-3 max-w-xs text-sm leading-relaxed">
                     Christian media you can trust — sermons, series and courses, free and always here.
                 </p>
             </div>
             <nav v-for="column in columns" :key="column.heading" :aria-label="column.heading">
-                <p class="text-xs font-semibold tracking-wider text-gray-500 uppercase">{{ column.heading }}</p>
+                <p class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">{{ column.heading }}</p>
                 <ul class="mt-3 space-y-2">
                     <li v-for="link in column.links" :key="link.name">
                         <Link
                             :href="link.href"
-                            class="focus-visible:ring-ring rounded text-sm text-gray-400 transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2"
+                            class="focus-visible:ring-ring text-muted-foreground hover:text-foreground rounded text-sm transition-colors duration-150 outline-none focus-visible:ring-2"
                         >
                             {{ link.name }}
                         </Link>
@@ -59,12 +60,16 @@ const columns = [
                 </ul>
             </nav>
         </div>
-        <div class="border-t border-white/5">
+        <div class="border-border border-t">
             <div class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-5 lg:px-8">
-                <p class="text-xs text-gray-600">© {{ year }} Clayton TV</p>
-                <div class="flex items-center gap-3">
+                <p class="text-muted-foreground text-xs">© {{ year }} Clayton TV</p>
+                <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
                     <div class="flex items-center gap-2">
-                        <span class="text-xs text-gray-600">Text size</span>
+                        <span class="text-muted-foreground text-xs">Theme</span>
+                        <ThemeToggle />
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <span class="text-muted-foreground text-xs">Text size</span>
                         <TextSizeControl />
                     </div>
                     <div class="flex gap-1">
@@ -75,7 +80,7 @@ const columns = [
                             :aria-label="social.name"
                             rel="noopener"
                             target="_blank"
-                            class="focus-visible:ring-ring inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-gray-500 transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2"
+                            class="focus-visible:ring-ring text-muted-foreground hover:text-foreground inline-flex min-h-11 min-w-11 items-center justify-center rounded-md transition-colors duration-150 outline-none focus-visible:ring-2"
                         >
                             <component :is="social.icon" class="h-5 w-5 stroke-[1.5]" aria-hidden="true" />
                         </a>

--- a/resources/js/components/layouts/AppHeader.vue
+++ b/resources/js/components/layouts/AppHeader.vue
@@ -2,6 +2,7 @@
 import LogoMark from '@/atoms/LogoMark.vue';
 import ShortcutsHelp from '@/molecules/ShortcutsHelp.vue';
 import TextSizeControl from '@/molecules/TextSizeControl.vue';
+import ThemeToggle from '@/molecules/ThemeToggle.vue';
 import CommandPalette from '@/organisms/CommandPalette.vue';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/ui/dropdown-menu';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/ui/sheet';
@@ -64,11 +65,11 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform);
 
 const navLink = (active: boolean) =>
-    `${active ? 'bg-white/10 text-white' : 'text-gray-400'} focus-visible:ring-ring inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2`;
+    `${active ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'} focus-visible:ring-ring inline-flex items-center gap-1.5 rounded-md px-3 py-2 text-sm font-medium transition-colors duration-150 outline-none hover:text-foreground focus-visible:ring-2`;
 </script>
 
 <template>
-    <header class="pt-safe px-safe sticky top-0 z-40 border-b border-white/5 bg-gray-950/90 backdrop-blur-md">
+    <header class="pt-safe px-safe border-border bg-background/90 sticky top-0 z-40 border-b backdrop-blur-md">
         <div class="mx-auto flex h-16 max-w-6xl items-center gap-6 px-4 lg:px-8">
             <Link
                 href="/"
@@ -76,7 +77,7 @@ const navLink = (active: boolean) =>
                 aria-label="Clayton TV home"
             >
                 <LogoMark class="fill-primary h-7 w-auto" />
-                <span class="font-display hidden text-[15px] font-bold tracking-wide text-gray-50 sm:block">Clayton&nbsp;TV</span>
+                <span class="font-display text-foreground hidden text-[15px] font-bold tracking-wide sm:block">Clayton&nbsp;TV</span>
             </Link>
 
             <nav class="hidden items-center gap-1 lg:flex" aria-label="Primary">
@@ -122,28 +123,28 @@ const navLink = (active: boolean) =>
             <!-- Looks like the old search field; opens the command palette -->
             <button
                 @click="openPalette"
-                class="focus-visible:ring-ring ml-auto hidden h-10 w-full max-w-xs cursor-pointer items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 text-gray-500 transition-colors duration-150 outline-none hover:bg-white/10 hover:text-gray-400 focus-visible:ring-2 sm:flex"
+                class="focus-visible:ring-ring border-border bg-muted text-muted-foreground hover:bg-accent hover:text-foreground ml-auto hidden h-10 w-full max-w-xs cursor-pointer items-center gap-2 rounded-lg border px-3 transition-colors duration-150 outline-none focus-visible:ring-2 sm:flex"
             >
                 <IconSearch class="h-4 w-4 shrink-0" aria-hidden="true" />
                 <span class="text-base">Search teaching…</span>
-                <kbd class="ml-auto rounded border border-white/15 bg-white/5 px-1.5 py-0.5 font-sans text-xs">{{ isMac ? '⌘K' : 'Ctrl K' }}</kbd>
+                <kbd class="border-border bg-muted ml-auto rounded border px-1.5 py-0.5 font-sans text-xs">{{ isMac ? '⌘K' : 'Ctrl K' }}</kbd>
             </button>
 
             <Sheet v-model:open="mobileNavOpen">
                 <SheetTrigger
-                    class="focus-visible:ring-ring ml-auto inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-gray-300 outline-none hover:text-white focus-visible:ring-2 sm:ml-0 lg:hidden"
+                    class="focus-visible:ring-ring text-muted-foreground hover:text-foreground ml-auto inline-flex min-h-11 min-w-11 items-center justify-center rounded-md outline-none focus-visible:ring-2 sm:ml-0 lg:hidden"
                     aria-label="Open menu"
                 >
                     <IconMenu2 class="h-6 w-6" aria-hidden="true" />
                 </SheetTrigger>
-                <SheetContent side="right" class="overflow-y-auto border-white/10 bg-gray-950 text-gray-100">
+                <SheetContent side="right" class="border-border bg-background text-foreground overflow-y-auto">
                     <SheetHeader>
-                        <SheetTitle class="font-display text-left text-gray-50">Clayton TV</SheetTitle>
+                        <SheetTitle class="font-display text-foreground text-left">Clayton TV</SheetTitle>
                     </SheetHeader>
                     <div class="px-4 pb-2">
                         <button
                             @click="openPalette"
-                            class="focus-visible:ring-ring flex h-11 w-full cursor-pointer items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-4 text-base text-gray-500 outline-none focus-visible:ring-2"
+                            class="focus-visible:ring-ring border-border bg-muted text-muted-foreground flex h-11 w-full cursor-pointer items-center gap-2 rounded-lg border px-4 text-base outline-none focus-visible:ring-2"
                         >
                             <IconSearch class="h-4 w-4 shrink-0" aria-hidden="true" />
                             Search teaching…
@@ -153,38 +154,38 @@ const navLink = (active: boolean) =>
                         <Link
                             href="/"
                             @click="mobileNavOpen = false"
-                            :class="isCurrent('/') ? 'bg-white/10 text-white' : 'text-gray-300'"
-                            class="focus-visible:ring-ring rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
+                            :class="isCurrent('/') ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'"
+                            class="focus-visible:ring-ring hover:bg-accent hover:text-foreground rounded-md px-4 py-3 text-base font-medium outline-none focus-visible:ring-2"
                         >
                             Home
                         </Link>
 
-                        <p class="px-4 pt-3 pb-1 text-xs font-semibold tracking-wider text-gray-500 uppercase">Browse</p>
+                        <p class="text-muted-foreground px-4 pt-3 pb-1 text-xs font-semibold tracking-wider uppercase">Browse</p>
                         <Link
                             v-for="link in browseLinks"
                             :key="link.href"
                             :href="link.href"
                             @click="mobileNavOpen = false"
-                            :class="isCurrent(link.href) ? 'bg-white/10 text-white' : 'text-gray-300'"
-                            class="focus-visible:ring-ring rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
+                            :class="isCurrent(link.href) ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'"
+                            class="focus-visible:ring-ring hover:bg-accent hover:text-foreground rounded-md px-4 py-3 text-base font-medium outline-none focus-visible:ring-2"
                         >
                             {{ link.name }}
                         </Link>
 
-                        <p class="px-4 pt-3 pb-1 text-xs font-semibold tracking-wider text-gray-500 uppercase">Watch</p>
+                        <p class="text-muted-foreground px-4 pt-3 pb-1 text-xs font-semibold tracking-wider uppercase">Watch</p>
                         <Link
                             href="/latest"
                             @click="mobileNavOpen = false"
-                            :class="isCurrent('/latest') ? 'bg-white/10 text-white' : 'text-gray-300'"
-                            class="focus-visible:ring-ring rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
+                            :class="isCurrent('/latest') ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'"
+                            class="focus-visible:ring-ring hover:bg-accent hover:text-foreground rounded-md px-4 py-3 text-base font-medium outline-none focus-visible:ring-2"
                         >
                             Latest
                         </Link>
                         <Link
                             href="/livestreams"
                             @click="mobileNavOpen = false"
-                            :class="isCurrent('/livestreams') ? 'bg-white/10 text-white' : 'text-gray-300'"
-                            class="focus-visible:ring-ring inline-flex items-center gap-2 rounded-md px-4 py-3 text-base font-medium outline-none hover:bg-white/5 hover:text-white focus-visible:ring-2"
+                            :class="isCurrent('/livestreams') ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'"
+                            class="focus-visible:ring-ring hover:bg-accent hover:text-foreground inline-flex items-center gap-2 rounded-md px-4 py-3 text-base font-medium outline-none focus-visible:ring-2"
                         >
                             Live
                             <span v-if="liveNow" class="relative flex h-2 w-2">
@@ -196,8 +197,12 @@ const navLink = (active: boolean) =>
                             </span>
                         </Link>
                     </nav>
-                    <div class="mt-4 flex items-center justify-between border-t border-white/10 px-4 pt-4">
-                        <span class="text-sm text-gray-400">Text size</span>
+                    <div class="border-border mt-4 flex items-center justify-between border-t px-4 pt-4">
+                        <span class="text-muted-foreground text-sm">Theme</span>
+                        <ThemeToggle />
+                    </div>
+                    <div class="flex items-center justify-between px-4 pt-3">
+                        <span class="text-muted-foreground text-sm">Text size</span>
                         <TextSizeControl />
                     </div>
                 </SheetContent>

--- a/resources/js/components/layouts/AppLayout.vue
+++ b/resources/js/components/layouts/AppLayout.vue
@@ -6,11 +6,11 @@ import PersistentPlayer from '@/organisms/PersistentPlayer.vue';
 
 <template>
     <!-- relative: PersistentPlayer's docked mode positions in document coords -->
-    <div class="relative flex min-h-full flex-col bg-gray-950">
+    <div class="bg-background relative flex min-h-full flex-col">
         <!-- Keyboard users skip the nav straight to content -->
         <a
             href="#main"
-            class="bg-primary text-primary-foreground sr-only z-50 rounded-md px-4 py-2 text-sm font-semibold focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:outline-none focus:ring-2 focus:ring-white"
+            class="bg-primary text-primary-foreground sr-only z-50 rounded-md px-4 py-2 text-sm font-semibold focus:not-sr-only focus:absolute focus:top-3 focus:left-3 focus:ring-2 focus:ring-white focus:outline-none"
         >
             Skip to content
         </a>

--- a/resources/js/components/layouts/Navigation.vue
+++ b/resources/js/components/layouts/Navigation.vue
@@ -76,11 +76,11 @@ const moreMenuItems = [
                     <a v-for="(item, index) in browseMenuItems" :key="index" :href="item.url" class="underline font-bold mx-2 mb-3 lg:my-0 flex">{{ item.name }}</a>
 
                     <div id="searchBox" class="mx-2 mb-1 mt-5 lg:my-0 lg:mr-0 lg:flex grow min-w-40 lg:max-w-96">
-                        <form class="rounded-xl hover:outline-claytonRed focus-within:outline-claytonRed bg-gray-800 hover:outline focus-within:outline focus-within:bg-gray-700 flex flex-wrap shrink grow">
+                        <form class="rounded-xl hover:outline-claytonRed focus-within:outline-claytonRed bg-muted hover:outline focus-within:outline focus-within:bg-muted flex flex-wrap shrink grow">
                             <input
                                 type="search"
                                 id="navbar-search"
-                                class="p-2 text-gray-100 bg-transparent outline-none w-20 flex shrink grow"
+                                class="p-2 text-foreground bg-transparent outline-none w-20 flex shrink grow"
                                 placeholder="Search"
                                 required />
                             <button

--- a/resources/js/components/molecules/EmptyState.vue
+++ b/resources/js/components/molecules/EmptyState.vue
@@ -15,7 +15,7 @@ defineProps({
 </script>
 
 <template>
-    <div class="border-border bg-muted flex flex-col items-center justify-center rounded-xl border px-6 py-16 text-center">
+    <div class="border-border bg-card flex flex-col items-center justify-center rounded-xl border px-6 py-16 text-center">
         <component :is="icon" class="text-muted-foreground h-12 w-12" aria-hidden="true" />
         <p class="font-display text-foreground mt-4 text-xl font-bold">{{ title }}</p>
         <p v-if="message" class="text-muted-foreground mt-2 max-w-md text-sm leading-relaxed">{{ message }}</p>

--- a/resources/js/components/molecules/EmptyState.vue
+++ b/resources/js/components/molecules/EmptyState.vue
@@ -15,14 +15,14 @@ defineProps({
 </script>
 
 <template>
-    <div class="flex flex-col items-center justify-center rounded-xl border border-white/10 bg-white/[0.02] px-6 py-16 text-center">
-        <component :is="icon" class="h-12 w-12 text-gray-600" aria-hidden="true" />
-        <p class="font-display mt-4 text-xl font-bold text-gray-100">{{ title }}</p>
-        <p v-if="message" class="mt-2 max-w-md text-sm leading-relaxed text-gray-400">{{ message }}</p>
+    <div class="border-border bg-muted flex flex-col items-center justify-center rounded-xl border px-6 py-16 text-center">
+        <component :is="icon" class="text-muted-foreground h-12 w-12" aria-hidden="true" />
+        <p class="font-display text-foreground mt-4 text-xl font-bold">{{ title }}</p>
+        <p v-if="message" class="text-muted-foreground mt-2 max-w-md text-sm leading-relaxed">{{ message }}</p>
         <Link
             v-if="ctaHref && ctaLabel"
             :href="ctaHref"
-            class="bg-primary text-primary-foreground focus-visible:ring-ring hover:bg-primary/90 mt-6 inline-flex min-h-11 items-center rounded-lg px-5 text-sm font-semibold transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+            class="bg-primary text-primary-foreground focus-visible:ring-ring hover:bg-primary/90 focus-visible:ring-offset-background mt-6 inline-flex min-h-11 items-center rounded-lg px-5 text-sm font-semibold transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
         >
             {{ ctaLabel }}
         </Link>

--- a/resources/js/components/molecules/EpisodeRow.vue
+++ b/resources/js/components/molecules/EpisodeRow.vue
@@ -22,9 +22,9 @@ const thumb = (episode) => {
     <Link
         :href="episode.url"
         prefetch
-        class="group focus-visible:ring-ring flex items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-3 transition-colors duration-150 outline-none hover:border-white/20 hover:bg-white/[0.06] focus-visible:ring-2"
+        class="group focus-visible:ring-ring border-border bg-card hover:border-ring hover:bg-accent flex items-center gap-4 rounded-xl border p-3 transition-colors duration-150 outline-none focus-visible:ring-2"
     >
-        <span class="w-6 shrink-0 text-center text-sm font-medium text-gray-500 tabular-nums">{{ position }}</span>
+        <span class="text-muted-foreground w-6 shrink-0 text-center text-sm font-medium tabular-nums">{{ position }}</span>
         <span class="relative aspect-video w-28 shrink-0 overflow-hidden rounded-md bg-gray-800 sm:w-32">
             <img
                 v-if="thumb(episode)"
@@ -49,8 +49,8 @@ const thumb = (episode) => {
             </span>
         </span>
         <span class="min-w-0 flex-1">
-            <span class="block truncate text-[15px] font-medium text-gray-100">{{ episode.name }}</span>
-            <span v-if="episode.date" class="mt-0.5 block text-xs text-gray-500 tabular-nums">{{ episode.date }}</span>
+            <span class="text-foreground block truncate text-[15px] font-medium">{{ episode.name }}</span>
+            <span v-if="episode.date" class="text-muted-foreground mt-0.5 block text-xs tabular-nums">{{ episode.date }}</span>
         </span>
         <span
             v-if="hasWatched(episode.id)"

--- a/resources/js/components/molecules/FilterChips.vue
+++ b/resources/js/components/molecules/FilterChips.vue
@@ -41,7 +41,7 @@ const chips = computed(() => {
         </button>
         <button
             @click="emit('clear')"
-            class="focus-visible:ring-ring min-h-9 cursor-pointer rounded-full px-3 text-sm text-gray-400 outline-none hover:text-white focus-visible:ring-2"
+            class="focus-visible:ring-ring text-muted-foreground hover:text-foreground min-h-9 cursor-pointer rounded-full px-3 text-sm outline-none focus-visible:ring-2"
         >
             Clear all
         </button>

--- a/resources/js/components/molecules/NextServiceCard.vue
+++ b/resources/js/components/molecules/NextServiceCard.vue
@@ -27,7 +27,7 @@ const formatSchedule = (iso: string) => {
 
 <template>
     <!-- LIVE now: one tap from the homepage into the service -->
-    <div v-if="live" class="border-primary/40 overflow-hidden rounded-xl border bg-white/[0.03]">
+    <div v-if="live" class="border-primary/40 bg-card overflow-hidden rounded-xl border">
         <div v-if="watching && liveEmbedUrl" class="aspect-video w-full bg-black">
             <iframe
                 class="h-full w-full"
@@ -59,14 +59,14 @@ const formatSchedule = (iso: string) => {
                 </span>
                 <p class="text-primary text-xs font-bold tracking-wider uppercase">Live now</p>
             </div>
-            <p class="font-display mt-2 text-lg leading-snug font-bold text-gray-50">{{ live.title }}</p>
-            <p v-if="live.channel" class="mt-1 text-sm text-gray-400">{{ live.channel }}</p>
+            <p class="font-display text-foreground mt-2 text-lg leading-snug font-bold">{{ live.title }}</p>
+            <p v-if="live.channel" class="text-muted-foreground mt-1 text-sm">{{ live.channel }}</p>
         </div>
     </div>
 
     <!-- Service starts within the half-hour: embed the stream's own waiting
          room — it shows the countdown and begins by itself when live -->
-    <div v-else-if="nextService?.starts_soon" class="border-primary/40 overflow-hidden rounded-xl border bg-white/[0.03]">
+    <div v-else-if="nextService?.starts_soon" class="border-primary/40 bg-card overflow-hidden rounded-xl border">
         <div class="aspect-video w-full bg-black">
             <iframe
                 class="h-full w-full"
@@ -82,23 +82,25 @@ const formatSchedule = (iso: string) => {
                 <span class="bg-primary inline-block h-2 w-2 rounded-full" aria-hidden="true"></span>
                 <p class="text-primary text-xs font-bold tracking-wider uppercase">Starting soon</p>
             </div>
-            <p class="font-display mt-2 text-lg leading-snug font-bold text-gray-50">{{ nextService.title }}</p>
-            <p class="mt-1 text-sm text-gray-400 tabular-nums">{{ formatSchedule(nextService.scheduled_start) }} — the stream will begin here.</p>
+            <p class="font-display text-foreground mt-2 text-lg leading-snug font-bold">{{ nextService.title }}</p>
+            <p class="text-muted-foreground mt-1 text-sm tabular-nums">
+                {{ formatSchedule(nextService.scheduled_start) }} — the stream will begin here.
+            </p>
         </div>
     </div>
 
     <!-- A real scheduled service: honest date and time, no countdown theatre -->
-    <div v-else-if="nextService" class="rounded-xl border border-white/10 bg-white/[0.03] p-5 sm:p-6">
+    <div v-else-if="nextService" class="border-border bg-card rounded-xl border p-5 sm:p-6">
         <div class="flex items-center gap-2">
             <span class="bg-primary inline-block h-2 w-2 rounded-full" aria-hidden="true"></span>
-            <p class="text-xs font-medium tracking-wider text-gray-400 uppercase">Next service</p>
+            <p class="text-muted-foreground text-xs font-medium tracking-wider uppercase">Next service</p>
         </div>
-        <p class="font-display mt-3 text-lg leading-snug font-bold text-gray-50">{{ nextService.title }}</p>
-        <p class="mt-1.5 text-sm leading-relaxed text-gray-300 tabular-nums">{{ formatSchedule(nextService.scheduled_start) }}</p>
-        <p class="mt-1 text-sm text-gray-400">The stream will appear here when it starts.</p>
+        <p class="font-display text-foreground mt-3 text-lg leading-snug font-bold">{{ nextService.title }}</p>
+        <p class="text-foreground mt-1.5 text-sm leading-relaxed tabular-nums">{{ formatSchedule(nextService.scheduled_start) }}</p>
+        <p class="text-muted-foreground mt-1 text-sm">The stream will appear here when it starts.</p>
         <Link
             href="/livestreams"
-            class="focus-visible:ring-ring mt-4 inline-flex min-h-11 items-center gap-1.5 rounded-lg bg-white/5 px-4 text-sm font-medium text-gray-100 transition-colors duration-150 outline-none hover:bg-white/10 focus-visible:ring-2"
+            class="focus-visible:ring-ring bg-muted text-foreground hover:bg-accent mt-4 inline-flex min-h-11 items-center gap-1.5 rounded-lg px-4 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2"
         >
             Watch past services
             <IconArrowRight class="h-4 w-4" aria-hidden="true" />
@@ -106,18 +108,18 @@ const formatSchedule = (iso: string) => {
     </div>
 
     <!-- Nothing live or scheduled: the quiet evergreen card -->
-    <div v-else class="rounded-xl border border-white/10 bg-white/[0.03] p-5 sm:p-6">
+    <div v-else class="border-border bg-card rounded-xl border p-5 sm:p-6">
         <div class="flex items-center gap-2">
             <span class="bg-primary inline-block h-2 w-2 rounded-full" aria-hidden="true"></span>
-            <p class="text-xs font-medium tracking-wider text-gray-400 uppercase">Sunday services</p>
+            <p class="text-muted-foreground text-xs font-medium tracking-wider uppercase">Sunday services</p>
         </div>
-        <p class="font-display mt-3 text-lg font-bold text-gray-50">Live streams appear here</p>
-        <p class="mt-1.5 text-sm leading-relaxed text-gray-400">
+        <p class="font-display text-foreground mt-3 text-lg font-bold">Live streams appear here</p>
+        <p class="text-muted-foreground mt-1.5 text-sm leading-relaxed">
             Morning and evening services stream live most Sundays. Until then, catch up on recent services any time.
         </p>
         <Link
             href="/livestreams"
-            class="focus-visible:ring-ring mt-4 inline-flex min-h-11 items-center gap-1.5 rounded-lg bg-white/5 px-4 text-sm font-medium text-gray-100 transition-colors duration-150 outline-none hover:bg-white/10 focus-visible:ring-2"
+            class="focus-visible:ring-ring bg-muted text-foreground hover:bg-accent mt-4 inline-flex min-h-11 items-center gap-1.5 rounded-lg px-4 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2"
         >
             Watch past services
             <IconArrowRight class="h-4 w-4" aria-hidden="true" />

--- a/resources/js/components/molecules/PaginationNav.vue
+++ b/resources/js/components/molecules/PaginationNav.vue
@@ -22,14 +22,14 @@ const goTo = (page: number) => {
 <template>
     <nav v-if="hasPrevPage || hasNextPage" class="flex justify-center gap-x-3" aria-label="Pagination">
         <button
-            class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-lg border border-white/15 px-5 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-35 disabled:hover:border-white/15"
+            class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground disabled:hover:border-input min-h-11 cursor-pointer rounded-lg border px-5 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2 disabled:cursor-default disabled:opacity-35"
             :disabled="!hasPrevPage"
             @click="goTo(currentPage() - 1)"
         >
             Previous
         </button>
         <button
-            class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-lg border border-white/15 px-5 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-35 disabled:hover:border-white/15"
+            class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground disabled:hover:border-input min-h-11 cursor-pointer rounded-lg border px-5 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2 disabled:cursor-default disabled:opacity-35"
             :disabled="!hasNextPage"
             @click="goTo(currentPage() + 1)"
         >

--- a/resources/js/components/molecules/SectionHeading.vue
+++ b/resources/js/components/molecules/SectionHeading.vue
@@ -11,11 +11,11 @@ defineProps({
 
 <template>
     <div class="mb-5 flex items-baseline justify-between gap-4">
-        <h2 class="font-display text-xl font-bold text-gray-50 sm:text-2xl">{{ title }}</h2>
+        <h2 class="font-display text-foreground text-xl font-bold sm:text-2xl">{{ title }}</h2>
         <Link
             v-if="moreHref"
             :href="moreHref"
-            class="focus-visible:ring-ring inline-flex shrink-0 items-center gap-1 rounded text-sm font-medium text-gray-400 transition-colors duration-150 outline-none hover:text-white focus-visible:ring-2"
+            class="focus-visible:ring-ring text-muted-foreground hover:text-foreground inline-flex shrink-0 items-center gap-1 rounded text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2"
         >
             {{ moreLabel }}
             <IconArrowRight class="h-3.5 w-3.5" aria-hidden="true" />

--- a/resources/js/components/molecules/SeriesCard.vue
+++ b/resources/js/components/molecules/SeriesCard.vue
@@ -12,15 +12,15 @@ defineProps({
     <Link
         :href="series.url"
         prefetch
-        class="group focus-visible:ring-ring flex gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-4 transition-colors duration-150 outline-none hover:border-white/20 hover:bg-white/[0.06] focus-visible:ring-2"
+        class="group focus-visible:ring-ring border-border bg-card hover:border-ring hover:bg-accent flex gap-4 rounded-xl border p-4 transition-colors duration-150 outline-none focus-visible:ring-2"
     >
         <div class="bg-primary/10 flex h-20 w-20 flex-none items-center justify-center rounded-lg" aria-hidden="true">
             <IconBook2 class="text-primary h-8 w-8 stroke-[1.5]" />
         </div>
         <div class="min-w-0">
-            <h3 class="truncate text-[15px] font-semibold text-gray-50">{{ series.name }}</h3>
-            <p v-if="series.summary" class="mt-1 line-clamp-2 text-[13px] leading-relaxed text-gray-400">{{ series.summary }}</p>
-            <p class="mt-2 inline-block rounded-md bg-white/5 px-2 py-0.5 text-xs text-gray-300 tabular-nums">
+            <h3 class="text-foreground truncate text-[15px] font-semibold">{{ series.name }}</h3>
+            <p v-if="series.summary" class="text-muted-foreground mt-1 line-clamp-2 text-[13px] leading-relaxed">{{ series.summary }}</p>
+            <p class="bg-muted text-muted-foreground mt-2 inline-block rounded-md px-2 py-0.5 text-xs tabular-nums">
                 {{ series.videosCount }} {{ countNoun }}{{ series.videosCount === 1 ? '' : 's' }}
             </p>
         </div>

--- a/resources/js/components/molecules/SeriesFloodRow.vue
+++ b/resources/js/components/molecules/SeriesFloodRow.vue
@@ -12,7 +12,7 @@ defineProps({
     <Link
         :href="item.url"
         prefetch
-        class="group focus-visible:ring-ring col-span-full flex items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-3 transition-colors duration-150 outline-none hover:border-white/25 hover:bg-white/[0.06] focus-visible:ring-2 sm:gap-5 sm:p-4"
+        class="group focus-visible:ring-ring border-border bg-card hover:border-ring hover:bg-accent col-span-full flex items-center gap-4 rounded-xl border p-3 transition-colors duration-150 outline-none focus-visible:ring-2 sm:gap-5 sm:p-4"
     >
         <!-- Fanned thumbnails signal "a stack of episodes" at a glance -->
         <span class="relative h-16 w-32 shrink-0 sm:h-20 sm:w-40" aria-hidden="true">
@@ -32,11 +32,13 @@ defineProps({
 
         <span class="min-w-0 flex-1">
             <span class="text-primary block text-xs font-semibold tracking-wider uppercase">Series</span>
-            <span class="mt-0.5 block truncate text-base font-bold text-gray-100 sm:text-lg">{{ item.name }}</span>
-            <span class="mt-0.5 block text-sm text-gray-400"> {{ item.count }} new {{ item.count === 1 ? 'episode' : 'episodes' }} </span>
+            <span class="text-foreground mt-0.5 block truncate text-base font-bold sm:text-lg">{{ item.name }}</span>
+            <span class="text-muted-foreground mt-0.5 block text-sm"> {{ item.count }} new {{ item.count === 1 ? 'episode' : 'episodes' }} </span>
         </span>
 
-        <span class="flex shrink-0 items-center gap-1 text-sm font-medium text-gray-400 transition-colors duration-150 group-hover:text-white">
+        <span
+            class="text-muted-foreground group-hover:text-foreground flex shrink-0 items-center gap-1 text-sm font-medium transition-colors duration-150"
+        >
             <span class="hidden sm:inline">View series</span>
             <IconChevronRight class="h-5 w-5" aria-hidden="true" />
         </span>

--- a/resources/js/components/molecules/ShareButton.vue
+++ b/resources/js/components/molecules/ShareButton.vue
@@ -47,7 +47,7 @@ const onClick = () => {
     <div class="relative">
         <button
             @click="onClick"
-            class="focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-lg border border-white/15 px-4 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2"
+            class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground inline-flex min-h-11 items-center gap-2 rounded-lg border px-4 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2"
             aria-label="Share this video"
         >
             <IconShare class="h-4 w-4" aria-hidden="true" />
@@ -57,23 +57,23 @@ const onClick = () => {
         <!-- Fallback menu for desktop browsers without the native share sheet -->
         <div
             v-if="menuOpen && !canNativeShare"
-            class="absolute top-full left-0 z-20 mt-2 w-56 rounded-xl border border-white/10 bg-gray-900 p-1.5 shadow-xl"
+            class="border-border bg-card absolute top-full left-0 z-20 mt-2 w-56 rounded-xl border p-1.5 shadow-xl"
         >
             <button
                 @click="copyLink"
-                class="focus-visible:ring-ring flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-gray-200 outline-none hover:bg-white/5 focus-visible:ring-2"
+                class="focus-visible:ring-ring text-foreground hover:bg-accent flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm outline-none focus-visible:ring-2"
             >
                 <IconCheck v-if="copied" class="text-primary h-4 w-4" aria-hidden="true" />
-                <IconLink v-else class="h-4 w-4 text-gray-400" aria-hidden="true" />
+                <IconLink v-else class="text-muted-foreground h-4 w-4" aria-hidden="true" />
                 {{ copied ? 'Link copied' : 'Copy link' }}
             </button>
             <a
                 :href="whatsappUrl"
                 target="_blank"
                 rel="noopener"
-                class="focus-visible:ring-ring flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm text-gray-200 outline-none hover:bg-white/5 focus-visible:ring-2"
+                class="focus-visible:ring-ring text-foreground hover:bg-accent flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm outline-none focus-visible:ring-2"
             >
-                <IconBrandWhatsapp class="h-4 w-4 text-gray-400" aria-hidden="true" />
+                <IconBrandWhatsapp class="text-muted-foreground h-4 w-4" aria-hidden="true" />
                 Share on WhatsApp
             </a>
         </div>

--- a/resources/js/components/molecules/ShortcutsHelp.vue
+++ b/resources/js/components/molecules/ShortcutsHelp.vue
@@ -33,19 +33,19 @@ const sections = [
             </DialogHeader>
             <div class="space-y-5">
                 <section v-for="section in sections" :key="section.heading">
-                    <h3 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">{{ section.heading }}</h3>
+                    <h3 class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">{{ section.heading }}</h3>
                     <ul class="mt-2 space-y-1.5">
                         <li
                             v-for="shortcut in section.shortcuts"
                             :key="shortcut.label + shortcut.keys.join()"
                             class="flex items-center justify-between gap-4"
                         >
-                            <span class="text-sm text-gray-300">{{ shortcut.label }}</span>
+                            <span class="text-foreground text-sm">{{ shortcut.label }}</span>
                             <span class="flex gap-1">
                                 <kbd
                                     v-for="key in shortcut.keys"
                                     :key="key"
-                                    class="rounded border border-white/15 bg-white/5 px-1.5 py-0.5 font-sans text-xs text-gray-300"
+                                    class="border-input bg-muted text-foreground rounded border px-1.5 py-0.5 font-sans text-xs"
                                 >
                                     {{ key }}
                                 </kbd>

--- a/resources/js/components/molecules/TextSizeControl.vue
+++ b/resources/js/components/molecules/TextSizeControl.vue
@@ -13,7 +13,7 @@ const { increase, decrease, reset, canIncrease, canDecrease, isDefault } = useTe
             @click="decrease()"
             :disabled="!canDecrease()"
             aria-label="Decrease text size"
-            class="focus-visible:ring-ring inline-flex min-h-9 min-w-9 cursor-pointer items-center justify-center rounded-md text-gray-400 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
+            class="focus-visible:ring-ring text-muted-foreground hover:bg-accent hover:text-foreground inline-flex min-h-9 min-w-9 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
         >
             <IconLetterA class="h-3.5 w-3.5" aria-hidden="true" />
         </button>
@@ -21,7 +21,7 @@ const { increase, decrease, reset, canIncrease, canDecrease, isDefault } = useTe
             @click="reset()"
             :disabled="isDefault()"
             aria-label="Reset text size"
-            class="focus-visible:ring-ring inline-flex min-h-9 min-w-9 cursor-pointer items-center justify-center rounded-md text-gray-400 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
+            class="focus-visible:ring-ring text-muted-foreground hover:bg-accent hover:text-foreground inline-flex min-h-9 min-w-9 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
         >
             <IconLetterA class="h-5 w-5" aria-hidden="true" />
         </button>
@@ -29,7 +29,7 @@ const { increase, decrease, reset, canIncrease, canDecrease, isDefault } = useTe
             @click="increase()"
             :disabled="!canIncrease()"
             aria-label="Increase text size"
-            class="focus-visible:ring-ring inline-flex min-h-9 min-w-9 cursor-pointer items-center justify-center rounded-md text-gray-400 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
+            class="focus-visible:ring-ring text-muted-foreground hover:bg-accent hover:text-foreground inline-flex min-h-9 min-w-9 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-transparent"
         >
             <IconLetterA class="h-6 w-6" aria-hidden="true" />
         </button>

--- a/resources/js/components/molecules/ThemeToggle.vue
+++ b/resources/js/components/molecules/ThemeToggle.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { IconDeviceDesktop, IconMoon, IconSun } from '@tabler/icons-vue';
+import { useAppearance } from '~/composables/useAppearance';
+
+// Light / System / Dark segmented control. Default is "system" (follows the
+// OS preference); the choice persists via useAppearance (localStorage + cookie).
+const { appearance, updateAppearance } = useAppearance();
+
+const options = [
+    { value: 'light', label: 'Light', icon: IconSun },
+    { value: 'system', label: 'System', icon: IconDeviceDesktop },
+    { value: 'dark', label: 'Dark', icon: IconMoon },
+] as const;
+</script>
+
+<template>
+    <div class="border-border inline-flex items-center gap-0.5 rounded-md border p-0.5" role="group" aria-label="Colour theme">
+        <button
+            v-for="option in options"
+            :key="option.value"
+            @click="updateAppearance(option.value)"
+            :aria-label="option.label + ' theme'"
+            :aria-pressed="appearance === option.value"
+            :class="appearance === option.value ? 'bg-accent text-accent-foreground' : 'text-muted-foreground hover:text-foreground'"
+            class="focus-visible:ring-ring inline-flex min-h-8 min-w-8 cursor-pointer items-center justify-center rounded outline-none focus-visible:ring-2"
+        >
+            <component :is="option.icon" class="h-4 w-4" aria-hidden="true" />
+        </button>
+    </div>
+</template>

--- a/resources/js/components/organisms/AZBar.vue
+++ b/resources/js/components/organisms/AZBar.vue
@@ -27,13 +27,13 @@ function updateShownLetters(dir) {
 </script>
 
 <template>
-    <div class="bg-gray-200 p-2">
+    <div class="bg-muted p-2">
         <div class="px-3 pb-2 text-lg">Filter A-Z:</div>
         <ul class="grid auto-cols-fr grid-flow-col text-center text-lg text-nowrap" role="radio">
             <!-- Full list will be visible on larger screens -->
             <div id="fullList" class="hidden lg:contents xl:contents 2xl:contents">
                 <div v-for="lettersGroup in letters" class="contents">
-                    <li v-for="x in lettersGroup" class="hover:border-claytonRed m-0.5 rounded border-2 border-gray-400">
+                    <li v-for="x in lettersGroup" class="hover:border-claytonRed border-border m-0.5 rounded border-2">
                         {{ x }}
                     </li>
                 </div>
@@ -50,7 +50,7 @@ function updateShownLetters(dir) {
                     v-bind:id="'lettersDiv' + lettersIndex"
                     v-bind:style="lettersSet == lettersIndex ? 'display: contents' : 'display: none'"
                 >
-                    <li v-for="x in lettersGroup" class="hover:border-claytonRed m-0.5 rounded border-2 border-gray-400">
+                    <li v-for="x in lettersGroup" class="hover:border-claytonRed border-border m-0.5 rounded border-2">
                         {{ x }}
                     </li>
                 </div>

--- a/resources/js/components/organisms/CategoriesBrowseWidget.vue
+++ b/resources/js/components/organisms/CategoriesBrowseWidget.vue
@@ -101,10 +101,10 @@ function selectCategory(category) {
 
 <template>
     <div class="justify-items-center space-y-2">
-        <h2 class="mt-8 text-center text-3xl font-bold text-gray-100" v-if="title">
+        <h2 class="text-foreground mt-8 text-center text-3xl font-bold" v-if="title">
             {{ title }}
         </h2>
-        <p class="mt-2 text-center text-gray-400" v-if="description">
+        <p class="text-muted-foreground mt-2 text-center" v-if="description">
             {{ description }}
         </p>
     </div>
@@ -116,8 +116,8 @@ function selectCategory(category) {
                 class="relative isolate mb-3 flex w-auto shrink-0 snap-center flex-col justify-end gap-y-2 rounded-md"
             >
                 <button
-                    class="me-2 rounded-full px-4 py-2 font-bold text-white hover:bg-red-400"
-                    :class="category === selectedCategory ? 'bg-primary' : 'bg-gray-700'"
+                    class="me-2 rounded-full px-4 py-2 font-bold hover:bg-red-400"
+                    :class="category === selectedCategory ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'"
                     @click="selectCategory(category)"
                 >
                     {{ category }}

--- a/resources/js/components/organisms/CategoriesBrowseWidget.vue
+++ b/resources/js/components/organisms/CategoriesBrowseWidget.vue
@@ -133,7 +133,7 @@ function selectCategory(category) {
             <span v-else-if="subcategories_sort_order === 'count'"> (most programmes first)</span>
         </h1>
         <div v-if="isLoadingSubCategories" class="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-2 sm:gap-x-6 lg:grid-cols-3 xl:gap-x-8">
-            <CardSkeleton v-for="skeletonIndex in 6" :key="skeletonIndex" :rowCount="1" :customClasses="'bg-blue-950'" :darkText="false" />
+            <CardSkeleton v-for="skeletonIndex in 6" :key="skeletonIndex" :rowCount="1" :customClasses="'bg-muted'" />
         </div>
         <ul v-else class="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-2 sm:gap-x-6 lg:grid-cols-3 xl:gap-x-8">
             <Link

--- a/resources/js/components/organisms/CommandPalette.vue
+++ b/resources/js/components/organisms/CommandPalette.vue
@@ -5,19 +5,40 @@ import {
     IconArrowRight,
     IconBook,
     IconCategory,
+    IconCheck,
     IconClock,
+    IconDeviceDesktop,
     IconLayoutGrid,
     IconMicrophone,
+    IconMoon,
+    IconRestore,
     IconSearch,
     IconSparkles,
+    IconSun,
+    IconTextDecrease,
+    IconTextIncrease,
     IconVideo,
 } from '@tabler/icons-vue';
-import { ref, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
+import { useAppearance } from '~/composables/useAppearance';
 import { usePalette } from '~/composables/usePalette';
+import { useTextScale } from '~/composables/useTextScale';
 import { useWatchHistory } from '~/composables/useWatchHistory';
 
 const { paletteOpen } = usePalette();
 const { continueWatching } = useWatchHistory();
+const { appearance, updateAppearance } = useAppearance();
+const { scale, increase, decrease, reset, canIncrease, canDecrease, isDefault } = useTextScale();
+
+// Theme + text-size live inside the palette too — selecting one applies it
+// immediately and keeps the palette open so the change is visible and you can
+// fine-tune (e.g. tap "Larger text" twice). Searchable by "theme"/"text size".
+const themeOptions = [
+    { value: 'light', label: 'Light theme', icon: IconSun },
+    { value: 'system', label: 'Use system theme', icon: IconDeviceDesktop },
+    { value: 'dark', label: 'Dark theme', icon: IconMoon },
+];
+const scalePercent = computed(() => `${Math.round(scale.value * 100)}%`);
 
 const query = ref('');
 const results = ref({ videos: [], categories: [] });
@@ -135,6 +156,38 @@ const navShortcuts = [
                     </CommandItem>
                 </CommandGroup>
             </template>
+
+            <!-- Always available (and searchable): theme + text size. Applying
+                 one keeps the palette open so the change is visible. -->
+            <CommandSeparator />
+            <CommandGroup heading="Theme">
+                <CommandItem
+                    v-for="option in themeOptions"
+                    :key="option.value"
+                    :value="`theme ${option.value} colour appearance`"
+                    @select="updateAppearance(option.value)"
+                >
+                    <component :is="option.icon" class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
+                    <span>{{ option.label }}</span>
+                    <IconCheck v-if="appearance === option.value" class="text-primary ml-auto h-4 w-4 shrink-0" aria-hidden="true" />
+                </CommandItem>
+            </CommandGroup>
+            <CommandGroup heading="Text size">
+                <CommandItem value="text size larger bigger increase" :disabled="!canIncrease()" @select="increase()">
+                    <IconTextIncrease class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
+                    <span>Larger text</span>
+                    <span class="text-muted-foreground ml-auto text-xs tabular-nums">{{ scalePercent }}</span>
+                </CommandItem>
+                <CommandItem value="text size smaller decrease" :disabled="!canDecrease()" @select="decrease()">
+                    <IconTextDecrease class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
+                    <span>Smaller text</span>
+                    <span class="text-muted-foreground ml-auto text-xs tabular-nums">{{ scalePercent }}</span>
+                </CommandItem>
+                <CommandItem value="text size reset default" :disabled="isDefault()" @select="reset()">
+                    <IconRestore class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
+                    <span>Reset text size</span>
+                </CommandItem>
+            </CommandGroup>
         </CommandList>
     </CommandDialog>
 </template>

--- a/resources/js/components/organisms/CommandPalette.vue
+++ b/resources/js/components/organisms/CommandPalette.vue
@@ -133,8 +133,10 @@ const navShortcuts = [
                 <CommandGroup v-if="results.videos.length" heading="Videos">
                     <CommandItem v-for="video in results.videos" :key="video.id" :value="`v-${video.id} ${video.name}`" @select="go(video.url)">
                         <IconVideo class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
-                        <span class="truncate">{{ video.name }}</span>
-                        <span v-if="video.date" class="text-muted-foreground ml-auto text-xs tabular-nums">{{ video.date }}</span>
+                        <span class="min-w-0 flex-1 truncate">{{ video.name }}</span>
+                        <span v-if="video.date" class="text-muted-foreground ml-auto shrink-0 text-xs whitespace-nowrap tabular-nums">{{
+                            video.date
+                        }}</span>
                     </CommandItem>
                 </CommandGroup>
                 <CommandGroup v-if="results.categories.length" heading="Browse">

--- a/resources/js/components/organisms/CommandPalette.vue
+++ b/resources/js/components/organisms/CommandPalette.vue
@@ -93,12 +93,12 @@ const navShortcuts = [
                     <CommandItem v-for="item in continueWatching()" :key="item.id" :value="`resume-${item.id}`" @select="go(`/video/${item.id}`)">
                         <IconClock class="text-primary h-4 w-4 shrink-0" aria-hidden="true" />
                         <span class="truncate">{{ item.name }}</span>
-                        <span class="ml-auto text-xs text-gray-500 tabular-nums">{{ formatTime(item.t) }} / {{ formatTime(item.d) }}</span>
+                        <span class="text-muted-foreground ml-auto text-xs tabular-nums">{{ formatTime(item.t) }} / {{ formatTime(item.d) }}</span>
                     </CommandItem>
                 </CommandGroup>
                 <CommandGroup heading="Go to">
                     <CommandItem v-for="nav in navShortcuts" :key="nav.url" :value="nav.name" @select="go(nav.url)">
-                        <IconArrowRight class="h-4 w-4 shrink-0 text-gray-500" aria-hidden="true" />
+                        <IconArrowRight class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
                         {{ nav.name }}
                     </CommandItem>
                 </CommandGroup>
@@ -107,9 +107,9 @@ const navShortcuts = [
             <template v-else>
                 <CommandGroup v-if="results.videos.length" heading="Videos">
                     <CommandItem v-for="video in results.videos" :key="video.id" :value="`v-${video.id} ${video.name}`" @select="go(video.url)">
-                        <IconVideo class="h-4 w-4 shrink-0 text-gray-500" aria-hidden="true" />
+                        <IconVideo class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
                         <span class="truncate">{{ video.name }}</span>
-                        <span v-if="video.date" class="ml-auto text-xs text-gray-500 tabular-nums">{{ video.date }}</span>
+                        <span v-if="video.date" class="text-muted-foreground ml-auto text-xs tabular-nums">{{ video.date }}</span>
                     </CommandItem>
                 </CommandGroup>
                 <CommandGroup v-if="results.categories.length" heading="Browse">
@@ -119,18 +119,18 @@ const navShortcuts = [
                         :value="`c-${category.kind}-${category.name}`"
                         @select="go(category.url)"
                     >
-                        <component :is="kindIcons[category.kind] || IconCategory" class="h-4 w-4 shrink-0 text-gray-500" aria-hidden="true" />
+                        <component :is="kindIcons[category.kind] || IconCategory" class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
                         <span class="truncate">{{ category.name }}</span>
-                        <span class="ml-auto flex items-center gap-2 text-xs text-gray-500">
+                        <span class="text-muted-foreground ml-auto flex items-center gap-2 text-xs">
                             <span v-if="category.count" class="tabular-nums">{{ category.count }} videos</span>
-                            <span class="rounded bg-white/10 px-1.5 py-0.5 text-[10px] tracking-wide uppercase">{{ category.kind }}</span>
+                            <span class="bg-muted rounded px-1.5 py-0.5 text-[10px] tracking-wide uppercase">{{ category.kind }}</span>
                         </span>
                     </CommandItem>
                 </CommandGroup>
                 <CommandSeparator />
                 <CommandGroup>
                     <CommandItem :value="`all ${query}`" @select="go(`/search?search=${encodeURIComponent(query.trim())}`)">
-                        <IconSearch class="h-4 w-4 shrink-0 text-gray-500" aria-hidden="true" />
+                        <IconSearch class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
                         See all results for “{{ query.trim() }}”
                     </CommandItem>
                 </CommandGroup>

--- a/resources/js/components/organisms/CommandPalette.vue
+++ b/resources/js/components/organisms/CommandPalette.vue
@@ -33,11 +33,15 @@ const { scale, increase, decrease, reset, canIncrease, canDecrease, isDefault } 
 // Theme + text-size live inside the palette too — selecting one applies it
 // immediately and keeps the palette open so the change is visible and you can
 // fine-tune (e.g. tap "Larger text" twice). Searchable by "theme"/"text size".
+// keywords = hidden search synonyms so intent words ("appearance", "contrast",
+// "accessibility"…) surface these even though they aren't in the visible label.
+const appearanceKeywords = ['appearance', 'colour', 'color', 'theme', 'accessibility', 'a11y'];
 const themeOptions = [
-    { value: 'light', label: 'Light theme', icon: IconSun },
-    { value: 'system', label: 'Use system theme', icon: IconDeviceDesktop },
-    { value: 'dark', label: 'Dark theme', icon: IconMoon },
+    { value: 'light', label: 'Light theme', icon: IconSun, keywords: [...appearanceKeywords, 'bright', 'day'] },
+    { value: 'system', label: 'Use system theme', icon: IconDeviceDesktop, keywords: [...appearanceKeywords, 'auto', 'os', 'default'] },
+    { value: 'dark', label: 'Dark theme', icon: IconMoon, keywords: [...appearanceKeywords, 'night', 'contrast', 'dim'] },
 ];
+const textSizeKeywords = ['text', 'font', 'size', 'accessibility', 'a11y', 'zoom', 'readability', 'legibility'];
 const scalePercent = computed(() => `${Math.round(scale.value * 100)}%`);
 
 const query = ref('');
@@ -160,11 +164,12 @@ const navShortcuts = [
             <!-- Always available (and searchable): theme + text size. Applying
                  one keeps the palette open so the change is visible. -->
             <CommandSeparator />
-            <CommandGroup heading="Theme">
+            <CommandGroup heading="Appearance">
                 <CommandItem
                     v-for="option in themeOptions"
                     :key="option.value"
-                    :value="`theme ${option.value} colour appearance`"
+                    :value="`theme-${option.value}`"
+                    :keywords="option.keywords"
                     @select="updateAppearance(option.value)"
                 >
                     <component :is="option.icon" class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
@@ -172,18 +177,33 @@ const navShortcuts = [
                     <IconCheck v-if="appearance === option.value" class="text-primary ml-auto h-4 w-4 shrink-0" aria-hidden="true" />
                 </CommandItem>
             </CommandGroup>
-            <CommandGroup heading="Text size">
-                <CommandItem value="text size larger bigger increase" :disabled="!canIncrease()" @select="increase()">
+            <CommandGroup heading="Accessibility">
+                <CommandItem
+                    value="text-larger"
+                    :keywords="[...textSizeKeywords, 'larger', 'bigger', 'increase']"
+                    :disabled="!canIncrease()"
+                    @select="increase()"
+                >
                     <IconTextIncrease class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
                     <span>Larger text</span>
                     <span class="text-muted-foreground ml-auto text-xs tabular-nums">{{ scalePercent }}</span>
                 </CommandItem>
-                <CommandItem value="text size smaller decrease" :disabled="!canDecrease()" @select="decrease()">
+                <CommandItem
+                    value="text-smaller"
+                    :keywords="[...textSizeKeywords, 'smaller', 'decrease', 'compact']"
+                    :disabled="!canDecrease()"
+                    @select="decrease()"
+                >
                     <IconTextDecrease class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
                     <span>Smaller text</span>
                     <span class="text-muted-foreground ml-auto text-xs tabular-nums">{{ scalePercent }}</span>
                 </CommandItem>
-                <CommandItem value="text size reset default" :disabled="isDefault()" @select="reset()">
+                <CommandItem
+                    value="text-reset"
+                    :keywords="[...textSizeKeywords, 'reset', 'default', 'normal']"
+                    :disabled="isDefault()"
+                    @select="reset()"
+                >
                     <IconRestore class="text-muted-foreground h-4 w-4 shrink-0" aria-hidden="true" />
                     <span>Reset text size</span>
                 </CommandItem>

--- a/resources/js/components/organisms/FacetSidebar.vue
+++ b/resources/js/components/organisms/FacetSidebar.vue
@@ -75,7 +75,7 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
         <!-- Speaker (multi, top voices) -->
         <fieldset v-if="facets.speaker.length">
             <legend class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">Speaker</legend>
-            <div class="mt-3 flex max-h-64 flex-col gap-1 overflow-y-auto pr-1">
+            <div class="mt-3 flex flex-col gap-1">
                 <label
                     v-for="opt in facets.speaker"
                     :key="opt.value"
@@ -97,7 +97,7 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
         <!-- Book (multi, grouped) -->
         <fieldset v-if="facets.book.length">
             <legend class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">Bible book</legend>
-            <div class="mt-3 max-h-64 space-y-3 overflow-y-auto pr-1">
+            <div class="mt-3 space-y-3">
                 <div v-if="otBooks.length">
                     <p class="text-muted-foreground px-3 text-[11px] font-medium tracking-wide uppercase">Old Testament</p>
                     <label

--- a/resources/js/components/organisms/FacetSidebar.vue
+++ b/resources/js/components/organisms/FacetSidebar.vue
@@ -19,14 +19,14 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
     <div class="space-y-7">
         <!-- Type (single) -->
         <fieldset>
-            <legend class="text-xs font-semibold tracking-wider text-gray-500 uppercase">Type</legend>
+            <legend class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">Type</legend>
             <div class="mt-3 flex flex-col gap-1">
                 <button
                     v-for="opt in facets.type"
                     :key="opt.value"
                     @click="emit('single', 'type', opt.value)"
                     :aria-pressed="isActive('type', opt.value)"
-                    :class="isActive('type', opt.value) ? 'bg-primary/15 text-primary' : 'text-gray-300 hover:bg-white/5 hover:text-white'"
+                    :class="isActive('type', opt.value) ? 'bg-primary/15 text-primary' : 'text-foreground hover:bg-accent hover:text-foreground'"
                     class="focus-visible:ring-ring flex min-h-10 items-center rounded-lg px-3 text-left text-sm outline-none focus-visible:ring-2"
                 >
                     {{ opt.label }}
@@ -36,14 +36,14 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
 
         <!-- Length (single) -->
         <fieldset>
-            <legend class="text-xs font-semibold tracking-wider text-gray-500 uppercase">Length</legend>
+            <legend class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">Length</legend>
             <div class="mt-3 flex flex-col gap-1">
                 <button
                     v-for="opt in facets.length"
                     :key="opt.value"
                     @click="emit('single', 'length', opt.value)"
                     :aria-pressed="isActive('length', opt.value)"
-                    :class="isActive('length', opt.value) ? 'bg-primary/15 text-primary' : 'text-gray-300 hover:bg-white/5 hover:text-white'"
+                    :class="isActive('length', opt.value) ? 'bg-primary/15 text-primary' : 'text-foreground hover:bg-accent hover:text-foreground'"
                     class="focus-visible:ring-ring flex min-h-10 items-center rounded-lg px-3 text-left text-sm outline-none focus-visible:ring-2"
                 >
                     {{ opt.label }}
@@ -53,12 +53,12 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
 
         <!-- Audience (multi) -->
         <fieldset v-if="facets.audience.length">
-            <legend class="text-xs font-semibold tracking-wider text-gray-500 uppercase">For</legend>
+            <legend class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">For</legend>
             <div class="mt-3 flex flex-col gap-1">
                 <label
                     v-for="opt in facets.audience"
                     :key="opt.value"
-                    class="flex min-h-10 cursor-pointer items-center gap-3 rounded-lg px-3 text-sm text-gray-300 hover:bg-white/5"
+                    class="text-foreground hover:bg-accent flex min-h-10 cursor-pointer items-center gap-3 rounded-lg px-3 text-sm"
                 >
                     <input
                         type="checkbox"
@@ -67,19 +67,19 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
                         class="accent-primary h-4 w-4"
                     />
                     <span class="flex-1">{{ opt.label }}</span>
-                    <span class="text-xs text-gray-500 tabular-nums">{{ opt.count }}</span>
+                    <span class="text-muted-foreground text-xs tabular-nums">{{ opt.count }}</span>
                 </label>
             </div>
         </fieldset>
 
         <!-- Speaker (multi, top voices) -->
         <fieldset v-if="facets.speaker.length">
-            <legend class="text-xs font-semibold tracking-wider text-gray-500 uppercase">Speaker</legend>
+            <legend class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">Speaker</legend>
             <div class="mt-3 flex max-h-64 flex-col gap-1 overflow-y-auto pr-1">
                 <label
                     v-for="opt in facets.speaker"
                     :key="opt.value"
-                    class="flex min-h-10 cursor-pointer items-center gap-3 rounded-lg px-3 text-sm text-gray-300 hover:bg-white/5"
+                    class="text-foreground hover:bg-accent flex min-h-10 cursor-pointer items-center gap-3 rounded-lg px-3 text-sm"
                 >
                     <input
                         type="checkbox"
@@ -88,7 +88,7 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
                         class="accent-primary h-4 w-4"
                     />
                     <span class="flex-1 truncate">{{ opt.label }}</span>
-                    <span class="text-xs text-gray-500 tabular-nums">{{ opt.count }}</span>
+                    <span class="text-muted-foreground text-xs tabular-nums">{{ opt.count }}</span>
                 </label>
             </div>
             <Link href="/speaker/" class="text-primary mt-2 inline-block text-xs hover:underline">More speakers →</Link>
@@ -96,14 +96,14 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
 
         <!-- Book (multi, grouped) -->
         <fieldset v-if="facets.book.length">
-            <legend class="text-xs font-semibold tracking-wider text-gray-500 uppercase">Bible book</legend>
+            <legend class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">Bible book</legend>
             <div class="mt-3 max-h-64 space-y-3 overflow-y-auto pr-1">
                 <div v-if="otBooks.length">
-                    <p class="px-3 text-[11px] font-medium tracking-wide text-gray-600 uppercase">Old Testament</p>
+                    <p class="text-muted-foreground px-3 text-[11px] font-medium tracking-wide uppercase">Old Testament</p>
                     <label
                         v-for="opt in otBooks"
                         :key="opt.value"
-                        class="flex min-h-9 cursor-pointer items-center gap-3 rounded-lg px-3 text-sm text-gray-300 hover:bg-white/5"
+                        class="text-foreground hover:bg-accent flex min-h-9 cursor-pointer items-center gap-3 rounded-lg px-3 text-sm"
                     >
                         <input
                             type="checkbox"
@@ -112,15 +112,15 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
                             class="accent-primary h-4 w-4"
                         />
                         <span class="flex-1 truncate">{{ opt.label }}</span>
-                        <span class="text-xs text-gray-500 tabular-nums">{{ opt.count }}</span>
+                        <span class="text-muted-foreground text-xs tabular-nums">{{ opt.count }}</span>
                     </label>
                 </div>
                 <div v-if="ntBooks.length">
-                    <p class="px-3 text-[11px] font-medium tracking-wide text-gray-600 uppercase">New Testament</p>
+                    <p class="text-muted-foreground px-3 text-[11px] font-medium tracking-wide uppercase">New Testament</p>
                     <label
                         v-for="opt in ntBooks"
                         :key="opt.value"
-                        class="flex min-h-9 cursor-pointer items-center gap-3 rounded-lg px-3 text-sm text-gray-300 hover:bg-white/5"
+                        class="text-foreground hover:bg-accent flex min-h-9 cursor-pointer items-center gap-3 rounded-lg px-3 text-sm"
                     >
                         <input
                             type="checkbox"
@@ -129,7 +129,7 @@ const ntBooks = computed(() => (props.facets.book || []).filter((b) => b.testame
                             class="accent-primary h-4 w-4"
                         />
                         <span class="flex-1 truncate">{{ opt.label }}</span>
-                        <span class="text-xs text-gray-500 tabular-nums">{{ opt.count }}</span>
+                        <span class="text-muted-foreground text-xs tabular-nums">{{ opt.count }}</span>
                     </label>
                 </div>
             </div>

--- a/resources/js/components/organisms/PersistentPlayer.vue
+++ b/resources/js/components/organisms/PersistentPlayer.vue
@@ -139,8 +139,8 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
         :style="frameStyle"
         :class="
             dock.mode.value === 'docked'
-                ? 'z-10 overflow-hidden rounded-xl border border-white/10'
-                : 'mini-in fixed right-[calc(1rem+env(safe-area-inset-right))] bottom-[calc(1rem+env(safe-area-inset-bottom))] z-50 w-[min(340px,calc(100vw-2rem))] overflow-hidden rounded-xl border border-white/15 bg-gray-900 shadow-2xl'
+                ? 'border-border z-10 overflow-hidden rounded-xl border'
+                : 'mini-in border-input bg-card fixed right-[calc(1rem+env(safe-area-inset-right))] bottom-[calc(1rem+env(safe-area-inset-bottom))] z-50 w-[min(340px,calc(100vw-2rem))] overflow-hidden rounded-xl border shadow-2xl'
         "
     >
         <div :class="dock.mode.value === 'docked' ? 'h-full w-full' : 'aspect-video w-full'">
@@ -157,7 +157,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
         <div v-if="dock.mode.value === 'mini'" class="flex flex-col gap-1 px-3 pt-2 pb-2.5">
             <button
                 @click="expand"
-                class="focus-visible:ring-ring cursor-pointer truncate text-left text-sm font-medium text-gray-100 outline-none hover:underline focus-visible:ring-2"
+                class="focus-visible:ring-ring text-foreground cursor-pointer truncate text-left text-sm font-medium outline-none hover:underline focus-visible:ring-2"
                 :title="dock.current.value.name"
             >
                 {{ dock.current.value.name }}
@@ -174,7 +174,7 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
             <div class="flex items-center gap-1">
                 <button
                     @click="dock.controls.value?.toggle()"
-                    class="focus-visible:ring-ring inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md text-gray-200 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring text-foreground hover:bg-accent hover:text-foreground inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2"
                     :aria-label="dock.playing.value ? 'Pause' : 'Play'"
                 >
                     <IconPlayerPause v-if="dock.playing.value" class="h-5 w-5" aria-hidden="true" />
@@ -183,25 +183,25 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
                 <button
                     v-if="dock.next.value"
                     @click="playNext"
-                    class="focus-visible:ring-ring inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md text-gray-200 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring text-foreground hover:bg-accent hover:text-foreground inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2"
                     aria-label="Next episode"
                     :title="`Next: ${dock.next.value.name}`"
                 >
                     <IconPlayerTrackNext class="h-5 w-5" aria-hidden="true" />
                 </button>
-                <span class="ml-1 text-xs text-gray-500 tabular-nums">
+                <span class="text-muted-foreground ml-1 text-xs tabular-nums">
                     {{ formatTime(dock.position.value) }}<template v-if="dock.duration.value"> / {{ formatTime(dock.duration.value) }}</template>
                 </span>
                 <button
                     @click="expand"
-                    class="focus-visible:ring-ring ml-auto inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md text-gray-300 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring text-muted-foreground hover:bg-accent hover:text-foreground ml-auto inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2"
                     aria-label="Open watch page"
                 >
                     <IconArrowsDiagonal class="h-5 w-5" aria-hidden="true" />
                 </button>
                 <button
                     @click="dock.close()"
-                    class="focus-visible:ring-ring inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md text-gray-300 outline-none hover:bg-white/10 hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring text-muted-foreground hover:bg-accent hover:text-foreground inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2"
                     aria-label="Close player"
                 >
                     <IconX class="h-5 w-5" aria-hidden="true" />

--- a/resources/js/components/organisms/Topics.vue
+++ b/resources/js/components/organisms/Topics.vue
@@ -68,7 +68,7 @@ function selectCategory(category) {
             <span class="text-xl font-bold">{{ selectedCategory }}</span>
         </h1>
         <div v-if="isLoadingSubCategories" class="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-2 sm:gap-x-6 lg:grid-cols-3 xl:gap-x-8">
-            <CardSkeleton v-for="skeletonIndex in 6" :key="skeletonIndex" :rowCount="1" :customClasses="'bg-blue-950'" :darkText="false" />
+            <CardSkeleton v-for="skeletonIndex in 6" :key="skeletonIndex" :rowCount="1" :customClasses="'bg-muted'" />
         </div>
         <ul v-else class="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-2 sm:gap-x-6 lg:grid-cols-3 xl:gap-x-8">
             <Link

--- a/resources/js/components/organisms/Topics.vue
+++ b/resources/js/components/organisms/Topics.vue
@@ -42,8 +42,8 @@ function selectCategory(category) {
 
 <template>
     <div class="mb-4 justify-items-center space-y-2">
-        <h2 class="text-center text-3xl font-bold text-gray-100">Explore Topics</h2>
-        <p class="text-center text-gray-400">There are a variety of topics for you to discover</p>
+        <h2 class="text-foreground text-center text-3xl font-bold">Explore Topics</h2>
+        <p class="text-muted-foreground text-center">There are a variety of topics for you to discover</p>
     </div>
     <div class="w-full items-center justify-center overflow-x-hidden pt-4">
         <ul class="flex snap-x snap-mandatory gap-x-0 overflow-x-auto px-2">
@@ -53,8 +53,8 @@ function selectCategory(category) {
                 class="relative isolate mb-3 flex w-auto shrink-0 snap-center flex-col justify-end gap-y-2 rounded-md"
             >
                 <button
-                    class="me-2 rounded-full px-4 py-2 font-bold text-white hover:bg-red-400"
-                    :class="category === selectedCategory ? 'bg-claytonRed' : 'bg-gray-700'"
+                    class="me-2 rounded-full px-4 py-2 font-bold hover:bg-red-400"
+                    :class="category === selectedCategory ? 'bg-claytonRed text-white' : 'bg-muted text-foreground'"
                     @click="selectCategory(category)"
                 >
                     {{ category }}

--- a/resources/js/components/organisms/VideoCardGrid.vue
+++ b/resources/js/components/organisms/VideoCardGrid.vue
@@ -50,10 +50,10 @@ const nextPage = () => {
 <template>
     <section v-bind="entrance()" class="flex flex-col gap-y-6">
         <div v-if="title || description">
-            <h1 v-if="title" class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">
+            <h1 v-if="title" class="font-display text-foreground text-2xl font-bold sm:text-3xl">
                 {{ title }}
             </h1>
-            <p v-if="description" class="mt-2 text-sm text-gray-500" v-html="description"></p>
+            <p v-if="description" class="text-muted-foreground mt-2 text-sm" v-html="description"></p>
         </div>
 
         <EmptyState v-if="!videos.length" :title="emptyTitle" :message="emptyMessage" cta-href="/latest" cta-label="Browse the latest teaching" />
@@ -64,7 +64,7 @@ const nextPage = () => {
                     :href="`/video/` + video.id"
                     :id="video.id"
                     prefetch
-                    class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                    class="focus-visible:ring-ring focus-visible:ring-offset-background block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                 >
                     <VideoCardItem :video="video" />
                     <span class="sr-only"> View video for {{ video.name }} </span>
@@ -74,14 +74,14 @@ const nextPage = () => {
 
         <nav v-if="has_prev_page || has_next_page" class="flex justify-center gap-x-3" aria-label="Pagination">
             <button
-                class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-lg border border-white/15 px-5 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-35 disabled:hover:border-white/15"
+                class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground disabled:hover:border-input min-h-11 cursor-pointer rounded-lg border px-5 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2 disabled:cursor-default disabled:opacity-35"
                 @click="prevPage()"
                 :disabled="!has_prev_page"
             >
                 Previous
             </button>
             <button
-                class="focus-visible:ring-ring min-h-11 cursor-pointer rounded-lg border border-white/15 px-5 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2 disabled:cursor-default disabled:opacity-35 disabled:hover:border-white/15"
+                class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground disabled:hover:border-input min-h-11 cursor-pointer rounded-lg border px-5 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2 disabled:cursor-default disabled:opacity-35"
                 @click="nextPage()"
                 :disabled="!has_next_page"
             >

--- a/resources/js/components/organisms/VideoCardList.vue
+++ b/resources/js/components/organisms/VideoCardList.vue
@@ -60,10 +60,10 @@ const playVideo = (id) => {
 <template>
     <section class="mt-8 mb-4 flex flex-col items-center gap-y-6">
         <div class="space-y-2">
-            <h2 class="text-center text-3xl font-bold text-gray-100" v-if="title">
+            <h2 class="text-foreground text-center text-3xl font-bold" v-if="title">
                 {{ title }}
             </h2>
-            <p class="text-center text-gray-400" v-if="description" v-html="description"></p>
+            <p class="text-muted-foreground text-center" v-if="description" v-html="description"></p>
         </div>
 
         <div class="mt-2 w-full overflow-x-hidden">

--- a/resources/js/components/ui/command/CommandDialog.vue
+++ b/resources/js/components/ui/command/CommandDialog.vue
@@ -18,7 +18,9 @@ const forwarded = useForwardPropsEmits(props, emits)
 
 <template>
   <Dialog v-slot="slotProps" v-bind="forwarded">
-    <DialogContent class="overflow-hidden p-0 ">
+    <!-- Nudge the close button to centre on the h-9 search row (the generic
+         top-4/right-4 is tuned for p-6 dialogs, not this p-0 palette). -->
+    <DialogContent class="overflow-hidden p-0 [&>button]:top-2.5 [&>button]:right-3">
       <DialogHeader class="sr-only">
         <DialogTitle>{{ title }}</DialogTitle>
         <DialogDescription>{{ description }}</DialogDescription>

--- a/resources/js/components/ui/command/CommandItem.vue
+++ b/resources/js/components/ui/command/CommandItem.vue
@@ -7,10 +7,12 @@ import { computed, onMounted, onUnmounted, ref } from "vue"
 import { cn } from "@/lib/utils"
 import { useCommand, useCommandGroup } from "."
 
-const props = defineProps<ListboxItemProps & { class?: HTMLAttributes["class"] }>()
+// `keywords` are hidden search synonyms (cmdk-style): the filter matches them in
+// addition to the visible label, so e.g. "font" or "contrast" can surface an item.
+const props = defineProps<ListboxItemProps & { class?: HTMLAttributes["class"], keywords?: string[] }>()
 const emits = defineEmits<ListboxItemEmits>()
 
-const delegatedProps = reactiveOmit(props, "class")
+const delegatedProps = reactiveOmit(props, "class", "keywords")
 
 const forwarded = useForwardPropsEmits(delegatedProps, emits)
 
@@ -41,8 +43,10 @@ onMounted(() => {
   if (!(currentElement.value instanceof HTMLElement))
     return
 
-  // textValue to perform filter
-  allItems.value.set(id, currentElement.value.textContent ?? (props.value?.toString() ?? ""))
+  // textValue to perform filter — visible label plus any hidden keywords
+  const text = currentElement.value.textContent ?? (props.value?.toString() ?? "")
+  const keywords = props.keywords?.length ? ` ${props.keywords.join(" ")}` : ""
+  allItems.value.set(id, text + keywords)
 
   const groupId = groupContext?.id
   if (groupId) {

--- a/resources/js/composables/useAppearance.ts
+++ b/resources/js/composables/useAppearance.ts
@@ -9,10 +9,7 @@ export function updateTheme(value: Appearance) {
 
     if (value === 'system') {
         const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
-
-        // FIXME: Currently the light mode looks awful due to various hardcoded colours. Force dark mode for now until that is fixed. See also /templates/app.html
-        //const systemTheme = mediaQueryList.matches ? 'dark' : 'light';
-        const systemTheme = 'dark';
+        const systemTheme = mediaQueryList.matches ? 'dark' : 'light';
 
         document.documentElement.classList.toggle('dark', systemTheme === 'dark');
     } else {

--- a/resources/js/pages/AudiencesIndex.vue
+++ b/resources/js/pages/AudiencesIndex.vue
@@ -27,7 +27,7 @@ const thumb = (audience) => (audience.thumbnail?.startsWith('http') ? audience.t
                 :key="audience.url"
                 :href="audience.url"
                 prefetch
-                class="group focus-visible:ring-ring border-border bg-muted hover:border-ring block overflow-hidden rounded-2xl border transition-colors duration-150 outline-none focus-visible:ring-2"
+                class="group focus-visible:ring-ring border-border bg-card hover:border-ring block overflow-hidden rounded-2xl border transition-colors duration-150 outline-none focus-visible:ring-2"
             >
                 <div class="from-primary/30 relative flex aspect-[16/9] items-center justify-center bg-gradient-to-br to-gray-900">
                     <img

--- a/resources/js/pages/AudiencesIndex.vue
+++ b/resources/js/pages/AudiencesIndex.vue
@@ -18,8 +18,8 @@ const thumb = (audience) => (audience.thumbnail?.startsWith('http') ? audience.t
 <template>
     <Head title="For every age" />
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
-        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">For every age</h1>
-        <p class="mt-2 text-sm text-gray-500">Teaching chosen for children, young people and adults.</p>
+        <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">For every age</h1>
+        <p class="text-muted-foreground mt-2 text-sm">Teaching chosen for children, young people and adults.</p>
 
         <div v-bind="entrance(80)" class="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
             <Link
@@ -27,7 +27,7 @@ const thumb = (audience) => (audience.thumbnail?.startsWith('http') ? audience.t
                 :key="audience.url"
                 :href="audience.url"
                 prefetch
-                class="group focus-visible:ring-ring block overflow-hidden rounded-2xl border border-white/10 bg-white/[0.03] transition-colors duration-150 outline-none hover:border-white/25 focus-visible:ring-2"
+                class="group focus-visible:ring-ring border-border bg-muted hover:border-ring block overflow-hidden rounded-2xl border transition-colors duration-150 outline-none focus-visible:ring-2"
             >
                 <div class="from-primary/30 relative flex aspect-[16/9] items-center justify-center bg-gradient-to-br to-gray-900">
                     <img
@@ -42,9 +42,9 @@ const thumb = (audience) => (audience.thumbnail?.startsWith('http') ? audience.t
                     <IconMoodKid class="h-12 w-12 text-white/80" aria-hidden="true" />
                 </div>
                 <div class="p-5">
-                    <p class="font-display text-xl font-bold text-gray-50">{{ audience.name }}</p>
-                    <p v-if="audience.summary" class="mt-1 line-clamp-2 text-sm leading-relaxed text-gray-400">{{ audience.summary }}</p>
-                    <p class="mt-3 text-sm text-gray-500 tabular-nums">
+                    <p class="font-display text-foreground text-xl font-bold">{{ audience.name }}</p>
+                    <p v-if="audience.summary" class="text-muted-foreground mt-1 line-clamp-2 text-sm leading-relaxed">{{ audience.summary }}</p>
+                    <p class="text-muted-foreground mt-3 text-sm tabular-nums">
                         {{ audience.videosCount }} {{ audience.videosCount === 1 ? 'video' : 'videos' }}
                     </p>
                 </div>

--- a/resources/js/pages/BookDetail.vue
+++ b/resources/js/pages/BookDetail.vue
@@ -31,19 +31,19 @@ const bookCode = () => decodeURIComponent(window.location.pathname.split('/').po
             </div>
             <div>
                 <p class="text-primary text-xs font-semibold tracking-[0.12em] uppercase">{{ book.section }}</p>
-                <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">{{ book.name }}</h1>
-                <p class="mt-1 text-sm text-gray-500 tabular-nums">{{ book.videosCount }} {{ book.videosCount === 1 ? 'talk' : 'talks' }}</p>
+                <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">{{ book.name }}</h1>
+                <p class="text-muted-foreground mt-1 text-sm tabular-nums">{{ book.videosCount }} {{ book.videosCount === 1 ? 'talk' : 'talks' }}</p>
             </div>
         </header>
 
         <!-- Chapter strip: jump straight to teaching on a chapter -->
         <section v-if="chapters.length" class="mt-8" aria-label="Chapters">
             <div class="flex items-center justify-between">
-                <h2 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">By chapter</h2>
+                <h2 class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">By chapter</h2>
                 <button
                     v-if="selected_chapter"
                     @click="selectChapter(selected_chapter)"
-                    class="focus-visible:ring-ring inline-flex items-center gap-1 rounded text-xs font-medium text-gray-400 outline-none hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring text-muted-foreground hover:text-foreground inline-flex items-center gap-1 rounded text-xs font-medium outline-none focus-visible:ring-2"
                 >
                     <IconX class="h-3.5 w-3.5" aria-hidden="true" /> Clear
                 </button>
@@ -59,7 +59,7 @@ const bookCode = () => decodeURIComponent(window.location.pathname.split('/').po
                     :class="
                         chapter === selected_chapter
                             ? 'bg-primary text-primary-foreground border-primary'
-                            : 'border-white/15 text-gray-300 hover:border-white/30 hover:text-white'
+                            : 'border-input text-foreground hover:border-ring hover:text-foreground'
                     "
                     class="focus-visible:ring-ring flex h-10 items-center justify-center rounded-lg border text-sm font-medium tabular-nums transition-colors duration-150 outline-none focus-visible:ring-2"
                 >
@@ -74,7 +74,7 @@ const bookCode = () => decodeURIComponent(window.location.pathname.split('/').po
                     <Link
                         :href="`/video/${video.id}`"
                         prefetch
-                        class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                        class="focus-visible:ring-ring focus-visible:ring-offset-background block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                     >
                         <VideoCardItem :video="video" />
                         <span
@@ -87,7 +87,9 @@ const bookCode = () => decodeURIComponent(window.location.pathname.split('/').po
                     </Link>
                 </li>
             </ul>
-            <p v-if="!videos.length" class="mt-12 text-center text-sm text-gray-500">No teaching on {{ book.name }} {{ selected_chapter }} yet.</p>
+            <p v-if="!videos.length" class="text-muted-foreground mt-12 text-center text-sm">
+                No teaching on {{ book.name }} {{ selected_chapter }} yet.
+            </p>
         </section>
     </div>
 </template>

--- a/resources/js/pages/BooksIndex.vue
+++ b/resources/js/pages/BooksIndex.vue
@@ -9,22 +9,26 @@ defineProps({
 <template>
     <Head title="Bible books" />
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
-        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Bible books</h1>
-        <p class="mt-2 text-sm text-gray-500">Genesis to Revelation, in canonical order</p>
+        <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Bible books</h1>
+        <p class="text-muted-foreground mt-2 text-sm">Genesis to Revelation, in canonical order</p>
 
         <section v-for="group in book_groups" :key="group.section" class="mt-10" :aria-label="group.section">
-            <h2 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">{{ group.section }}</h2>
+            <h2 class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">{{ group.section }}</h2>
             <div class="mt-3 flex flex-wrap gap-2.5">
                 <Link
                     v-for="book in group.books"
                     :key="book.url"
                     :href="book.url"
                     prefetch
-                    :class="book.videosCount ? 'text-gray-300 hover:border-white/30 hover:text-white' : 'text-gray-600 hover:text-gray-400'"
-                    class="focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-4 text-[13px] transition-colors duration-150 outline-none focus-visible:ring-2"
+                    :class="
+                        book.videosCount
+                            ? 'text-foreground hover:border-ring hover:text-foreground'
+                            : 'text-muted-foreground hover:text-muted-foreground'
+                    "
+                    class="focus-visible:ring-ring border-input inline-flex min-h-11 items-center gap-2 rounded-full border px-4 text-[13px] transition-colors duration-150 outline-none focus-visible:ring-2"
                 >
                     <span>{{ book.name }}</span>
-                    <span v-if="book.videosCount" class="rounded-full bg-white/10 px-1.5 py-0.5 text-[11px] text-gray-400 tabular-nums">
+                    <span v-if="book.videosCount" class="bg-muted text-muted-foreground rounded-full px-1.5 py-0.5 text-[11px] tabular-nums">
                         {{ book.videosCount }}
                     </span>
                 </Link>

--- a/resources/js/pages/BrowseFaceted.vue
+++ b/resources/js/pages/BrowseFaceted.vue
@@ -29,21 +29,21 @@ const filtersOpen = ref(false);
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
         <div class="flex flex-wrap items-end justify-between gap-3">
             <div>
-                <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Browse teaching</h1>
-                <p class="mt-2 text-sm text-gray-500 tabular-nums">{{ total }} {{ total === 1 ? 'video' : 'videos' }}</p>
+                <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Browse teaching</h1>
+                <p class="text-muted-foreground mt-2 text-sm tabular-nums">{{ total }} {{ total === 1 ? 'video' : 'videos' }}</p>
             </div>
             <!-- Mobile: open the filters in a sheet -->
             <Sheet v-model:open="filtersOpen">
                 <SheetTrigger
-                    class="focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-lg border border-white/15 px-4 text-sm font-medium text-gray-200 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2 lg:hidden"
+                    class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground inline-flex min-h-11 items-center gap-2 rounded-lg border px-4 text-sm font-medium outline-none focus-visible:ring-2 lg:hidden"
                 >
                     <IconAdjustmentsHorizontal class="h-4 w-4" aria-hidden="true" />
                     Filters<span v-if="activeCount()" class="bg-primary text-primary-foreground ml-1 rounded-full px-1.5 text-xs">{{
                         activeCount()
                     }}</span>
                 </SheetTrigger>
-                <SheetContent side="left" class="overflow-y-auto border-white/10 bg-gray-950 text-gray-100">
-                    <SheetHeader><SheetTitle class="font-display text-left text-gray-50">Filters</SheetTitle></SheetHeader>
+                <SheetContent side="left" class="border-border bg-background text-foreground overflow-y-auto">
+                    <SheetHeader><SheetTitle class="font-display text-foreground text-left">Filters</SheetTitle></SheetHeader>
                     <div class="px-4 py-2">
                         <FacetSidebar :facets="facets" :is-active="isActive" @single="setSingle" @toggle="toggleMulti" />
                     </div>

--- a/resources/js/pages/BrowseFaceted.vue
+++ b/resources/js/pages/BrowseFaceted.vue
@@ -52,8 +52,12 @@ const filtersOpen = ref(false);
         </div>
 
         <div class="mt-6 lg:grid lg:grid-cols-[16rem_1fr] lg:gap-8">
-            <!-- Desktop sidebar -->
-            <aside class="hidden lg:block" aria-label="Filters">
+            <!-- Desktop sidebar: sticky under the header, one scroll region that
+                 fills the viewport so it's clearly a scrollable container. -->
+            <aside
+                class="ctv-scroll hidden self-start lg:sticky lg:top-20 lg:block lg:max-h-[calc(100dvh-6rem)] lg:overflow-y-auto lg:pr-2 lg:pb-8"
+                aria-label="Filters"
+            >
                 <FacetSidebar :facets="facets" :is-active="isActive" @single="setSingle" @toggle="toggleMulti" />
             </aside>
 

--- a/resources/js/pages/BrowseFaceted.vue
+++ b/resources/js/pages/BrowseFaceted.vue
@@ -52,13 +52,13 @@ const filtersOpen = ref(false);
         </div>
 
         <div class="mt-6 lg:grid lg:grid-cols-[16rem_1fr] lg:gap-8">
-            <!-- Desktop sidebar: sticky under the header, one scroll region that
-                 fills the viewport so it's clearly a scrollable container. -->
-            <aside
-                class="ctv-scroll hidden self-start lg:sticky lg:top-20 lg:block lg:max-h-[calc(100dvh-6rem)] lg:overflow-y-auto lg:pr-2 lg:pb-8"
-                aria-label="Filters"
-            >
-                <FacetSidebar :facets="facets" :is-active="isActive" @single="setSingle" @toggle="toggleMulti" />
+            <!-- Desktop filter rail: a full-height bordered panel (so the space
+                 below the facets reads as an intentional rail, not a void) with
+                 the facets in a sticky, viewport-height scroll region inside it. -->
+            <aside class="lg:border-border hidden lg:block lg:border-r lg:pr-6" aria-label="Filters">
+                <div class="ctv-scroll sticky top-20 max-h-[calc(100dvh-6rem)] overflow-y-auto pb-8">
+                    <FacetSidebar :facets="facets" :is-active="isActive" @single="setSingle" @toggle="toggleMulti" />
+                </div>
             </aside>
 
             <div class="mt-6 lg:mt-0">

--- a/resources/js/pages/BrowseFaceted.vue
+++ b/resources/js/pages/BrowseFaceted.vue
@@ -26,9 +26,11 @@ const filtersOpen = ref(false);
 
 <template>
     <Head title="Browse teaching" />
-    <!-- pb removed on desktop so the filter-rail divider meets the footer's top
-         border; the results column carries its own bottom padding instead. -->
-    <div class="mx-auto max-w-6xl px-4 pt-10 pb-10 lg:px-8 lg:pb-0">
+    <!-- On desktop the filter-rail divider should meet the footer's top border:
+         drop our bottom padding and cancel the footer's mt-16 (the results column
+         carries its own bottom padding so content isn't cramped). Other pages keep
+         the footer's normal top margin. -->
+    <div class="mx-auto max-w-6xl px-4 pt-10 pb-10 lg:-mb-16 lg:px-8 lg:pb-0">
         <div class="flex flex-wrap items-end justify-between gap-3">
             <div>
                 <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Browse teaching</h1>

--- a/resources/js/pages/BrowseFaceted.vue
+++ b/resources/js/pages/BrowseFaceted.vue
@@ -26,7 +26,9 @@ const filtersOpen = ref(false);
 
 <template>
     <Head title="Browse teaching" />
-    <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
+    <!-- pb removed on desktop so the filter-rail divider meets the footer's top
+         border; the results column carries its own bottom padding instead. -->
+    <div class="mx-auto max-w-6xl px-4 pt-10 pb-10 lg:px-8 lg:pb-0">
         <div class="flex flex-wrap items-end justify-between gap-3">
             <div>
                 <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Browse teaching</h1>
@@ -61,7 +63,7 @@ const filtersOpen = ref(false);
                 </div>
             </aside>
 
-            <div class="mt-6 lg:mt-0">
+            <div class="mt-6 lg:mt-0 lg:pb-10">
                 <div class="mb-5"><FilterChips :facets="facets" :active="active" @remove="remove" @clear="clearAll" /></div>
                 <VideoCardGrid
                     :videos="videos"

--- a/resources/js/pages/LatestFeed.vue
+++ b/resources/js/pages/LatestFeed.vue
@@ -36,19 +36,19 @@ const dividerBeforeId = computed(() => {
 <template>
     <Head :title="title" />
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
-        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Latest</h1>
-        <p class="mt-2 text-sm text-gray-500">New teaching and recent series, most recent first.</p>
+        <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Latest</h1>
+        <p class="text-muted-foreground mt-2 text-sm">New teaching and recent series, most recent first.</p>
 
         <section v-for="(group, i) in groups" :key="group.label" v-bind="entrance(80 + i * 70)" class="mt-10" :aria-label="group.label">
-            <h2 class="flex items-center gap-3 text-sm font-semibold tracking-wider text-gray-400 uppercase">
+            <h2 class="text-muted-foreground flex items-center gap-3 text-sm font-semibold tracking-wider uppercase">
                 {{ group.label }}
-                <span class="h-px flex-1 bg-white/10" aria-hidden="true"></span>
+                <span class="bg-muted h-px flex-1" aria-hidden="true"></span>
             </h2>
 
             <ul class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
                 <template v-for="item in group.items" :key="`${item.type}-${item.id}`">
                     <li v-if="item.id === dividerBeforeId" class="col-span-full" aria-hidden="true">
-                        <p class="flex items-center gap-3 text-xs font-medium text-gray-500">
+                        <p class="text-muted-foreground flex items-center gap-3 text-xs font-medium">
                             <span class="bg-primary/40 h-px flex-1" aria-hidden="true"></span>
                             You've seen everything below this
                             <span class="bg-primary/40 h-px flex-1" aria-hidden="true"></span>
@@ -61,7 +61,7 @@ const dividerBeforeId = computed(() => {
                         <Link
                             :href="`/video/${item.id}`"
                             prefetch
-                            class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                            class="focus-visible:ring-ring focus-visible:ring-offset-background block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                         >
                             <VideoCardItem :video="item" />
                             <span class="sr-only">View video for {{ item.name }}</span>
@@ -71,7 +71,7 @@ const dividerBeforeId = computed(() => {
             </ul>
         </section>
 
-        <p v-if="num_pages > 1" class="mt-10 text-center text-xs text-gray-500 tabular-nums">Page {{ page }} of {{ num_pages }}</p>
+        <p v-if="num_pages > 1" class="text-muted-foreground mt-10 text-center text-xs tabular-nums">Page {{ page }} of {{ num_pages }}</p>
         <div class="mt-4">
             <PaginationNav :has-prev-page="has_prev_page" :has-next-page="has_next_page" />
         </div>

--- a/resources/js/pages/MinistriesIndex.vue
+++ b/resources/js/pages/MinistriesIndex.vue
@@ -11,8 +11,8 @@ defineProps({
 <template>
     <Head title="Ministries" />
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
-        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Ministries</h1>
-        <p class="mt-2 text-sm text-gray-500 tabular-nums">{{ total }} churches and ministries with teaching on Clayton TV</p>
+        <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Ministries</h1>
+        <p class="text-muted-foreground mt-2 text-sm tabular-nums">{{ total }} churches and ministries with teaching on Clayton TV</p>
 
         <div class="mt-8 grid gap-5 sm:grid-cols-2">
             <SeriesCard v-for="ministry in ministries" :key="ministry.url" :series="ministry" count-noun="video" />

--- a/resources/js/pages/Search.vue
+++ b/resources/js/pages/Search.vue
@@ -28,11 +28,11 @@ const props = defineProps({
 <template>
     <Head :title="title" />
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
-        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">{{ title }}</h1>
-        <p v-if="description" class="mt-2 text-sm text-gray-500">{{ description }}</p>
+        <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">{{ title }}</h1>
+        <p v-if="description" class="text-muted-foreground mt-2 text-sm">{{ description }}</p>
 
         <section v-if="categories?.length" class="mt-8" aria-label="Matching categories">
-            <h2 class="text-xs font-medium tracking-wider text-gray-500 uppercase">
+            <h2 class="text-muted-foreground text-xs font-medium tracking-wider uppercase">
                 {{ categories.length }} matching {{ categories.length === 1 ? 'category' : 'categories' }}
             </h2>
             <div class="mt-3 flex flex-wrap gap-2.5">
@@ -41,11 +41,11 @@ const props = defineProps({
                     :key="category.url"
                     :href="category.url"
                     prefetch
-                    class="focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-4 text-[13px] text-gray-300 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground inline-flex min-h-11 items-center gap-2 rounded-full border px-4 text-[13px] transition-colors duration-150 outline-none focus-visible:ring-2"
                 >
                     <span>{{ category.name }}</span>
-                    <span class="text-xs text-gray-500">{{ category.category }}</span>
-                    <span v-if="category.videosCount" class="rounded-full bg-white/10 px-1.5 py-0.5 text-[11px] text-gray-300 tabular-nums">
+                    <span class="text-muted-foreground text-xs">{{ category.category }}</span>
+                    <span v-if="category.videosCount" class="bg-muted text-foreground rounded-full px-1.5 py-0.5 text-[11px] tabular-nums">
                         {{ category.videosCount }}
                     </span>
                 </Link>

--- a/resources/js/pages/SeriesDetail.vue
+++ b/resources/js/pages/SeriesDetail.vue
@@ -43,20 +43,20 @@ const positionFor = (episode, index) => episode.number ?? props.page_start + ind
             </div>
             <div class="min-w-0">
                 <p class="text-primary text-xs font-semibold tracking-[0.12em] uppercase">Series</p>
-                <h1 class="font-display mt-1 text-2xl leading-tight font-bold text-gray-50 sm:text-3xl">{{ series_meta.name }}</h1>
-                <p class="mt-2 text-sm text-gray-500 tabular-nums">
+                <h1 class="font-display text-foreground mt-1 text-2xl leading-tight font-bold sm:text-3xl">{{ series_meta.name }}</h1>
+                <p class="text-muted-foreground mt-2 text-sm tabular-nums">
                     {{ series_meta.videosCount }} {{ series_meta.videosCount === 1 ? 'episode' : 'episodes' }}
                     <template v-if="totalRuntime()"> · {{ totalRuntime() }}</template>
                     <template v-if="years()"> · {{ years() }}</template>
                 </p>
-                <p v-if="series_meta.summary" class="mt-3 max-w-prose text-[15px] leading-relaxed text-gray-400">
+                <p v-if="series_meta.summary" class="text-muted-foreground mt-3 max-w-prose text-[15px] leading-relaxed">
                     {{ series_meta.summary }}
                 </p>
                 <Link
                     v-if="start_url"
                     :href="start_url"
                     prefetch
-                    class="bg-primary text-primary-foreground focus-visible:ring-ring hover:bg-primary/90 mt-4 inline-flex min-h-11 items-center gap-2 rounded-lg px-5 text-sm font-semibold transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+                    class="bg-primary text-primary-foreground focus-visible:ring-ring hover:bg-primary/90 focus-visible:ring-offset-background mt-4 inline-flex min-h-11 items-center gap-2 rounded-lg px-5 text-sm font-semibold transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                 >
                     <IconPlayerPlayFilled class="h-4 w-4" aria-hidden="true" />
                     Start from the beginning

--- a/resources/js/pages/SeriesIndex.vue
+++ b/resources/js/pages/SeriesIndex.vue
@@ -25,21 +25,24 @@ const submitFilter = () => {
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
         <div class="flex flex-wrap items-end justify-between gap-4">
             <div>
-                <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Series</h1>
-                <p class="mt-2 text-sm text-gray-500 tabular-nums">
+                <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Series</h1>
+                <p class="text-muted-foreground mt-2 text-sm tabular-nums">
                     {{ total }} series{{ query ? ` matching “${query}”` : '' }}, most episodes first
                 </p>
             </div>
             <form @submit.prevent="submitFilter" class="w-full sm:w-72">
                 <label class="sr-only" for="series-filter">Filter series</label>
                 <div class="relative">
-                    <IconSearch class="pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-gray-500" aria-hidden="true" />
+                    <IconSearch
+                        class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2"
+                        aria-hidden="true"
+                    />
                     <input
                         id="series-filter"
                         v-model="filter"
                         type="search"
                         placeholder="Filter series…"
-                        class="focus:ring-ring h-11 w-full rounded-lg border border-white/10 bg-white/5 pr-3 pl-9 text-base text-gray-100 transition-colors duration-150 placeholder:text-gray-500 focus:bg-white/10 focus:ring-2 focus:outline-none"
+                        class="focus:ring-ring border-border bg-muted text-foreground placeholder:text-muted-foreground focus:bg-accent h-11 w-full rounded-lg border pr-3 pl-9 text-base transition-colors duration-150 focus:ring-2 focus:outline-none"
                     />
                 </div>
             </form>
@@ -48,7 +51,7 @@ const submitFilter = () => {
         <div class="mt-8 grid gap-5 sm:grid-cols-2">
             <SeriesCard v-for="entry in series" :key="entry.url" :series="entry" />
         </div>
-        <p v-if="!series.length" class="mt-12 text-center text-sm text-gray-500">No series match “{{ query }}”.</p>
+        <p v-if="!series.length" class="text-muted-foreground mt-12 text-center text-sm">No series match “{{ query }}”.</p>
 
         <div class="mt-10">
             <PaginationNav :has-prev-page="has_prev_page" :has-next-page="has_next_page" />

--- a/resources/js/pages/Services.vue
+++ b/resources/js/pages/Services.vue
@@ -51,7 +51,7 @@ const formatSchedule = (iso) => {
                 Live now
             </h2>
             <div class="mt-4 grid gap-6" :class="live.length > 1 ? 'lg:grid-cols-2' : ''">
-                <div v-for="stream in live" :key="stream.video_id" class="border-primary/40 bg-muted overflow-hidden rounded-xl border">
+                <div v-for="stream in live" :key="stream.video_id" class="border-primary/40 bg-card overflow-hidden rounded-xl border">
                     <div v-if="watching.has(stream.video_id)" class="aspect-video w-full bg-black">
                         <iframe
                             class="h-full w-full"
@@ -89,7 +89,7 @@ const formatSchedule = (iso) => {
         <section v-if="upcoming.length" v-bind="entrance(80)" class="mt-12" aria-label="Upcoming services">
             <h2 class="text-muted-foreground text-sm font-semibold tracking-wider uppercase">Coming up</h2>
             <ul class="mt-4 grid gap-4 sm:grid-cols-2">
-                <li v-for="stream in upcoming" :key="stream.video_id" class="border-border bg-muted rounded-xl border p-5">
+                <li v-for="stream in upcoming" :key="stream.video_id" class="border-border bg-card rounded-xl border p-5">
                     <p class="font-display text-foreground text-base leading-snug font-bold">{{ stream.title }}</p>
                     <p class="text-foreground mt-1.5 text-sm tabular-nums">{{ formatSchedule(stream.scheduled_start) }}</p>
                     <p class="text-muted-foreground mt-1 text-xs">The stream will appear here when it starts.</p>

--- a/resources/js/pages/Services.vue
+++ b/resources/js/pages/Services.vue
@@ -36,8 +36,8 @@ const formatSchedule = (iso) => {
 <template>
     <Head :title="title" />
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
-        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Services</h1>
-        <p class="mt-2 text-sm text-gray-500">Watch live, see what's coming up, or catch up on a past service.</p>
+        <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Services</h1>
+        <p class="text-muted-foreground mt-2 text-sm">Watch live, see what's coming up, or catch up on a past service.</p>
 
         <!-- LIVE NOW — the most important thing on the page when present -->
         <section v-if="live.length" v-bind="entrance(0)" class="mt-8" aria-label="Live now">
@@ -51,7 +51,7 @@ const formatSchedule = (iso) => {
                 Live now
             </h2>
             <div class="mt-4 grid gap-6" :class="live.length > 1 ? 'lg:grid-cols-2' : ''">
-                <div v-for="stream in live" :key="stream.video_id" class="border-primary/40 overflow-hidden rounded-xl border bg-white/[0.03]">
+                <div v-for="stream in live" :key="stream.video_id" class="border-primary/40 bg-muted overflow-hidden rounded-xl border">
                     <div v-if="watching.has(stream.video_id)" class="aspect-video w-full bg-black">
                         <iframe
                             class="h-full w-full"
@@ -78,8 +78,8 @@ const formatSchedule = (iso) => {
                         </span>
                     </button>
                     <div class="p-4">
-                        <p class="font-display text-lg leading-snug font-bold text-gray-50">{{ stream.title }}</p>
-                        <p v-if="stream.channel" class="mt-1 text-sm text-gray-400">{{ stream.channel }}</p>
+                        <p class="font-display text-foreground text-lg leading-snug font-bold">{{ stream.title }}</p>
+                        <p v-if="stream.channel" class="text-muted-foreground mt-1 text-sm">{{ stream.channel }}</p>
                     </div>
                 </div>
             </div>
@@ -87,19 +87,19 @@ const formatSchedule = (iso) => {
 
         <!-- UPCOMING — real scheduled services -->
         <section v-if="upcoming.length" v-bind="entrance(80)" class="mt-12" aria-label="Upcoming services">
-            <h2 class="text-sm font-semibold tracking-wider text-gray-400 uppercase">Coming up</h2>
+            <h2 class="text-muted-foreground text-sm font-semibold tracking-wider uppercase">Coming up</h2>
             <ul class="mt-4 grid gap-4 sm:grid-cols-2">
-                <li v-for="stream in upcoming" :key="stream.video_id" class="rounded-xl border border-white/10 bg-white/[0.03] p-5">
-                    <p class="font-display text-base leading-snug font-bold text-gray-50">{{ stream.title }}</p>
-                    <p class="mt-1.5 text-sm text-gray-300 tabular-nums">{{ formatSchedule(stream.scheduled_start) }}</p>
-                    <p class="mt-1 text-xs text-gray-500">The stream will appear here when it starts.</p>
+                <li v-for="stream in upcoming" :key="stream.video_id" class="border-border bg-muted rounded-xl border p-5">
+                    <p class="font-display text-foreground text-base leading-snug font-bold">{{ stream.title }}</p>
+                    <p class="text-foreground mt-1.5 text-sm tabular-nums">{{ formatSchedule(stream.scheduled_start) }}</p>
+                    <p class="text-muted-foreground mt-1 text-xs">The stream will appear here when it starts.</p>
                 </li>
             </ul>
         </section>
 
         <!-- PAST — the archive, lower down / "catch up" -->
         <section v-bind="entrance(160)" class="mt-12" aria-label="Past services">
-            <h2 class="text-sm font-semibold tracking-wider text-gray-400 uppercase">
+            <h2 class="text-muted-foreground text-sm font-semibold tracking-wider uppercase">
                 {{ live.length || upcoming.length ? 'Catch up on past services' : 'Past services' }}
             </h2>
             <div class="mt-4">

--- a/resources/js/pages/SpeakerDetail.vue
+++ b/resources/js/pages/SpeakerDetail.vue
@@ -36,18 +36,20 @@ const initials = (name) =>
             </span>
             <div>
                 <p class="text-primary text-xs font-semibold tracking-[0.12em] uppercase">Speaker</p>
-                <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">{{ speaker.name }}</h1>
-                <p class="mt-1 text-sm text-gray-500 tabular-nums">{{ speaker.talksCount }} {{ speaker.talksCount === 1 ? 'talk' : 'talks' }}</p>
+                <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">{{ speaker.name }}</h1>
+                <p class="text-muted-foreground mt-1 text-sm tabular-nums">
+                    {{ speaker.talksCount }} {{ speaker.talksCount === 1 ? 'talk' : 'talks' }}
+                </p>
             </div>
         </header>
 
-        <p v-if="speaker.bio" class="mt-5 max-w-prose text-[15px] leading-relaxed text-gray-400">{{ speaker.bio }}</p>
+        <p v-if="speaker.bio" class="text-muted-foreground mt-5 max-w-prose text-[15px] leading-relaxed">{{ speaker.bio }}</p>
 
         <Deferred data="series">
             <template #fallback>
                 <section class="mt-12" aria-label="Series">
-                    <Skeleton class="h-7 w-56 bg-white/5" />
-                    <div class="mt-5 grid gap-5 sm:grid-cols-2"><Skeleton v-for="n in 2" :key="n" class="h-28 rounded-xl bg-white/5" /></div>
+                    <Skeleton class="bg-muted h-7 w-56" />
+                    <div class="mt-5 grid gap-5 sm:grid-cols-2"><Skeleton v-for="n in 2" :key="n" class="bg-muted h-28 rounded-xl" /></div>
                 </section>
             </template>
             <section v-if="series?.length" class="mt-12" aria-label="Series">
@@ -65,7 +67,7 @@ const initials = (name) =>
                     <Link
                         :href="`/video/${video.id}`"
                         prefetch
-                        class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                        class="focus-visible:ring-ring focus-visible:ring-offset-background block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                     >
                         <VideoCardItem :video="video" />
                         <span class="sr-only">View video for {{ video.name }}</span>

--- a/resources/js/pages/SpeakersIndex.vue
+++ b/resources/js/pages/SpeakersIndex.vue
@@ -39,18 +39,21 @@ const initials = (name) =>
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
         <!-- Lookup-first: the search IS the hero. Nobody scans 662 names. -->
         <div class="mx-auto max-w-xl text-center">
-            <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Speakers</h1>
-            <p class="mt-2 text-sm text-gray-500 tabular-nums">Find any of the {{ total }} speakers on Clayton TV</p>
+            <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Speakers</h1>
+            <p class="text-muted-foreground mt-2 text-sm tabular-nums">Find any of the {{ total }} speakers on Clayton TV</p>
             <form @submit.prevent="submit" class="mt-5">
                 <label class="sr-only" for="speaker-search">Search speakers</label>
                 <div class="relative">
-                    <IconSearch class="pointer-events-none absolute top-1/2 left-4 h-5 w-5 -translate-y-1/2 text-gray-500" aria-hidden="true" />
+                    <IconSearch
+                        class="text-muted-foreground pointer-events-none absolute top-1/2 left-4 h-5 w-5 -translate-y-1/2"
+                        aria-hidden="true"
+                    />
                     <input
                         id="speaker-search"
                         v-model="filter"
                         type="search"
                         placeholder="Search by name…"
-                        class="focus:ring-ring h-13 w-full rounded-xl border border-white/10 bg-white/5 pr-4 pl-12 text-base text-gray-100 transition-colors duration-150 placeholder:text-gray-500 focus:bg-white/10 focus:ring-2 focus:outline-none"
+                        class="focus:ring-ring border-border bg-muted text-foreground placeholder:text-muted-foreground focus:bg-accent h-13 w-full rounded-xl border pr-4 pl-12 text-base transition-colors duration-150 focus:ring-2 focus:outline-none"
                     />
                 </div>
             </form>
@@ -59,12 +62,12 @@ const initials = (name) =>
         <!-- Lookup results -->
         <section v-if="query" class="mt-10" aria-label="Results">
             <div class="flex items-baseline justify-between">
-                <h2 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">
+                <h2 class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">
                     {{ results.length }} {{ results.length === 1 ? 'match' : 'matches' }} for “{{ query }}”
                 </h2>
                 <button
                     @click="clear"
-                    class="focus-visible:ring-ring inline-flex items-center gap-1 rounded text-xs font-medium text-gray-400 outline-none hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring text-muted-foreground hover:text-foreground inline-flex items-center gap-1 rounded text-xs font-medium outline-none focus-visible:ring-2"
                 >
                     <IconX class="h-3.5 w-3.5" aria-hidden="true" /> Clear
                 </button>
@@ -74,7 +77,7 @@ const initials = (name) =>
                     <Link
                         :href="speaker.url"
                         prefetch
-                        class="focus-visible:ring-ring flex items-center gap-3.5 rounded-xl border border-white/10 bg-white/[0.03] p-3.5 transition-colors duration-150 outline-none hover:border-white/20 hover:bg-white/[0.06] focus-visible:ring-2"
+                        class="focus-visible:ring-ring border-border bg-muted hover:border-ring hover:bg-accent flex items-center gap-3.5 rounded-xl border p-3.5 transition-colors duration-150 outline-none focus-visible:ring-2"
                     >
                         <span
                             class="bg-primary/10 text-primary flex h-11 w-11 flex-none items-center justify-center rounded-full text-sm font-semibold"
@@ -83,15 +86,15 @@ const initials = (name) =>
                             {{ initials(speaker.name) }}
                         </span>
                         <span class="min-w-0">
-                            <span class="block truncate text-[15px] font-medium text-gray-100">{{ speaker.name }}</span>
-                            <span class="block text-xs text-gray-500 tabular-nums">
+                            <span class="text-foreground block truncate text-[15px] font-medium">{{ speaker.name }}</span>
+                            <span class="text-muted-foreground block text-xs tabular-nums">
                                 {{ speaker.videosCount }} {{ speaker.videosCount === 1 ? 'talk' : 'talks' }}
                             </span>
                         </span>
                     </Link>
                 </li>
             </ul>
-            <p v-if="!results.length" class="mt-10 text-center text-sm text-gray-500">No speakers match “{{ query }}”.</p>
+            <p v-if="!results.length" class="text-muted-foreground mt-10 text-center text-sm">No speakers match “{{ query }}”.</p>
         </section>
 
         <template v-else>
@@ -104,7 +107,7 @@ const initials = (name) =>
                         :key="speaker.url"
                         :href="speaker.url"
                         prefetch
-                        class="focus-visible:ring-ring flex items-center gap-4 rounded-xl border border-white/10 bg-white/[0.03] p-4 transition-colors duration-150 outline-none hover:border-white/20 hover:bg-white/[0.06] focus-visible:ring-2"
+                        class="focus-visible:ring-ring border-border bg-muted hover:border-ring hover:bg-accent flex items-center gap-4 rounded-xl border p-4 transition-colors duration-150 outline-none focus-visible:ring-2"
                     >
                         <span
                             class="bg-primary/10 text-primary flex h-14 w-14 flex-none items-center justify-center rounded-full text-lg font-semibold"
@@ -113,8 +116,8 @@ const initials = (name) =>
                             {{ initials(speaker.name) }}
                         </span>
                         <span class="min-w-0">
-                            <span class="block truncate text-[15px] font-semibold text-gray-50">{{ speaker.name }}</span>
-                            <span class="block text-xs text-gray-500 tabular-nums">
+                            <span class="text-foreground block truncate text-[15px] font-semibold">{{ speaker.name }}</span>
+                            <span class="text-muted-foreground block text-xs tabular-nums">
                                 {{ speaker.videosCount }} talks<template v-if="speaker.knownFor"> · known for {{ speaker.knownFor }}</template>
                             </span>
                         </span>
@@ -126,24 +129,24 @@ const initials = (name) =>
             <WhenVisible data="all_speakers" :buffer="300">
                 <template #fallback>
                     <section class="mt-14" aria-label="All speakers">
-                        <Skeleton class="h-7 w-48 bg-white/5" />
+                        <Skeleton class="bg-muted h-7 w-48" />
                         <div class="mt-5 grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-                            <Skeleton v-for="n in 12" :key="n" class="h-5 w-36 bg-white/5" />
+                            <Skeleton v-for="n in 12" :key="n" class="bg-muted h-5 w-36" />
                         </div>
                     </section>
                 </template>
                 <section class="mt-14" aria-label="All speakers">
                     <SectionHeading title="All speakers A–Z" />
                     <div v-for="group in all_speakers || []" :key="group.letter" class="mt-6">
-                        <h3 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">{{ group.letter }}</h3>
+                        <h3 class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">{{ group.letter }}</h3>
                         <ul class="mt-2 grid grid-cols-1 gap-x-6 gap-y-1.5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                             <li v-for="speaker in group.speakers" :key="speaker.url" class="min-w-0">
                                 <Link
                                     :href="speaker.url"
-                                    class="focus-visible:ring-ring inline-flex max-w-full items-baseline gap-1.5 rounded text-sm text-gray-300 outline-none hover:text-white hover:underline focus-visible:ring-2"
+                                    class="focus-visible:ring-ring text-foreground hover:text-foreground inline-flex max-w-full items-baseline gap-1.5 rounded text-sm outline-none hover:underline focus-visible:ring-2"
                                 >
                                     <span class="truncate">{{ speaker.name }}</span>
-                                    <span class="shrink-0 text-xs text-gray-600 tabular-nums">{{ speaker.videosCount }}</span>
+                                    <span class="text-muted-foreground shrink-0 text-xs tabular-nums">{{ speaker.videosCount }}</span>
                                 </Link>
                             </li>
                         </ul>

--- a/resources/js/pages/SpeakersIndex.vue
+++ b/resources/js/pages/SpeakersIndex.vue
@@ -77,7 +77,7 @@ const initials = (name) =>
                     <Link
                         :href="speaker.url"
                         prefetch
-                        class="focus-visible:ring-ring border-border bg-muted hover:border-ring hover:bg-accent flex items-center gap-3.5 rounded-xl border p-3.5 transition-colors duration-150 outline-none focus-visible:ring-2"
+                        class="focus-visible:ring-ring border-border bg-card hover:border-ring hover:bg-accent flex items-center gap-3.5 rounded-xl border p-3.5 transition-colors duration-150 outline-none focus-visible:ring-2"
                     >
                         <span
                             class="bg-primary/10 text-primary flex h-11 w-11 flex-none items-center justify-center rounded-full text-sm font-semibold"
@@ -107,7 +107,7 @@ const initials = (name) =>
                         :key="speaker.url"
                         :href="speaker.url"
                         prefetch
-                        class="focus-visible:ring-ring border-border bg-muted hover:border-ring hover:bg-accent flex items-center gap-4 rounded-xl border p-4 transition-colors duration-150 outline-none focus-visible:ring-2"
+                        class="focus-visible:ring-ring border-border bg-card hover:border-ring hover:bg-accent flex items-center gap-4 rounded-xl border p-4 transition-colors duration-150 outline-none focus-visible:ring-2"
                     >
                         <span
                             class="bg-primary/10 text-primary flex h-14 w-14 flex-none items-center justify-center rounded-full text-lg font-semibold"

--- a/resources/js/pages/TopicsIndex.vue
+++ b/resources/js/pages/TopicsIndex.vue
@@ -14,33 +14,33 @@ const prettify = (category) => category.toLowerCase();
 <template>
     <Head title="Topics" />
     <div class="mx-auto max-w-6xl px-4 py-10 lg:px-8">
-        <h1 class="font-display text-2xl font-bold text-gray-50 sm:text-3xl">Topics</h1>
-        <p class="mt-2 text-sm text-gray-500 tabular-nums">{{ total }} topics across {{ topic_groups.length }} areas</p>
+        <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Topics</h1>
+        <p class="text-muted-foreground mt-2 text-sm tabular-nums">{{ total }} topics across {{ topic_groups.length }} areas</p>
 
         <!-- Audiences have their own area now; a calm pointer, not the old fold-in -->
         <Link
             href="/audience/"
-            class="focus-visible:ring-ring mt-6 flex items-center justify-between gap-3 rounded-xl border border-white/10 bg-white/[0.03] px-5 py-4 transition-colors duration-150 outline-none hover:border-white/20 focus-visible:ring-2"
+            class="focus-visible:ring-ring border-border bg-muted hover:border-ring mt-6 flex items-center justify-between gap-3 rounded-xl border px-5 py-4 transition-colors duration-150 outline-none focus-visible:ring-2"
         >
             <span>
-                <span class="font-display block text-base font-bold text-gray-100">Looking for Kids, Youth or Adults?</span>
-                <span class="mt-0.5 block text-sm text-gray-400">Browse teaching for every age</span>
+                <span class="font-display text-foreground block text-base font-bold">Looking for Kids, Youth or Adults?</span>
+                <span class="text-muted-foreground mt-0.5 block text-sm">Browse teaching for every age</span>
             </span>
             <IconArrowRight class="text-primary h-5 w-5 shrink-0" aria-hidden="true" />
         </Link>
 
         <section v-for="group in topic_groups" :key="group.category" class="mt-10" :aria-label="group.category">
-            <h2 class="text-xs font-semibold tracking-wider text-gray-500 uppercase">{{ prettify(group.category) }}</h2>
+            <h2 class="text-muted-foreground text-xs font-semibold tracking-wider uppercase">{{ prettify(group.category) }}</h2>
             <div class="mt-3 flex flex-wrap gap-2.5">
                 <Link
                     v-for="topic in group.topics"
                     :key="topic.url"
                     :href="topic.url"
                     prefetch
-                    class="focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-full border border-white/15 px-4 text-[13px] text-gray-300 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring border-input text-muted-foreground hover:border-ring hover:text-foreground inline-flex min-h-11 items-center gap-2 rounded-full border px-4 text-[13px] transition-colors duration-150 outline-none focus-visible:ring-2"
                 >
                     <span>{{ topic.name }}</span>
-                    <span v-if="topic.videosCount" class="rounded-full bg-white/10 px-1.5 py-0.5 text-[11px] text-gray-400 tabular-nums">
+                    <span v-if="topic.videosCount" class="bg-muted text-muted-foreground rounded-full px-1.5 py-0.5 text-[11px] tabular-nums">
                         {{ topic.videosCount }}
                     </span>
                 </Link>

--- a/resources/js/pages/WatchVideo.vue
+++ b/resources/js/pages/WatchVideo.vue
@@ -87,7 +87,7 @@ const entries = (key) => {
         <div ref="placeholderEl" class="aspect-video w-full rounded-xl bg-black" aria-hidden="true"></div>
 
         <!-- Quiet note when playback picked up where the viewer left off -->
-        <p v-if="resumedFrom" class="mt-3 flex items-center gap-2 text-sm text-gray-400">
+        <p v-if="resumedFrom" class="text-muted-foreground mt-3 flex items-center gap-2 text-sm">
             <span class="tabular-nums">Resuming from {{ formatTime(resumedFrom) }}</span>
             <button
                 @click="startOver"
@@ -100,7 +100,7 @@ const entries = (key) => {
 
         <div class="mt-6">
             <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
-                <h1 class="font-display text-2xl leading-tight font-bold text-gray-50 sm:text-3xl">{{ video.name }}</h1>
+                <h1 class="font-display text-foreground text-2xl leading-tight font-bold sm:text-3xl">{{ video.name }}</h1>
                 <Link
                     v-if="passage"
                     :href="passage.url"
@@ -110,12 +110,12 @@ const entries = (key) => {
                     <IconBook class="h-4 w-4" aria-hidden="true" />
                     {{ passage.label }}
                 </Link>
-                <span v-if="video.is_livestream" class="rounded bg-white/10 px-2 py-0.5 text-xs font-bold tracking-wide text-gray-300 uppercase">
+                <span v-if="video.is_livestream" class="bg-muted text-muted-foreground rounded px-2 py-0.5 text-xs font-bold tracking-wide uppercase">
                     Streamed
                 </span>
             </div>
             <div class="mt-2 flex flex-wrap items-center justify-between gap-3">
-                <p class="text-sm text-gray-500 tabular-nums">
+                <p class="text-muted-foreground text-sm tabular-nums">
                     {{ video.date_recorded ? `Recorded ${video.date_recorded}` : `Added ${video.date_created}` }}
                     <template v-if="formatDuration(video.duration_seconds)"> · {{ formatDuration(video.duration_seconds) }}</template>
                 </p>
@@ -125,13 +125,13 @@ const entries = (key) => {
             <div class="mt-5 space-y-3">
                 <template v-for="group in metaGroups" :key="group.key">
                     <div v-if="entries(group.key).length" class="flex flex-wrap items-baseline gap-2">
-                        <span class="w-24 shrink-0 text-xs font-medium tracking-wider text-gray-500 uppercase">{{ group.label }}</span>
+                        <span class="text-muted-foreground w-24 shrink-0 text-xs font-medium tracking-wider uppercase">{{ group.label }}</span>
                         <Link
                             v-for="entry in entries(group.key)"
                             :key="entry.url"
                             :href="entry.url"
                             prefetch
-                            class="focus-visible:ring-ring inline-flex min-h-9 items-center rounded-full border border-white/10 px-3.5 text-[13px] text-gray-300 transition-colors duration-150 outline-none hover:border-white/25 hover:text-white focus-visible:ring-2"
+                            class="focus-visible:ring-ring border-border text-muted-foreground hover:border-ring hover:text-foreground inline-flex min-h-9 items-center rounded-full border px-3.5 text-[13px] transition-colors duration-150 outline-none focus-visible:ring-2"
                         >
                             {{ entry.name }}
                         </Link>
@@ -139,7 +139,7 @@ const entries = (key) => {
                 </template>
             </div>
 
-            <p v-if="video.description" class="mt-6 max-w-prose text-[15px] leading-relaxed text-gray-400" v-html="video.description"></p>
+            <p v-if="video.description" class="text-muted-foreground mt-6 max-w-prose text-[15px] leading-relaxed" v-html="video.description"></p>
 
             <!-- Rescued companion links (transcripts/audio on partner sites) -->
             <div v-if="resources.length" class="mt-6 flex flex-wrap gap-3">
@@ -149,7 +149,7 @@ const entries = (key) => {
                     :href="resource.url"
                     rel="noopener"
                     target="_blank"
-                    class="focus-visible:ring-ring inline-flex min-h-11 items-center gap-2 rounded-lg border border-white/15 px-4 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2"
+                    class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground inline-flex min-h-11 items-center gap-2 rounded-lg border px-4 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2"
                 >
                     <component :is="(resourceMeta[resource.kind] || resourceMeta.other).icon" class="h-4 w-4" aria-hidden="true" />
                     {{ (resourceMeta[resource.kind] || resourceMeta.other).label }}
@@ -160,9 +160,9 @@ const entries = (key) => {
         <Deferred data="up_next">
             <template #fallback>
                 <section class="mt-12" aria-label="More in this series">
-                    <Skeleton class="h-7 w-64 bg-white/5" />
+                    <Skeleton class="bg-muted h-7 w-64" />
                     <div class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3">
-                        <Skeleton v-for="n in 3" :key="n" class="aspect-video rounded-lg bg-white/5" />
+                        <Skeleton v-for="n in 3" :key="n" class="bg-muted aspect-video rounded-lg" />
                     </div>
                 </section>
             </template>
@@ -174,7 +174,7 @@ const entries = (key) => {
                         <Link
                             :href="`/video/${item.id}`"
                             prefetch
-                            class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                            class="focus-visible:ring-ring focus-visible:ring-offset-background block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                         >
                             <VideoCardItem :video="item" />
                             <span class="sr-only">View video for {{ item.name }}</span>

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -91,7 +91,7 @@ const { entrance } = useEntrance();
                     :key="tile.href"
                     :href="tile.href"
                     prefetch
-                    class="group focus-visible:ring-ring border-border bg-muted hover:border-ring hover:bg-accent flex flex-col items-center justify-center gap-2 rounded-xl border px-3 py-6 text-center transition-colors duration-150 outline-none focus-visible:ring-2"
+                    class="group focus-visible:ring-ring border-border bg-card hover:border-ring hover:bg-accent flex flex-col items-center justify-center gap-2 rounded-xl border px-3 py-6 text-center transition-colors duration-150 outline-none focus-visible:ring-2"
                 >
                     <component :is="tile.icon" class="text-primary h-7 w-7" aria-hidden="true" />
                     <span class="text-foreground text-sm font-medium">{{ tile.label }}</span>

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -38,23 +38,23 @@ const { entrance } = useEntrance();
         <section class="grid items-center gap-10 py-14 sm:py-20 lg:grid-cols-[1.3fr_1fr]" aria-label="Welcome">
             <div v-bind="entrance(0)">
                 <p class="text-primary text-xs font-semibold tracking-[0.12em] uppercase">Christian media you can trust</p>
-                <h1 class="font-display mt-3 text-4xl leading-[1.15] font-bold text-gray-50 sm:text-5xl">
+                <h1 class="font-display text-foreground mt-3 text-4xl leading-[1.15] font-bold sm:text-5xl">
                     Teaching for every<br class="hidden sm:block" />
                     step of the journey
                 </h1>
-                <p class="mt-4 max-w-md text-base leading-relaxed text-gray-400">
+                <p class="text-muted-foreground mt-4 max-w-md text-base leading-relaxed">
                     Sermons, series and courses from churches and ministries you know — free, searchable, and always here.
                 </p>
                 <div class="mt-7 flex flex-wrap gap-3">
                     <Link
                         :href="latestVideoUrl"
-                        class="bg-primary text-primary-foreground focus-visible:ring-ring hover:bg-primary/90 inline-flex min-h-12 items-center rounded-lg px-5 text-sm font-semibold transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950"
+                        class="bg-primary text-primary-foreground focus-visible:ring-ring hover:bg-primary/90 focus-visible:ring-offset-background inline-flex min-h-12 items-center rounded-lg px-5 text-sm font-semibold transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                     >
                         Watch latest sermon
                     </Link>
                     <Link
                         href="/series"
-                        class="focus-visible:ring-ring inline-flex min-h-12 items-center rounded-lg border border-white/15 px-5 text-sm font-medium text-gray-200 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2"
+                        class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground inline-flex min-h-12 items-center rounded-lg border px-5 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2"
                     >
                         Browse series
                     </Link>
@@ -72,7 +72,7 @@ const { entrance } = useEntrance();
                     <Link
                         :href="`/video/${video.id}`"
                         prefetch
-                        class="focus-visible:ring-ring block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-gray-950 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+                        class="focus-visible:ring-ring focus-visible:ring-offset-background block h-full w-full rounded-lg transition-transform duration-200 ease-out outline-none hover:-translate-y-0.5 focus-visible:ring-2 focus-visible:ring-offset-2 motion-reduce:transition-none motion-reduce:hover:translate-y-0"
                     >
                         <VideoCardItem :video="video" />
                         <span class="sr-only">View video for {{ video.name }}</span>
@@ -91,10 +91,10 @@ const { entrance } = useEntrance();
                     :key="tile.href"
                     :href="tile.href"
                     prefetch
-                    class="group focus-visible:ring-ring flex flex-col items-center justify-center gap-2 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-6 text-center transition-colors duration-150 outline-none hover:border-white/25 hover:bg-white/[0.06] focus-visible:ring-2"
+                    class="group focus-visible:ring-ring border-border bg-muted hover:border-ring hover:bg-accent flex flex-col items-center justify-center gap-2 rounded-xl border px-3 py-6 text-center transition-colors duration-150 outline-none focus-visible:ring-2"
                 >
                     <component :is="tile.icon" class="text-primary h-7 w-7" aria-hidden="true" />
-                    <span class="text-sm font-medium text-gray-200">{{ tile.label }}</span>
+                    <span class="text-foreground text-sm font-medium">{{ tile.label }}</span>
                 </Link>
             </div>
         </section>
@@ -104,9 +104,9 @@ const { entrance } = useEntrance();
         <WhenVisible data="featured_series" :buffer="300">
             <template #fallback>
                 <section class="mt-14" aria-label="Featured series">
-                    <Skeleton class="h-8 w-56 bg-white/5" />
+                    <Skeleton class="bg-muted h-8 w-56" />
                     <div class="mt-5 grid gap-5 sm:grid-cols-2">
-                        <Skeleton v-for="n in 4" :key="n" class="h-28 rounded-xl bg-white/5" />
+                        <Skeleton v-for="n in 4" :key="n" class="bg-muted h-28 rounded-xl" />
                     </div>
                 </section>
             </template>
@@ -121,9 +121,9 @@ const { entrance } = useEntrance();
         <WhenVisible :data="['topics_data', 'topics_total']" :buffer="300">
             <template #fallback>
                 <section class="mt-14 pb-4" aria-label="Browse by topic">
-                    <Skeleton class="h-8 w-56 bg-white/5" />
+                    <Skeleton class="bg-muted h-8 w-56" />
                     <div class="mt-5 flex flex-wrap gap-2.5">
-                        <Skeleton v-for="n in 8" :key="n" class="h-11 w-28 rounded-full bg-white/5" />
+                        <Skeleton v-for="n in 8" :key="n" class="bg-muted h-11 w-28 rounded-full" />
                     </div>
                 </section>
             </template>
@@ -135,7 +135,7 @@ const { entrance } = useEntrance();
                         :key="topic.url"
                         :href="topic.url"
                         prefetch
-                        class="focus-visible:ring-ring inline-flex min-h-11 items-center rounded-full border border-white/15 px-4 text-[13px] text-gray-300 transition-colors duration-150 outline-none hover:border-white/30 hover:text-white focus-visible:ring-2"
+                        class="focus-visible:ring-ring border-input text-muted-foreground hover:border-ring hover:text-foreground inline-flex min-h-11 items-center rounded-full border px-4 text-[13px] transition-colors duration-150 outline-none focus-visible:ring-2"
                     >
                         {{ topic.name }}
                     </Link>

--- a/templates/app.html
+++ b/templates/app.html
@@ -24,11 +24,11 @@
 
     <style>
         html {
-            background-color: oklch(1 0 0);
+            background-color: oklch(0.985 0.004 264);
         }
 
         html.dark {
-            background-color: oklch(0.145 0 0);
+            background-color: oklch(0.17 0.018 264);
         }
     </style>
 

--- a/templates/app.html
+++ b/templates/app.html
@@ -10,19 +10,14 @@
     <meta content="width=device-width, initial-scale=1, viewport-fit=cover" name="viewport">
 
     <script>
-        // This script is used to detect the user's preferred color scheme and set the class on the html element.
+        // Set the colour scheme before first paint to avoid a flash. Mirrors
+        // resources/js/composables/useAppearance.ts (which takes over on mount).
         (function() {
-            // TODO: persist the user's choice in localStorage (via a util, likely called from a base layout)
             const appearance = localStorage.getItem('appearance') || 'system';
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-            if (appearance === 'system') {
-                // FIXME: Currently the light mode looks awful due to various hardcoded colours. Force dark mode for now until that is fixed. See also /resources/js/composables/useAppearance.ts
-                // const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-                const prefersDark = true;
-
-                if (prefersDark) {
-                    document.documentElement.classList.add('dark');
-                }
+            if (appearance === 'dark' || (appearance === 'system' && prefersDark)) {
+                document.documentElement.classList.add('dark');
             }
         })();
     </script>

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,25 @@
+"""Light mode (#30): the base template must honour the OS colour-scheme
+preference before first paint, not force dark. The per-component token
+migration is verified visually; this locks the no-force-dark regression."""
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def head_html(client):
+    return client.get("/").content.decode()
+
+
+def test_first_paint_follows_system_preference(client):
+    html = head_html(client)
+    # The pre-paint script must read the real OS preference...
+    assert "prefers-color-scheme: dark" in html
+    # ...and must NOT hard-force dark (the old FIXME stop-gap).
+    assert "const prefersDark = true" not in html
+
+
+def test_default_appearance_is_system(client):
+    # No stored choice → "system"; the script only adds .dark when the OS asks.
+    html = head_html(client)
+    assert "localStorage.getItem('appearance') || 'system'" in html


### PR DESCRIPTION
Closes the last deferred overhaul item (#30). Opening for review rather than auto-merging, since it repaints the signature dark surface.

## What's here
- **Light mode** across the app: the chrome colour utilities (`gray-*`/`white`/`black`) were migrated to the semantic tokens that define **both** themes. On-media surfaces (thumbnails, player, scrims) are deliberately left fixed.
- **Theme toggle** (Light · System · Dark), default **system**, persisted in localStorage + cookie. Surfaced in the footer (desktop) and mobile menu, **and** in the ⌘K palette.
- **Cohesive cool-grey palette**: both ramps rebuilt on a single cool hue (264) with real chroma — modern, not flat-neutral, pairing with the warm red. Authored in **OKLCH** so P3/wide-gamut displays render richer and sRGB clamps gracefully.
- **Command palette** gains Theme + Text-size controls (active theme ticked, live text-size %); applying keeps the palette open.
- **Fixes from review:** palette close ✕ re-centred on the search row; Browse sidebar is now a sticky, full-height single scroll region (no dead space) with a slim always-visible scrollbar.

## Verified
- Both themes in-browser: home, faceted browse (sticky sidebar), topics, watch, command palette. Thumbnails/player stay dark in light mode by design.
- 175 backend tests pass; `npm run build-only` green; ruff clean. `tests/test_theme.py` locks the no-force-dark regression.

## Review notes (token judgment calls)
- `bg-white/[0.03]` card frames map inconsistently across a couple of card components (`bg-card` vs `bg-muted`) — harmonise if you have a preference.
- Inactive category/browse pills keep `text-foreground` on a red hover — check that hover's contrast in light mode.
- Palette search matches visible label text, so "text size" only surfaces "Reset…"; "larger"/"smaller"/"theme"/"dark" all work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)