### PR TITLE
fix (claytontv/148): repair frontend type-check + run it in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,26 @@ jobs:
       - name: Format code
         run: uv run poe format-check
 
+  frontend:
+    name: Frontend Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
   test:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,8 @@ uv run poe dev      # Django + Vite dev servers (or use .claude/launch.json)
 uv run poe test     # pytest (coverage gate: 60%)
 uv run poe fix      # ruff lint --fix + format
 uv run poe manage <cmd>
-npm run build-only  # production asset build (type-check is known-broken, #148)
+npm run build-only  # production asset build
+npm run type-check  # vue-tsc against tsconfig.app.json (runs in CI)
 ```
 
 Local HTTPS: `herd proxy claytontv http://127.0.0.1:8000 --secure` →

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,9 +15,9 @@ export default defineConfigWithVueTs(
         files: ['**/*.{ts,mts,tsx,vue}'],
     },
 
-    globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
+    globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']) as any,
 
-    pluginVue.configs['flat/essential'],
+    pluginVue.configs['flat/essential'] as any,
     vueTsConfigs.recommended,
     {
         ignores: ['vendor', 'node_modules', 'public', 'bootstrap/ssr', 'tailwind.config.js', 'resources/js/components/ui/*'],
@@ -28,6 +28,6 @@ export default defineConfigWithVueTs(
             '@typescript-eslint/no-explicit-any': 'off',
         },
     },
-    ...pluginOxlint.configs['flat/recommended'],
-    skipFormatting,
+    ...(pluginOxlint.configs['flat/recommended'] as any[]),
+    skipFormatting as any,
 );

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-only": "vite build",
     "build-ssr": "vite build --ssr resources/js/ssr.ts --outDir bootstrap/ssr",
     "ssr": "node bootstrap/ssr/ssr.js",
-    "type-check": "vue-tsc --build",
+    "type-check": "vue-tsc --noEmit -p tsconfig.app.json",
     "lint:oxlint": "oxlint . --fix -D correctness --ignore-path .gitignore",
     "lint:eslint": "eslint . --fix",
     "lint": "run-s lint:*",

--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -1,7 +1,7 @@
 import '../css/app.css';
 
 import { createInertiaApp, router } from '@inertiajs/vue3';
-import { createApp, createSSRApp, DefineComponent, h } from 'vue';
+import { createApp, createSSRApp, type DefineComponent, h } from 'vue';
 import { useFlash } from '~/composables/useFlash';
 import { initializeAnalytics } from '~/lib/analytics';
 import { resolvePageComponent } from '~/lib/inertia-helper';
@@ -51,13 +51,14 @@ createInertiaApp({
     },
 });
 
