### PR TITLE
docs: comprehensive, verified README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ Clayton TV provides Christian media you can trust.
 
 > The revamp roadmap lives in [docs/MASTER_PLAN.md](docs/MASTER_PLAN.md).
 
+## Prerequisites
+
+- **Python** — installed for you by uv (3.14, pinned in `.python-version`). No
+  pyenv or system Python required.
+- **Node.js 22+ and npm** — for the Vue/Vite frontend. Install from
+  [nodejs.org](https://nodejs.org), or with a version manager such as
+  [nvm](https://github.com/nvm-sh/nvm) (`nvm install 22`) or
+  [fnm](https://github.com/Schniz/fnm). npm ships with Node.
+- **Git**.
+
 ## 1. Clone the repository
 
 ```bash
@@ -14,8 +24,7 @@ cd claytontv
 ## 2. Install uv
 
 The project uses [uv](https://docs.astral.sh/uv/) for Python and dependency
-management. uv installs the right Python (3.14, pinned in `.python-version`)
-automatically — no pyenv or system Python required.
+management. uv installs the right Python automatically.
 
 ```bash
 # macOS / Linux / WSL
@@ -27,13 +36,17 @@ powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | ie
 
 ## 3. Install dependencies
 
+Python (and the dev tools), then the frontend packages:
+
 ```bash
-uv sync
+uv sync                  # creates .venv/ and installs locked Python deps
 uv run pre-commit install
+npm install              # Vue / Vite / Tailwind frontend deps
 ```
 
-This creates `.venv/`, installs all locked dependencies (including dev tools),
-and sets up the pre-commit hooks.
+> `uv run` always uses the project venv — there is nothing to "activate". If you
+> prefer shorter commands, `source .venv/bin/activate` once per shell and drop
+> the `uv run` prefix.
 
 ## 4. Set up the environment
 
@@ -42,7 +55,23 @@ cp .env.example .env
 uv run poe generate-key   # writes a SECRET_KEY into .env
 ```
 
-## 5. Run the application
+## 5. Set up the database
+
+The local database is SQLite — no server to install. Apply the migrations:
+
+```bash
+uv run poe manage migrate
+```
+
+Optionally seed it with the legacy catalogue (imports the CSVs under `CSV/` —
+takes a few minutes). This is **destructive** (delete-all-then-reload), so only
+ever run it against a local database you don't mind wiping:
+
+```bash
+uv run poe manage link_and_import_all
+```
+
+## 6. Run the application
 
 We use [Poe the Poet](https://poethepoet.natn.io/) as a task runner; it
 self-documents the useful commands:
@@ -52,9 +81,9 @@ uv run poe          # list all tasks
 uv run poe dev      # run Django + Vite together (the usual dev loop)
 ```
 
-> Tip: `uv run` always uses the project venv — there is nothing to "activate".
-> If you prefer shorter commands, `source .venv/bin/activate` once per shell
-> and drop the `uv run` prefix.
+`uv run poe dev` starts the Django server and the Vite dev server side by side.
+Open the app at the Django URL (http://localhost:8000) — Vite (port 5173) only
+serves frontend assets.
 
 ### Local HTTPS (optional, macOS)
 
@@ -66,7 +95,7 @@ herd proxy claytontv http://127.0.0.1:8000 --secure
 # → https://claytontv.test
 ```
 
-## 6. Everyday commands
+## 7. Everyday commands
 
 ```bash
 uv run poe manage <cmd>   # any Django management command
@@ -74,6 +103,7 @@ uv run poe test           # pytest suite
 uv run poe fix            # ruff lint --fix + format
 uv run poe lint-check     # lint without fixing (CI parity)
 uv run poe format-check   # format check (CI parity)
+npm run build-only        # production frontend build
 ```
 
 Pre-commit hooks (ruff + gitleaks) run automatically on commit; run them
@@ -83,7 +113,23 @@ manually with:
 uv run pre-commit run --all-files --show-diff-on-failure
 ```
 
-## 7. Stack at a glance
+## 8. Troubleshooting
+
+- **`uv: command not found`** — uv isn't on your `PATH` yet. Restart the shell
+  after installing, or `source $HOME/.local/bin/env` (macOS/Linux).
+- **`npm: command not found` or Vite errors** — Node isn't installed or is too
+  old. Check with `node --version` (need 22+) and re-run `npm install`.
+- **Blank page / missing styles in the browser** — make sure both servers are
+  running via `uv run poe dev`, and open the Django URL (port 8000), not Vite's
+  port 5173.
+- **`SECRET_KEY` / settings errors on startup** — you skipped step 4. Confirm
+  `.env` exists and that `uv run poe generate-key` populated `SECRET_KEY`.
+- **No videos / empty catalogue** — the database hasn't been seeded. Run
+  `uv run poe manage link_and_import_all` (step 5).
+- **Frontend deps fail to install on Linux/CI** — platform-specific binaries are
+  declared as `optionalDependencies`; a clean `npm install` resolves them.
+
+## 9. Stack at a glance
 
 - **Backend:** Python 3.14, Django 6, Inertia (inertia-django), SQLite locally /
   PostgreSQL in production


### PR DESCRIPTION
## Summary

Refreshes the README install instructions to be current and complete (issue #172):

- **Node.js 22+ / npm prerequisite + install step** added alongside the uv/Python flow (`npm install` for the Vue/Vite/Tailwind frontend).
- **Database setup section** — explicit `uv run poe manage migrate`, plus the optional, clearly-flagged-destructive seed `uv run poe manage link_and_import_all`.
- **Troubleshooting section** covering the common first-run failures (missing uv/Node on PATH, blank page when only one server is running, unset SECRET_KEY, empty catalogue, optional Linux/CI deps).
- Clarified the dev loop: open the Django URL (`:8000`), not Vite (`:5173`).
- Dropped the stale pyenv mention (the issue asked: uv already manages venvs/Python).

Docs-only — no code changes.

## Verification

Every documented command was checked against the source of truth:
- `poe` tasks (`dev`, `test`, `fix`, `lint-check`, `format-check`, `manage`, `generate-key`) confirmed present in `pyproject.toml`.
- npm scripts (`build-only`, `dev`) confirmed present in `package.json`.
- `migrate` confirmed a valid management command (`manage.py help migrate`).
- Seed command `catalogue/management/commands/link_and_import_all.py` confirmed to exist; its destructive nature cross-checked against CLAUDE.md.
- `.env.example` confirmed present (referenced by the env-setup step).
- Python 3.14 pin (`.python-version`) and Node 22 baseline (`@tsconfig/node22`) confirmed.

No build/test run required (documentation only).

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)