### PR TITLE
Hotfix: beta asset 404s + watch-page 500

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -326,7 +326,19 @@ def video(request, id):
             request,
             "WatchVideo",
             {
-                "video": video_object,
+                # A plain dict, never the model: serializing a Video follows its
+                # M2M relations (series → demographic → video → …) and recurses
+                # forever under SSR. Mirror video_card_props' raw-field approach.
+                "video": {
+                    "id": video_object.id,
+                    "name": video_object.name,
+                    "url": video_object.url,
+                    "description": video_object.description,
+                    "date_recorded": video_object.date_recorded,
+                    "date_created": video_object.date_created,
+                    "duration_seconds": video_object.duration_seconds,
+                    "is_livestream": video_object.is_livestream,
+                },
                 "video_metadata": video_metadata,
                 "passage": passage_badge,
                 "resources": resources,

--- a/tests/test_watch_video.py
+++ b/tests/test_watch_video.py
@@ -20,6 +20,19 @@ def test_watch_page_renders_video_with_metadata(client):
     assert page["component"] == "WatchVideo"
 
     props = page["props"]
+    # `video` must be a plain dict of scalar fields, never the Video model:
+    # serializing the model walks its M2M relations into an infinite
+    # Video → series → demographic → video cycle (crashes on real data).
+    assert set(props["video"]) == {
+        "id",
+        "name",
+        "url",
+        "description",
+        "date_recorded",
+        "date_created",
+        "duration_seconds",
+        "is_livestream",
+    }
     assert props["video"]["name"] == "The Word Became Flesh"
     metadata = props["video_metadata"]
     assert metadata["series"]["name"] == "John's Gospel"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,11 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, process.cwd());
 
     return {
-        base: '/static/',
+        // Runtime-imported chunks (lazy pages, dynamic icons) resolve against
+        // `base`. In production collectstatic serves the Vite output under
+        // /static/build/ (django-vite static_url_prefix="build"), so the base
+        // must match or those chunks 404. Dev serves from the Vite dev server.
+        base: mode === 'production' ? '/static/build/' : '/static/',
         publicDir: false,
         build: {
             manifest: 'manifest.json',


### PR DESCRIPTION
Two latent production bugs surfaced on beta (both masked locally / by acyclic test data).

### 1. Lazy-chunk 404s broke client navigation
Vite `base` was `/static/`, but in production collectstatic serves the build under `/static/build/` (django-vite `static_url_prefix="build"`). The entry bundle loaded fine (django-vite emits the correct URL) but **runtime dynamic imports** (lazy page components, dynamic icons) resolved to `/static/assets/*` → 404. Set production `base` to `/static/build/`; dev unchanged.

Confirmed on the server: `staticfiles_collected/build/assets/` has the files; `/static/assets/SeriesDetail-*.js` → 404, `/static/build/assets/SeriesDetail-*.js` → 200.

### 2. `/video/<id>` returned 500
The view passed the **full `Video` model** as an Inertia prop. Serializing it walks the M2M relations into an infinite `Video → series → demographic → video` cycle (Sentry **CLAYTONTV-6** / #215). Now passes a plain dict of the 8 scalar fields `WatchVideo.vue` uses, mirroring `video_card_props`. A test locks the prop shape so the model can't creep back.

### Verification
- 175 backend tests pass (incl. the new shape assertion); `npm run build-only` green and the built bundle references `/static/build/` for chunks.

Closes #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)