### PR TITLE
Sanitize video description HTML on the watch page (#110)

### DIFF
--- a/app/sanitize.py
+++ b/app/sanitize.py
@@ -1,0 +1,63 @@
+"""Sanitize the raw HTML that legacy video descriptions carry.
+
+Descriptions were authored in the old admin's rich-text box, so they arrive as
+HTML — mostly harmless `<p>`/`<br>` formatting, but also inline `style`/`color`
+directives (e.g. the Gospel Choir May 2018 service sets white-on-white text,
+issue #110) and, in principle, anything a future editor could paste. The watch
+page renders this with `v-html`, so it has to be made safe and predictable
+*before* it reaches the client.
+
+Strategy: keep a small allowlist of formatting tags, drop everything else
+(unwrapping the children so the text survives), and strip every attribute —
+that removes the colour directives and any `on*`/`href="javascript:"` vector in
+one move. BeautifulSoup is already a project dependency; bleach is not, so we
+build the allowlist on bs4 rather than pull in another package.
+"""
+
+from bs4 import BeautifulSoup
+
+# Inline + block formatting that legitimately appears in descriptions. Anything
+# outside this set (script, style, span colour-wrappers, …) is unwrapped.
+ALLOWED_TAGS = frozenset({"p", "br", "b", "strong", "i", "em", "u", "ul", "ol", "li", "a", "blockquote"})
+
+# Attributes kept per tag. Links keep their href (validated below); everything
+# else — notably `style` and `color` — is dropped, which is what un-breaks the
+# invisible-text descriptions.
+ALLOWED_ATTRS = {"a": frozenset({"href"})}
+
+# href schemes we trust. Anything else (javascript:, data:, …) loses the href.
+SAFE_URL_SCHEMES = frozenset({"http", "https", "mailto"})
+
+
+def _href_is_safe(href):
+    value = (href or "").strip().lower()
+    if value.startswith("/") or value.startswith("#"):
+        return True  # site-relative / in-page anchors
+    scheme = value.split(":", 1)[0] if ":" in value else ""
+    return scheme in SAFE_URL_SCHEMES
+
+
+def sanitize_description(html):
+    """Return `html` reduced to the formatting allowlist, attribute-stripped.
+
+    `None`/empty input passes straight through so callers can stay terse.
+    """
+    if not html:
+        return html
+
+    soup = BeautifulSoup(html, "html.parser")
+
+    for tag in soup.find_all(True):
+        if tag.name not in ALLOWED_TAGS:
+            tag.unwrap()  # drop the tag, keep its text
+            continue
+
+        allowed = ALLOWED_ATTRS.get(tag.name, frozenset())
+        for attr in list(tag.attrs):
+            if attr not in allowed:
+                del tag[attr]
+
+        if tag.name == "a" and not _href_is_safe(tag.get("href")):
+            del tag["href"]
+
+    return str(soup)

--- a/app/views.py
+++ b/app/views.py
@@ -9,6 +9,7 @@ from inertia import defer, optional, render
 from app.browse import browse_props
 from app.cards import video_card_props
 from app.feed import latest_feed
+from app.sanitize import sanitize_description
 from catalogue.ingest.normalize import clean_name, clean_topic_name
 from catalogue.models.bible_book import Bible_Book
 from catalogue.models.channel import Channel
@@ -333,7 +334,9 @@ def video(request, id):
                     "id": video_object.id,
                     "name": video_object.name,
                     "url": video_object.url,
-                    "description": video_object.description,
+                    # Legacy descriptions carry raw HTML rendered via v-html;
+                    # sanitize before it reaches the client (issue #110).
+                    "description": sanitize_description(video_object.description),
                     "date_recorded": video_object.date_recorded,
                     "date_created": video_object.date_created,
                     "duration_seconds": video_object.duration_seconds,

--- a/tests/test_sanitize_description.py
+++ b/tests/test_sanitize_description.py
@@ -1,0 +1,64 @@
+"""Issue #110: legacy descriptions ship raw HTML rendered via v-html — keep
+the formatting, drop the breakage (invisible colour directives) and the XSS."""
+
+import pytest
+
+from app.sanitize import sanitize_description
+from tests.factories import VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize("value", [None, "", "Just plain text, no tags."])
+def test_passes_through_empty_and_plain(value):
+    assert sanitize_description(value) == value
+
+
+def test_keeps_allowlisted_formatting_tags():
+    # bs4 may normalize void tags (<br> → <br/>); the tags themselves survive.
+    cleaned = sanitize_description("<p>Welcome <strong>back</strong>.<br>New <em>series</em> below.</p>")
+    for fragment in ("<p>", "<strong>back</strong>", "<br", "<em>series</em>"):
+        assert fragment in cleaned
+
+
+def test_strips_style_and_colour_directives_but_keeps_text():
+    # The Gospel Choir May 2018 case: white-on-white text is invisible. We drop
+    # the attributes (and unwrap the bare <font>/<span> wrappers) so the words
+    # render in the page's own colour.
+    html = '<p style="color:#ffffff">Praise <font color="white">team</font></p>'
+
+    cleaned = sanitize_description(html)
+
+    assert "style" not in cleaned
+    assert "color" not in cleaned
+    assert "<font" not in cleaned
+    assert "Praise" in cleaned and "team" in cleaned
+
+
+def test_removes_script_and_event_handlers():
+    html = '<p onclick="steal()">Hi</p><script>alert(1)</script>'
+
+    cleaned = sanitize_description(html)
+
+    assert "script" not in cleaned.lower()
+    assert "onclick" not in cleaned
+    assert "Hi" in cleaned
+
+
+def test_keeps_safe_links_drops_javascript_href():
+    assert 'href="https://example.com"' in sanitize_description('<a href="https://example.com">x</a>')
+    cleaned = sanitize_description('<a href="javascript:alert(1)">x</a>')
+    assert "javascript" not in cleaned
+    assert ">x</a>" in cleaned  # the link text survives, the href is gone
+
+
+def test_watch_page_serves_sanitized_description(client):
+    video = VideoFactory(description='<p style="color:#fff">Sunday <font color="white">service</font></p>')
+
+    response = client.get(f"/video/{video.id}")
+
+    description = inertia_page(response)["props"]["video"]["description"]
+    assert "style" not in description
+    assert "<font" not in description
+    assert "Sunday" in description and "service" in description


### PR DESCRIPTION
## Summary

Legacy video descriptions carry raw HTML authored in the old admin's rich-text box. The watch page renders it via `v-html`, so:

- inline `style`/`color` directives break rendering — e.g. the Gospel Choir May 2018 service sets white-on-white text and reads as blank (issue #110);
- arbitrary pasted markup is a latent XSS vector.

This sanitizes the HTML **server-side**, before it reaches the client:

- `app/sanitize.py` — `sanitize_description()` uses BeautifulSoup (already a project dependency; no new package) with a small formatting-tag allowlist. Non-allowed tags are unwrapped so their text survives, all attributes are stripped (removing the colour directives), and link `href`s are scheme-checked (`javascript:`/`data:` dropped).
- `app/views.py` — applied where `watch_video` builds the `video` dict.

Scoped tightly to the watch page render path; no frontend changes.

## Verification

- `uv run pytest tests/test_sanitize_description.py tests/test_watch_video.py tests/test_watch_enrichment.py` — 14 passed
- `uv run pytest` — full suite, 186 passed (coverage gate held)
- `uv run poe fix` — ruff lint + format clean

No JS/asset changes, so `npm run build-only` was not required.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)