### PR TITLE
feat(ui): toast notification system (#160)

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -86,6 +86,10 @@
    renders the fuller gamut automatically; on sRGB it clamps gracefully. */
 :root {
     --radius: 0.5rem;
+    /* Stacking order for floating layers. Toasts sit above dialogs and the
+       player dock so feedback is never hidden (placeholder for the fuller
+       token system in #150). */
+    --z-toast: 400;
     --background: oklch(0.985 0.004 264);
     --foreground: oklch(0.21 0.024 264);
     --card: oklch(1 0 0);

--- a/resources/js/components/AppShell.vue
+++ b/resources/js/components/AppShell.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { SharedData } from '@/types';
 import { SidebarProvider } from '@/ui/sidebar';
+import { ToastViewport } from '@/ui/toast';
 import { usePage } from '@inertiajs/vue3';
 
 interface Props {
@@ -19,4 +20,6 @@ const isOpen = usePage<SharedData>().props.sidebarOpen;
     <SidebarProvider v-else :default-open="isOpen">
         <slot />
     </SidebarProvider>
+    <!-- Single app-wide toast outlet; fed by the useToast() store. -->
+    <ToastViewport />
 </template>

--- a/resources/js/components/molecules/ShareButton.vue
+++ b/resources/js/components/molecules/ShareButton.vue
@@ -1,10 +1,13 @@
 <script setup>
 import { IconBrandWhatsapp, IconCheck, IconLink, IconShare } from '@tabler/icons-vue';
 import { computed, ref } from 'vue';
+import { useToast } from '~/composables/useToast';
 
 const props = defineProps({
     title: { type: String, required: true },
 });
+
+const toast = useToast();
 
 const copied = ref(false);
 const menuOpen = ref(false);
@@ -26,9 +29,11 @@ const copyLink = async () => {
     try {
         await navigator.clipboard.writeText(shareUrl());
         copied.value = true;
+        toast.success('Link copied to clipboard');
         setTimeout(() => (copied.value = false), 2000);
     } catch {
         copied.value = false;
+        toast.error('Could not copy the link');
     }
 };
 

--- a/resources/js/components/ui/toast/Toast.vue
+++ b/resources/js/components/ui/toast/Toast.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils';
+import type { ToastVariant } from '~/composables/useToast';
+import { IconAlertTriangle, IconCircleCheck, IconInfoCircle, IconX } from '@tabler/icons-vue';
+import { ToastClose, ToastDescription, ToastRoot } from 'reka-ui';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    variant: ToastVariant;
+    message: string;
+    duration: number;
+}>();
+
+const emit = defineEmits<{ close: [] }>();
+
+// Coloured left accent + matching icon per variant. Success and info lean on
+// the brand/neutral palette; error reuses the destructive token.
+const variants = {
+    success: { icon: IconCircleCheck, accent: 'border-l-primary', iconColor: 'text-primary' },
+    error: { icon: IconAlertTriangle, accent: 'border-l-destructive', iconColor: 'text-destructive' },
+    info: { icon: IconInfoCircle, accent: 'border-l-muted-foreground', iconColor: 'text-muted-foreground' },
+} as const;
+
+const current = computed(() => variants[props.variant]);
+</script>
+
+<template>
+    <ToastRoot
+        :duration="duration"
+        @update:open="(open: boolean) => !open && emit('close')"
+        :class="
+            cn(
+                'bg-card text-card-foreground border-border flex items-center gap-3 rounded-lg border border-l-4 p-3.5 shadow-lg',
+                // Slide up + fade in on enter, fade out on exit; swipe-to-dismiss
+                // tracks the drag. prefers-reduced-motion users get instant
+                // show/hide via the media query below.
+                'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:slide-in-from-bottom-2 data-[state=open]:duration-200 data-[state=open]:ease-out',
+                'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:duration-150 data-[state=closed]:ease-out',
+                'data-[swipe=move]:translate-x-(--reka-toast-swipe-move-x) data-[swipe=cancel]:translate-x-0 data-[swipe=cancel]:transition-transform data-[swipe=end]:animate-out data-[swipe=end]:fade-out-0',
+                'motion-reduce:animate-none motion-reduce:transition-none',
+                current.accent,
+            )
+        "
+    >
+        <component :is="current.icon" :class="cn('size-5 shrink-0', current.iconColor)" aria-hidden="true" />
+        <ToastDescription class="flex-1 text-sm">{{ message }}</ToastDescription>
+        <ToastClose
+            class="text-muted-foreground hover:text-foreground focus-visible:ring-ring -m-1 shrink-0 rounded-sm p-1 outline-none focus-visible:ring-2"
+            aria-label="Dismiss notification"
+        >
+            <IconX class="size-4" aria-hidden="true" />
+        </ToastClose>
+    </ToastRoot>
+</template>

--- a/resources/js/components/ui/toast/ToastViewport.vue
+++ b/resources/js/components/ui/toast/ToastViewport.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { useToast } from '~/composables/useToast';
+import { ToastPortal, ToastProvider, ToastViewport } from 'reka-ui';
+import Toast from './Toast.vue';
+
+// Mounted once in the app layout. Reka's ToastProvider gives us hover-to-pause
+// and swipe handling for free; the actual toasts come from the module-level
+// store in useToast(), so any component can fire one without wiring.
+const { toasts, dismiss } = useToast();
+</script>
+
+<template>
+    <ToastProvider :swipe-direction="'right'">
+        <Toast
+            v-for="t in toasts"
+            :key="t.id"
+            :variant="t.variant"
+            :message="t.message"
+            :duration="t.duration"
+            @close="dismiss(t.id)"
+        />
+        <ToastPortal>
+            <!-- Bottom-centre on mobile, bottom-right on desktop. Sits above the
+                 safe-area inset so it clears the home indicator on notched
+                 devices. z-toast keeps it over dialogs and the player dock. -->
+            <ToastViewport
+                class="fixed bottom-0 left-1/2 z-[var(--z-toast)] flex w-full max-w-[100vw] -translate-x-1/2 flex-col gap-2 p-4 pb-[max(1rem,env(safe-area-inset-bottom))] outline-none sm:right-0 sm:left-auto sm:translate-x-0 sm:max-w-sm"
+            />
+        </ToastPortal>
+    </ToastProvider>
+</template>

--- a/resources/js/components/ui/toast/index.ts
+++ b/resources/js/components/ui/toast/index.ts
@@ -1,0 +1,2 @@
+export { default as Toast } from './Toast.vue'
+export { default as ToastViewport } from './ToastViewport.vue'

--- a/resources/js/composables/useToast.ts
+++ b/resources/js/composables/useToast.ts
@@ -1,0 +1,56 @@
+import { reactive } from 'vue';
+
+/**
+ * App-wide toast notifications. A single module-level store backs every caller,
+ * so `useToast()` works anywhere — no provider injection, no prop drilling. The
+ * <ToastViewport> mounted in the layout renders whatever lands in `toasts`.
+ *
+ *   const toast = useToast()
+ *   toast.success('Link copied to clipboard')
+ *   toast.error('Failed to subscribe. Please try again.')
+ *   toast.info('Showing results for "gospel"')
+ */
+
+export type ToastVariant = 'success' | 'error' | 'info';
+
+export interface Toast {
+    id: number;
+    variant: ToastVariant;
+    message: string;
+    duration: number;
+}
+
+// Oldest toasts past this count are dropped so the stack never overwhelms the
+// screen (matches the "max 3 visible" behaviour in #160).
+const MAX_TOASTS = 3;
+const DEFAULT_DURATION = 3000;
+
+const toasts = reactive<Toast[]>([]);
+let nextId = 0;
+
+function add(variant: ToastVariant, message: string, duration = DEFAULT_DURATION): number {
+    const id = nextId++;
+    toasts.push({ id, variant, message, duration });
+
+    if (toasts.length > MAX_TOASTS) {
+        toasts.splice(0, toasts.length - MAX_TOASTS);
+    }
+
+    return id;
+}
+
+function dismiss(id: number) {
+    const index = toasts.findIndex((t) => t.id === id);
+    if (index !== -1) toasts.splice(index, 1);
+}
+
+export function useToast() {
+    return {
+        toasts,
+        toast: add,
+        success: (message: string, duration?: number) => add('success', message, duration),
+        error: (message: string, duration?: number) => add('error', message, duration),
+        info: (message: string, duration?: number) => add('info', message, duration),
+        dismiss,
+    };
+}


### PR DESCRIPTION
## Summary

Adds a lightweight, app-wide toast notification system built on Reka UI's Toast primitive, so user actions can give success/error/info feedback instead of happening silently.

- **`resources/js/composables/useToast.ts`** — a module-level reactive store exposing `toast()`, `success()`, `error()`, `info()`. Works anywhere (no provider injection / prop drilling). Caps the visible stack at 3, dropping the oldest.
- **`resources/js/components/ui/toast/`** — `Toast.vue` (success/error/info variants with a coloured left accent + matching icon, swipe-to-dismiss, hover-to-pause, `prefers-reduced-motion` via `motion-reduce:`) and `ToastViewport.vue` (single outlet, bottom-centre on mobile / bottom-right on desktop, positioned above the safe-area inset).
- **`AppShell.vue`** — mounts one `ToastViewport`, so every page is covered.
- **`app.css`** — adds `--z-toast: 400` (placeholder ahead of the fuller token system in #150) so toasts sit above dialogs and the player dock.
- **Real usage** — `ShareButton`'s "Copy link" now fires `success`/`error` toasts (covers the native-share path too, where there's no inline menu confirmation).

### API
```ts
const toast = useToast()
toast.success('Link copied to clipboard')
toast.error('Failed to subscribe. Please try again.')
toast.info('Showing results for "gospel"')
```

## Verification

- `npm run build-only` — passes (built in ~3s, no errors).
- `npx prettier --write` on touched files — clean.
- `npx eslint` on the new composable — no errors (the `ui/toast/*` Vue files fall under the same eslint ignore as the other `ui/*` Reka-derived components).
- Confirmed the swipe CSS var `--reka-toast-swipe-move-x` against `node_modules/reka-ui/dist` so the swipe transform actually binds.

Note: the running browser preview points at the main working copy, not this worktree, so live in-browser verification wasn't applicable; the production build is the authoritative check for these frontend-only changes.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)