### PR TITLE
chore: remove unused @headlessui/vue and @heroicons/vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "@headlessui/vue": "^1.7.23",
-        "@heroicons/vue": "^2.2.0",
         "@inertiajs/vue3": "^3.4.0",
         "@tabler/icons-vue": "^3.34.0",
         "@tailwindcss/vite": "^4.1.6",
@@ -1198,30 +1196,6 @@
         "@vue/composition-api": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@headlessui/vue": {
-      "version": "1.7.23",
-      "resolved": "https://registry.npmjs.org/@headlessui/vue/-/vue-1.7.23.tgz",
-      "integrity": "sha512-JzdCNqurrtuu0YW6QaDtR2PIYCKPUWq28csDyMvN4zmGccmE7lz40Is6hc3LA4HFeCI7sekZ/PQMTNmn9I/4Wg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tanstack/vue-virtual": "^3.0.0-beta.60"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "peerDependencies": {
-        "vue": "^3.2.0"
-      }
-    },
-    "node_modules/@heroicons/vue": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.2.0.tgz",
-      "integrity": "sha512-G3dbSxoeEKqbi/DFalhRxJU4mTXJn7GwZ7ae8NuEQzd1bqdd0jAbdaBZlHPcvPD2xI1iGzNVB4k20Un2AguYPw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "vue": ">= 3"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,6 @@
     "vue-tsc": "^2.2.8"
   },
   "dependencies": {
-    "@headlessui/vue": "^1.7.23",
-    "@heroicons/vue": "^2.2.0",
     "@inertiajs/vue3": "^3.4.0",
     "@tabler/icons-vue": "^3.34.0",
     "@tailwindcss/vite": "^4.1.6",


### PR DESCRIPTION
## Summary

`@headlessui/vue` and `@heroicons/vue` have zero imports anywhere in `resources/js` (and the wider codebase) after the legacy layout files were removed. This drops them from `package.json` / `package-lock.json` so they no longer ship in the dependency tree.

Verified empirically before removal — `grep -rn "@headlessui\|@heroicons"` over the source returned no matches.

## Verification

- `grep -rn "@headlessui\|@heroicons" resources/js` (and a broad `*.vue`/`*.js`/`*.ts` grep over the repo, excluding `node_modules`/lockfile) — zero matches.
- `npm uninstall @headlessui/vue @heroicons/vue` — removed from both `package.json` and `package-lock.json`.
- `npm run build-only` — production build succeeds (`✓ built in 3.35s`).

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)