### PR TITLE
refactor(js): normalize relative imports to path aliases (#116)

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -5,8 +5,8 @@ import { createApp, createSSRApp, DefineComponent, h } from 'vue';
 import { useFlash } from '~/composables/useFlash';
 import { initializeAnalytics } from '~/lib/analytics';
 import { resolvePageComponent } from '~/lib/inertia-helper';
-import { initializeTheme } from './composables/useAppearance';
-import { initializeTextScale } from './composables/useTextScale';
+import { initializeTheme } from '~/composables/useAppearance';
+import { initializeTextScale } from '~/composables/useTextScale';
 
 import AppLayout from '@/layouts/AppLayout.vue';
 

--- a/resources/js/components/organisms/CategoriesBrowseWidget.vue
+++ b/resources/js/components/organisms/CategoriesBrowseWidget.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
-import CardSkeleton from '../atoms/CardSkeleton.vue';
+import CardSkeleton from '@/atoms/CardSkeleton.vue';
 const props = defineProps({
     categories_data: {
         type: Object,

--- a/resources/js/components/organisms/Topics.vue
+++ b/resources/js/components/organisms/Topics.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
-import CardSkeleton from '../atoms/CardSkeleton.vue';
+import CardSkeleton from '@/atoms/CardSkeleton.vue';
 const props = defineProps({
     topics_data: {
         type: Object,


### PR DESCRIPTION
## Summary

Normalizes cross-directory relative imports in `resources/js` to the path aliases configured in `vite.config.ts` (`@` → `resources/js/components`, `~` → `resources/js`), matching the convention already used throughout the codebase.

- `../atoms/CardSkeleton.vue` → `@/atoms/CardSkeleton.vue` in `CategoriesBrowseWidget.vue` and `Topics.vue` (every other atom import already uses `@/atoms/...`).
- `./composables/use*` → `~/composables/use*` in `app.ts`, aligning with the file's own `~/lib/*` imports and the rest of the app.

The remaining `./sibling` imports are all inside the vendored shadcn-vue `ui/` component groups (barrel `index.ts` re-exports and co-located component references). Those are intentionally self-contained library internals and are deliberately left untouched. `app.ts`'s `../css/app.css` also stays — it points outside `resources/js`, so no alias reaches it.

Mechanical, no behaviour change.

## Verification

- `npm run build-only` — passes (built in ~2.7s, no errors). Type-check is skipped per CLAUDE.md (#148, known-broken).
- Confirmed no parent-traversing (`../`) imports remain in `resources/js` except the legitimate `../css/app.css`.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)