### PR TITLE
Fix: mobile horizontal overflow (series title wrap + shell clip)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ coverage
 
 # Inertia SSR build output
 bootstrap/ssr/
+
+# Claude workflow worktrees (local only)
+.claude/worktrees/

--- a/resources/js/components/layouts/AppLayout.vue
+++ b/resources/js/components/layouts/AppLayout.vue
@@ -5,8 +5,10 @@ import PersistentPlayer from '@/organisms/PersistentPlayer.vue';
 </script>
 
 <template>
-    <!-- relative: PersistentPlayer's docked mode positions in document coords -->
-    <div class="bg-background relative flex min-h-full flex-col">
+    <!-- relative: PersistentPlayer's docked mode positions in document coords.
+         overflow-x-clip: belt-and-braces against any descendant forcing
+         horizontal scroll on mobile (clip, not hidden, so sticky still works). -->
+    <div class="bg-background relative flex min-h-full flex-col overflow-x-clip">
         <!-- Keyboard users skip the nav straight to content -->
         <a
             href="#main"

--- a/resources/js/components/molecules/SeriesCard.vue
+++ b/resources/js/components/molecules/SeriesCard.vue
@@ -18,7 +18,7 @@ defineProps({
             <IconBook2 class="text-primary h-8 w-8 stroke-[1.5]" />
         </div>
         <div class="min-w-0">
-            <h3 class="text-foreground truncate text-[15px] font-semibold">{{ series.name }}</h3>
+            <h3 class="text-foreground line-clamp-2 text-[15px] font-semibold">{{ series.name }}</h3>
             <p v-if="series.summary" class="text-muted-foreground mt-1 line-clamp-2 text-[13px] leading-relaxed">{{ series.summary }}</p>
             <p class="bg-muted text-muted-foreground mt-2 inline-block rounded-md px-2 py-0.5 text-xs tabular-nums">
                 {{ series.videosCount }} {{ countNoun }}{{ series.videosCount === 1 ? '' : 's' }}


### PR DESCRIPTION
**Phase 1** of the post-overhaul fixes.

On Safari/iOS the page was slightly wider than the viewport — the sticky header didn't reach the right edge and content gutters were lopsided.

**Root cause:** `SeriesCard`'s title used `truncate` (`white-space: nowrap`), whose *min-content width is the entire title*. On the 1-column mobile grid the featured-series cards forced the card — and the whole page — wider than the screen.

**Fix:**
- `SeriesCard.vue` title `truncate` → `line-clamp-2` (wraps, min-content = longest word; clamps to two lines — also nicer for long church-service names).
- `overflow-x-clip` on the `AppLayout` shell as defense-in-depth (`clip`, not `hidden`, so the sticky header still works).
- Also adds `.claude/worktrees/` to `.gitignore`.

**Verified** in Claude Preview at 375px: `scrollWidth === innerWidth` (overflow 0) on `/`, `/series`, `/topic`; cards symmetric, header full-width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)