-// A failed visit (server 500 / non-Inertia response / network drop) shows a
-// friendly toast instead of Inertia's raw error modal.
-router.on('invalid', (event) => {
+// A failed visit shows a friendly toast instead of Inertia's raw error modal.
+// The v3 client renamed these events: 'invalid' → 'httpException' (a non-Inertia
+// / error HTTP response, e.g. a raw 500 page) and 'exception' → 'networkError'.
+router.on('httpException', (event) => {
     event.preventDefault();
     useFlash().push("That page couldn't be loaded. Please try again.", 'error');
 });
-router.on('exception', () => {
+router.on('networkError', () => {
     useFlash().push('A network error stopped that request. Please try again.', 'error');
 });
 

--- a/resources/js/components/molecules/NextServiceCard.vue
+++ b/resources/js/components/molecules/NextServiceCard.vue
@@ -8,8 +8,8 @@ import { getEmbedUrl } from '~/lib/embeds';
 // states: live right now (embedded player), a scheduled next service
 // (real date/time), or the quiet evergreen fallback.
 const props = defineProps({
-    livestreams: { type: Array, default: () => [] },
-    nextService: { type: Object, default: null },
+    livestreams: { type: Array as () => Record<string, any>[], default: () => [] },
+    nextService: { type: Object as () => Record<string, any> | null, default: null },
 });
 
 const live = computed(() => props.livestreams[0] ?? null);

--- a/resources/js/components/molecules/ShortcutsHelp.vue
+++ b/resources/js/components/molecules/ShortcutsHelp.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/ui/dialog';
 import { usePalette } from '~/composables/usePalette';
 

--- a/resources/js/components/molecules/TextSizeControl.vue
+++ b/resources/js/components/molecules/TextSizeControl.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script setup lang="ts">
 import { ALargeSmall } from 'lucide-vue-next';
 import { useTextScale } from '~/composables/useTextScale';
 

--- a/resources/js/composables/useCategoryFilter.ts
+++ b/resources/js/composables/useCategoryFilter.ts
@@ -17,6 +17,7 @@ export type SortOrder = 'alphabetical' | 'count' | 'none';
 
 export interface CategoryItem {
     name: string;
+    url: string;
     category: string | string[];
     videosCount: number;
     [key: string]: unknown;
@@ -64,9 +65,9 @@ export function useCategoryFilter(
 
     const sortedCategories = computed(() => {
         if (categoriesSortOrder === 'alphabetical') {
-            return categories.value.toSorted((a, b) => a.localeCompare(b));
+            return [...categories.value].sort((a, b) => a.localeCompare(b));
         } else if (categoriesSortOrder === 'count') {
-            return categories.value.toSorted((a, b) => categoryCounts.value[b] - categoryCounts.value[a]);
+            return [...categories.value].sort((a, b) => categoryCounts.value[b] - categoryCounts.value[a]);
         }
         return categories.value;
     });
@@ -80,9 +81,9 @@ export function useCategoryFilter(
         }
 
         if (subcategoriesSortOrder === 'alphabetical') {
-            return filtered.toSorted((a, b) => a.name.localeCompare(b.name));
+            return [...filtered].sort((a, b) => a.name.localeCompare(b.name));
         } else if (subcategoriesSortOrder === 'count') {
-            return filtered.toSorted((a, b) => b.videosCount - a.videosCount);
+            return [...filtered].sort((a, b) => b.videosCount - a.videosCount);
         }
         return filtered;
     });

--- a/resources/js/ssr.ts
+++ b/resources/js/ssr.ts
@@ -1,6 +1,6 @@
 import { createInertiaApp } from '@inertiajs/vue3';
 import createServer from '@inertiajs/vue3/server';
-import { DefineComponent, createSSRApp, h } from 'vue';
+import { type DefineComponent, createSSRApp, h } from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import { resolvePageComponent } from '~/lib/inertia-helper';
 

--- a/resources/js/types/vue-shims.d.ts
+++ b/resources/js/types/vue-shims.d.ts
@@ -1,0 +1,9 @@
+// Fallback declaration for plain-JS `<script setup>` single-file components.
+// vue-tsc / Volar generates precise types for `.vue` files that use
+// `<script setup lang="ts">`; this shim only covers the remaining untyped
+// legacy components so importing them from TypeScript doesn't error.
+declare module '*.vue' {
+    import type { DefineComponent } from 'vue';
+    const component: DefineComponent<Record<string, any>, Record<string, any>, any>;
+    export default component;
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,17 +1,25 @@
 {
   "extends": "@vue/tsconfig/tsconfig.dom.json",
-  "include": ["env.d.ts",
-    "js/**/*",
-    "js/**/*.vue"
+  "include": [
+    "env.d.ts",
+    "resources/js/**/*",
+    "resources/js/**/*.vue"
   ],
   "exclude": [
-    "js/**/__tests__/*"
+    "resources/js/**/__tests__/*"
   ],
   "compilerOptions": {
+    "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
+    "types": [
+      "vite/client",
+      "./resources/js/types"
+    ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./resources/js/components/*"],
+      "~/*": ["./resources/js/*"],
+      "ziggy-js": ["./vendor/tightenco/ziggy"]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,14 +34,14 @@
     "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
-      /* Specify a set of entries that re-map imports to additional lookup locations. */ "@/*": ["./resources/js/*"],
+      /* Specify a set of entries that re-map imports to additional lookup locations. */ "@/*": ["./resources/js/components/*"],
+      "~/*": ["./resources/js/*"],
       "ziggy-js": ["./vendor/tightenco/ziggy"]
     },
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     "types": [
       "vite/client",
-      "vue/tsx",
       "./resources/js/types"
     ] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */


### PR DESCRIPTION
## Summary

`npm run type-check` was broken across three layers (tsconfig project refs, a nonexistent `vue/tsx` type, and an eslint config type mismatch) and CI never ran it. This fixes all of them and adds a frontend type-check job so regressions get caught.

Adapts the approach from the now-stale #149 onto the current `beta` — the directory layout and tsconfig differ from what #149 assumed, so the path/alias fixes were re-derived against `vite.config.ts`.

### Config
- **type-check command** → `vue-tsc --noEmit -p tsconfig.app.json`. The previous `--build` project-reference mode collided with the root tsconfig's own `include` patterns, emitting stray `.d.ts` files and `TS6305` errors.
- **tsconfig.app.json** — replaced stale `js/**/*` includes and `@/* -> ./src/*` paths with the real `resources/js` layout; added `noEmit`, `vite/client` + project types, and the `@` / `~` / `ziggy-js` aliases.
- **tsconfig.json** — dropped the nonexistent `vue/tsx` type reference (Vue 3.5 doesn't ship it); aligned the `@` and `~` path aliases with `vite.config.ts` (`@` → `resources/js/components`, `~` → `resources/js`). They were mismatched, which is what caused the cascade of `Cannot find module` errors.
- **eslint.config.ts** — `as any` casts to bypass the `ecmaVersion: 17` mismatch between eslint 9 and `@typescript-eslint/utils`.

### Code
- Fixed `@/types`, `@/composables/*`, `@/layouts/app/*` imports that actually live under `~` (`resources/js`), not `@` (`resources/js/components`).
- `type`-only imports for `DefineComponent` (app.ts, ssr.ts) and `SharedData` (AppShell).
- Added `lang="ts"` to `TextSizeControl` / `ShortcutsHelp` (clean) and a non-null avatar assertion in `UserInfo`.
- Typed `NextServiceCard`'s `livestreams` / `nextService` props.
- Added a `*.vue` shim (`resources/js/types/vue-shims.d.ts`) so the remaining untyped legacy JS SFCs (e.g. `CommandPalette`, `PersistentPlayer`, `PlayerFrame`) import cleanly. Verified the shim does **not** mask checks on typed SFCs — a real error in `UserInfo` still surfaced through it.

### CI
- New `frontend` job (Node 22, `npm ci`, `npm run type-check`).

## Verification
- `npm run type-check` → **0 errors** (exit 0)
- `npm run build-only` → success
- `npm run build-ssr` → success
- Confirmed on a clean `origin/beta` checkout that `npm run lint` already fails (59 pre-existing `vue/block-lang` etc. errors) — out of scope here, and **not** wired into CI by this PR. This change actually reduces it to 52.

## Notes for reviewer
- The `frontend` CI job runs only `type-check`, intentionally not `npm run lint`, since lint is pre-existing red on `beta`. Fixing the ~52 lint errors (mostly missing `lang="ts"` on legacy JS pages) is a separate, larger cleanup.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)