### PR TITLE
Extract useCategoryFilter composable from CategoriesBrowseWidget

### DIFF
--- a/resources/js/components/organisms/CategoriesBrowseWidget.vue
+++ b/resources/js/components/organisms/CategoriesBrowseWidget.vue
@@ -1,7 +1,8 @@
-<script setup>
+<script setup lang="ts">
 import { Link } from '@inertiajs/vue3';
-import { computed, ref } from 'vue';
+import { ref } from 'vue';
 import CardSkeleton from '@/atoms/CardSkeleton.vue';
+import { useCategoryFilter, type CategoryItem, type SortOrder } from '~/composables/useCategoryFilter';
 const props = defineProps({
     categories_data: {
         type: Object,
@@ -39,64 +40,13 @@ const props = defineProps({
 const fold_results = ref(!props.unfold);
 const num_shown_folded = 12;
 
-// List out category from all entries, then filter down to only keep the first instance of each category
-const categories = ref([props.categories_data.map((t) => t.category)].flat(Infinity).filter((item, index, array) => array.indexOf(item) == index));
-
-// For each entry, obtain its name, category it belongs to, and number of videos it encompasses
-const subCategories = ref(props.categories_data);
-
-const categoryCounts = computed(() => {
-    let counts = {};
-    for (const c of categories.value) {
-        if (props.single_parent_category) {
-            counts[c] = subCategories.value.filter(({ category }) => category === c).reduce((a, b) => a + b.videosCount, 0);
-        } else {
-            counts[c] = subCategories.value.filter(({ category }) => category.includes(c)).reduce((a, b) => a + b.videosCount, 0);
-        }
-    }
-    return counts;
+const { sortedCategories, filteredItems, selectedCategory, selectCategory } = useCategoryFilter(props.categories_data as CategoryItem[], {
+    singleParentCategory: props.single_parent_category,
+    categoriesSortOrder: props.categories_sort_order as SortOrder,
+    subcategoriesSortOrder: props.subcategories_sort_order as SortOrder,
 });
 
-const sortedCategories = computed(() => {
-    if (props.categories_sort_order === 'alphabetical') {
-        return categories.value.toSorted((a, b) => a.localeCompare(b));
-    } else if (props.categories_sort_order === 'count') {
-        return categories.value.toSorted((a, b) => categoryCounts.value[b] - categoryCounts.value[a]);
-    } else {
-        return categories.value;
-    }
-});
-
-const filteredSubCategories = computed(() => {
-    let filtered = subCategories.value;
-    if (selectedCategory.value !== 'All') {
-        if (props.single_parent_category) {
-            filtered = subCategories.value.filter(({ category }) => category === selectedCategory.value);
-        } else {
-            filtered = subCategories.value.filter(({ category }) => category.includes(selectedCategory.value));
-        }
-    }
-
-    if (props.subcategories_sort_order === 'alphabetical') {
-        filtered.sort((a, b) => a.name.localeCompare(b.name));
-    } else if (props.subcategories_sort_order === 'count') {
-        filtered.sort((a, b) => b.videosCount - a.videosCount);
-    }
-    return filtered;
-});
-
-let selectedCategory = ref('All');
-let isLoadingSubCategories = ref(false);
-
-function selectCategory(category) {
-    if (category !== selectedCategory.value) {
-        selectedCategory.value = category;
-        isLoadingSubCategories.value = false;
-        //setTimeout(() => {
-        //    isLoadingSubCategories.value = false
-        //}, 800)
-    }
-}
+const isLoadingSubCategories = ref(false);
 </script>
 
 <template>
@@ -137,7 +87,7 @@ function selectCategory(category) {
         </div>
         <ul v-else class="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-2 sm:gap-x-6 lg:grid-cols-3 xl:gap-x-8">
             <Link
-                v-for="(subcategory, index) in fold_results ? filteredSubCategories.slice(0, num_shown_folded) : filteredSubCategories"
+                v-for="(subcategory, index) in fold_results ? filteredItems.slice(0, num_shown_folded) : filteredItems"
                 :key="index"
                 :href="subcategory.url"
                 :id="subcategory.name"
@@ -150,7 +100,7 @@ function selectCategory(category) {
         <button
             class="mx-auto my-6 flex w-auto cursor-pointer rounded-md bg-blue-950 p-3"
             @click="fold_results = false"
-            v-if="fold_results && filteredSubCategories.length > num_shown_folded"
+            v-if="fold_results && filteredItems.length > num_shown_folded"
         >
             Show All
         </button>

--- a/resources/js/composables/useCategoryFilter.ts
+++ b/resources/js/composables/useCategoryFilter.ts
@@ -1,0 +1,104 @@
+import { computed, ref, type ComputedRef, type Ref } from 'vue';
+
+/**
+ * Category-filtering state for the CategoriesBrowseWidget.
+ *
+ * Each item belongs to one category (`single_parent_category`, so `category` is
+ * a string) or several (so `category` is an array). The composable derives the
+ * distinct category list, per-category video counts, the active selection, and
+ * the filtered + sorted item list.
+ *
+ * Sort orders match the widget's props — `'alphabetical'`, `'count'`, or
+ * `'none'` (retain source order) — applied independently to the category chips
+ * and the filtered items.
+ */
+
+export type SortOrder = 'alphabetical' | 'count' | 'none';
+
+export interface CategoryItem {
+    name: string;
+    category: string | string[];
+    videosCount: number;
+    [key: string]: unknown;
+}
+
+export interface UseCategoryFilterOptions {
+    singleParentCategory?: boolean;
+    categoriesSortOrder?: SortOrder;
+    subcategoriesSortOrder?: SortOrder;
+}
+
+export interface UseCategoryFilterReturn {
+    categories: ComputedRef<string[]>;
+    categoryCounts: ComputedRef<Record<string, number>>;
+    sortedCategories: ComputedRef<string[]>;
+    filteredItems: ComputedRef<CategoryItem[]>;
+    selectedCategory: Ref<string>;
+    selectCategory: (category: string) => void;
+}
+
+export function useCategoryFilter(
+    items: Ref<CategoryItem[]> | ComputedRef<CategoryItem[]> | CategoryItem[],
+    options: UseCategoryFilterOptions = {},
+): UseCategoryFilterReturn {
+    const { singleParentCategory = false, categoriesSortOrder = 'none', subcategoriesSortOrder = 'none' } = options;
+
+    const rawItems = computed(() => (Array.isArray(items) ? items : items.value));
+
+    const belongsTo = (item: CategoryItem, category: string) =>
+        singleParentCategory ? item.category === category : (item.category as string[]).includes(category);
+
+    // Distinct category list, keeping the first instance of each category.
+    const categories = computed(() => {
+        const all = [rawItems.value.map((item) => item.category)].flat(Infinity) as string[];
+        return all.filter((item, index, array) => array.indexOf(item) === index);
+    });
+
+    const categoryCounts = computed(() => {
+        const counts: Record<string, number> = {};
+        for (const category of categories.value) {
+            counts[category] = rawItems.value.filter((item) => belongsTo(item, category)).reduce((sum, item) => sum + item.videosCount, 0);
+        }
+        return counts;
+    });
+
+    const sortedCategories = computed(() => {
+        if (categoriesSortOrder === 'alphabetical') {
+            return categories.value.toSorted((a, b) => a.localeCompare(b));
+        } else if (categoriesSortOrder === 'count') {
+            return categories.value.toSorted((a, b) => categoryCounts.value[b] - categoryCounts.value[a]);
+        }
+        return categories.value;
+    });
+
+    const selectedCategory = ref('All');
+
+    const filteredItems = computed(() => {
+        let filtered = rawItems.value;
+        if (selectedCategory.value !== 'All') {
+            filtered = rawItems.value.filter((item) => belongsTo(item, selectedCategory.value));
+        }
+
+        if (subcategoriesSortOrder === 'alphabetical') {
+            return filtered.toSorted((a, b) => a.name.localeCompare(b.name));
+        } else if (subcategoriesSortOrder === 'count') {
+            return filtered.toSorted((a, b) => b.videosCount - a.videosCount);
+        }
+        return filtered;
+    });
+
+    function selectCategory(category: string): void {
+        if (category !== selectedCategory.value) {
+            selectedCategory.value = category;
+        }
+    }
+
+    return {
+        categories,
+        categoryCounts,
+        sortedCategories,
+        filteredItems,
+        selectedCategory,
+        selectCategory,
+    };
+}


### PR DESCRIPTION
Extracts the category-filtering logic out of `CategoriesBrowseWidget.vue` into a reusable, typed composable `resources/js/composables/useCategoryFilter.ts`, and refactors the component to consume it.

## What moved

The composable owns the derived state that was previously inline in the widget:

- distinct category list (first-instance dedupe)
- per-category video counts (`categoryCounts`)
- the active selection (`selectedCategory` / `selectCategory`)
- the filtered + sorted item list (`filteredItems`)

It preserves the widget's existing behaviour exactly:

- the same three sort orders (`alphabetical` / `count` / `none`) applied independently to the category chips and the filtered items
- the single-vs-multi parent-category handling (`single_parent_category`)

The widget's public prop interface is unchanged, so the only consumer (`CategoriesBrowsePage.vue`) needs no changes.

## Verification

- `npm run build-only` — passes (type-check is intentionally skipped per #148).
- `npx prettier --check` on both files — clean.
- `npx eslint` on both files — clean.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)