### PR TITLE
Guardrail: strict Inertia prop encoder + auto-close issues on beta merge

### DIFF
--- a/.github/workflows/close-issues-on-beta-merge.yaml
+++ b/.github/workflows/close-issues-on-beta-merge.yaml
@@ -1,0 +1,41 @@
+name: Close linked issues on beta merge
+
+# We deploy from `beta`, but GitHub only auto-closes issues referenced by
+# closing keywords when a PR merges into the DEFAULT branch (`main`). This
+# replicates that behaviour for `beta`: when a PR merges, any
+# "Closes/Fixes/Resolves #N" in its body is closed with a note.
+on:
+  pull_request:
+    types: [closed]
+    branches: [beta]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close issues referenced by closing keywords
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # GitHub's closing keywords: close(s|d), fix(es|ed), resolve(s|d).
+          numbers=$(printf '%s' "$BODY" \
+            | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' | sort -u)
+          if [ -z "$numbers" ]; then
+            echo "No closing keywords in PR #$PR body — nothing to close."
+            exit 0
+          fi
+          for n in $numbers; do
+            echo "Closing #$n (deployed to beta via #$PR)"
+            gh issue close "$n" --repo "$REPO" \
+              -c "Resolved and deployed to **beta** via #$PR. (Auto-closed on beta merge — \`main\` is the default branch, so GitHub's keyword-closing doesn't fire for beta.)" \
+              || echo "Skipped #$n (already closed, or it's a PR/cross-repo ref)."
+          done

--- a/app/base_settings.py
+++ b/app/base_settings.py
@@ -88,6 +88,11 @@ STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles_collected"
 
 INERTIA_LAYOUT = "app.html"
+# Fail loud if a view passes a raw model/queryset as a prop (see the encoder
+# docstring): the default encoder would recurse on our cyclic relations.
+from app.inertia_encoder import StrictInertiaJsonEncoder  # noqa: E402
+
+INERTIA_JSON_ENCODER = StrictInertiaJsonEncoder
 
 DJANGO_VITE = {
     "default": {

--- a/app/inertia_encoder.py
+++ b/app/inertia_encoder.py
@@ -1,0 +1,36 @@
+"""Strict Inertia prop encoder — fail loud on raw Django models.
+
+inertia-django's default encoder expands a `Model` prop via `model_to_dict`,
+which follows the model's relations. Our catalogue data is cyclic
+(Video → series → demographic → video → …), so that recurses until the worker
+crashes — a silent, catastrophic 500 (Sentry CLAYTONTV-6).
+
+Props must be plain JSON-able data: build them explicitly (e.g.
+`app.cards.video_card_props`). This encoder turns an *accidental* model/queryset
+prop into an immediate, descriptive error instead of an infinite loop, so a
+regression is caught by that view's feature test (and in CI) rather than in
+production. Escape hatch preserved: a model that declares `InertiaMeta.fields`
+still serializes safely via the parent encoder.
+"""
+
+from django.db import models
+from django.db.models.query import QuerySet
+from inertia.utils import InertiaJsonEncoder
+
+_HINT = "Build a plain dict/list of the fields the page needs (e.g. video_card_props(...))"
+
+
+class StrictInertiaJsonEncoder(InertiaJsonEncoder):
+    def default(self, value):
+        if isinstance(value, (models.Manager, QuerySet)):
+            raise TypeError(
+                f"Refusing to serialize a {type(value).__name__} as an Inertia prop. {_HINT} — "
+                "passing the queryset serializes each model's relations and recurses on cyclic data."
+            )
+        if isinstance(value, models.Model) and not hasattr(type(value), "InertiaMeta"):
+            raise TypeError(
+                f"Refusing to serialize the {type(value).__name__} model as an Inertia prop. {_HINT}, "
+                "or declare an InertiaMeta on the model — never pass the bare model, whose relations "
+                "recurse and crash serialization."
+            )
+        return super().default(value)

--- a/tests/test_inertia_encoder.py
+++ b/tests/test_inertia_encoder.py
@@ -1,0 +1,34 @@
+"""The Inertia prop encoder must reject raw models/querysets (which recurse on
+our cyclic relations) and pass plain data through. See app/inertia_encoder.py.
+"""
+
+import json
+
+import pytest
+
+from app.inertia_encoder import StrictInertiaJsonEncoder
+from catalogue.models.video import Video
+from tests.factories import VideoFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def dump(value):
+    return json.dumps(value, cls=StrictInertiaJsonEncoder)
+
+
+def test_rejects_a_bare_model():
+    video = VideoFactory()
+    with pytest.raises(TypeError, match="Inertia prop"):
+        dump({"video": video})
+
+
+def test_rejects_a_queryset():
+    VideoFactory()
+    with pytest.raises(TypeError, match="Inertia prop"):
+        dump({"videos": Video.objects.all()})
+
+
+def test_allows_plain_dicts_and_lists():
+    payload = {"title": "Hi", "videos": [{"id": 1, "name": "A"}]}
+    assert json.loads(dump(payload)) == payload


### PR DESCRIPTION
Two robustness additions following the watch-page 500 (#215).

## 1. Strict Inertia prop encoder — fail loud on raw model props
The 500 was inertia-django's default encoder expanding a raw `Video` model prop via `model_to_dict`, which follows relations and recurses forever on our cyclic catalogue data (`Video → series → demographic → video`). The acyclic test data masked it, so the watch test passed despite the bug.

`StrictInertiaJsonEncoder` (wired as `INERTIA_JSON_ENCODER`) refuses to auto-serialize a bare `Model`/`QuerySet`/`Manager` and raises a clear, actionable error instead of looping:
- **Prod**: an immediate, descriptive 500 + Sentry event pointing at the fix — not a hung worker.
- **Tests/CI**: every render/feature test becomes a guard — a view that passes a model now fails its own test loudly, regardless of test-data cycles.
- **Escape hatch**: a model that declares `InertiaMeta.fields` still serializes safely (inertia-django's built-in safe path).

~30 lines + one setting, no new abstraction. Running the full suite with it active confirms **no current view** passes a raw model. `tests/test_inertia_encoder.py` documents the contract.

## 2. Auto-close linked issues on beta merge
GitHub only auto-closes keyword-referenced issues on the **default** branch (`main`); we ship from `beta`, so `Closes #N` never fired. New workflow closes those issues (with a note) when a PR merges to `beta`.

178 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)