### PR TITLE
fix(livestreams): survive transient YouTube API connection failures (CLAYTONTV-2)

### DIFF
--- a/catalogue/management/commands/sync_live_streams.py
+++ b/catalogue/management/commands/sync_live_streams.py
@@ -13,7 +13,7 @@ import os
 import requests
 from django.core.management.base import BaseCommand
 
-from catalogue.youtube_live import discover_broadcasts, discover_channels, refresh_statuses
+from catalogue.youtube_live import YoutubeApiError, discover_broadcasts, discover_channels, refresh_statuses
 
 
 class Command(BaseCommand):
@@ -28,10 +28,18 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("YOUTUBE_API_KEY not set — skipping live-stream sync."))
             return
         session = requests.Session()
-        if options["discover"]:
-            channels = discover_channels(session)
-            found = discover_broadcasts(session, channels)
-            self.stdout.write(self.style.SUCCESS(f"Searched {len(channels)} channels; {found} broadcasts upserted."))
-        else:
-            checked = refresh_statuses(session)
-            self.stdout.write(self.style.SUCCESS(f"Refreshed {checked} active broadcasts."))
+        try:
+            if options["discover"]:
+                channels = discover_channels(session)
+                found = discover_broadcasts(session, channels)
+                self.stdout.write(
+                    self.style.SUCCESS(f"Searched {len(channels)} channels; {found} broadcasts upserted.")
+                )
+            else:
+                checked = refresh_statuses(session)
+                self.stdout.write(self.style.SUCCESS(f"Refreshed {checked} active broadcasts."))
+        except YoutubeApiError as exc:
+            # Transient upstream failures (intermittent datacenter-IP 403s,
+            # connection resets) shouldn't crash a cron that reruns in minutes
+            # — and shouldn't page Sentry. Warn and exit 0.
+            self.stderr.write(self.style.WARNING(f"YouTube API unavailable, skipping this run: {exc}"))

--- a/catalogue/youtube_live.py
+++ b/catalogue/youtube_live.py
@@ -16,6 +16,7 @@ import re
 import time
 from datetime import timedelta
 
+import requests
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 
@@ -38,18 +39,27 @@ class YoutubeApiError(RuntimeError):
 
 
 def api_get(session, endpoint, **params):
-    """GET with retries: YouTube intermittently 403s requests from
-    datacenter IPs ("cannot act on behalf of the specified Google account"
-    — observed ~1 in 3 from app03 with a valid, unrestricted-IP key)."""
+    """GET with retries over two transient failure modes seen from app03:
+    YouTube intermittently 403s requests from datacenter IPs ("cannot act on
+    behalf of the specified Google account" — ~1 in 3 with a valid,
+    unrestricted-IP key), and the connection itself is occasionally reset
+    mid-handshake (ConnectionResetError 104). Both are retried; a persistent
+    failure raises YoutubeApiError for the caller to handle (the sync command
+    treats that as a skip, not a crash)."""
     params["key"] = os.environ["YOUTUBE_API_KEY"]
-    response = None
+    last_error = "no response"
     for attempt in range(RETRY_ATTEMPTS):
         if attempt:
             time.sleep(RETRY_DELAY_SECONDS * attempt)
-        response = session.get(f"{API_BASE}/{endpoint}", params=params, timeout=20)
+        try:
+            response = session.get(f"{API_BASE}/{endpoint}", params=params, timeout=20)
+        except requests.RequestException as exc:
+            last_error = f"request failed: {exc}"
+            continue
         if response.status_code == 200:
             return response.json()
-    raise YoutubeApiError(f"{endpoint} returned {response.status_code}: {getattr(response, 'text', '')[:300]}")
+        last_error = f"returned {response.status_code}: {getattr(response, 'text', '')[:300]}"
+    raise YoutubeApiError(f"{endpoint} {last_error}")
 
 
 def youtube_id(url):

--- a/tests/test_youtube_live.py
+++ b/tests/test_youtube_live.py
@@ -8,8 +8,10 @@ Channel table is empty, so nothing is hardcoded.
 """
 
 import datetime
+import io
 
 import pytest
+import requests
 
 from catalogue.models import LiveStream
 from catalogue.youtube_live import discover_broadcasts, discover_channels, refresh_statuses
@@ -202,6 +204,60 @@ def test_persistent_api_failure_still_raises(monkeypatch):
 
     with _pytest.raises(YoutubeApiError):
         refresh_statuses(FlakySession(99, FakeSession({})))
+
+
+class ResettingSession:
+    """Raises a connection error for the first N calls, then defers — models
+    YouTube resetting the TCP connection mid-handshake (ConnectionResetError
+    104, "Connection reset by peer") as observed from app03. CLAYTONTV-2."""
+
+    def __init__(self, failures, then):
+        self.failures = failures
+        self.then = then
+        self.attempts = 0
+
+    def get(self, url, params=None, timeout=None):
+        self.attempts += 1
+        if self.attempts <= self.failures:
+            raise requests.exceptions.ConnectionError(
+                "('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))"
+            )
+        return self.then.get(url, params=params, timeout=timeout)
+
+
+def test_transient_connection_resets_are_retried(monkeypatch):
+    """A connection reset raises before any HTTP status exists, so it must be
+    retried at the request layer — not just on non-200 responses."""
+    monkeypatch.setenv("YOUTUBE_API_KEY", "k")
+    monkeypatch.setattr("catalogue.youtube_live.RETRY_DELAY_SECONDS", 0)
+    LiveStream.objects.create(video_id="vid12345678", title="Service", channel_id="UC1", status="upcoming")
+    recovered = FakeSession({"videos": {"items": [video_item("vid12345678", started="2026-06-14T10:30:00Z")]}})
+    session = ResettingSession(2, recovered)
+
+    refresh_statuses(session)
+
+    assert LiveStream.objects.get(video_id="vid12345678").status == "live"
+    assert session.attempts == 3
+
+
+def test_sync_command_exits_cleanly_when_youtube_unavailable(monkeypatch):
+    """Regression for CLAYTONTV-2: a persistent upstream failure must not
+    crash the 5-minute cron (and page Sentry) — the command warns and exits 0."""
+    from django.core.management import call_command
+
+    from catalogue.youtube_live import YoutubeApiError
+
+    monkeypatch.setenv("YOUTUBE_API_KEY", "k")
+
+    def boom(session):
+        raise YoutubeApiError("videos request failed: Connection reset by peer")
+
+    monkeypatch.setattr("catalogue.management.commands.sync_live_streams.refresh_statuses", boom)
+
+    err = io.StringIO()
+    call_command("sync_live_streams", stdout=io.StringIO(), stderr=err)  # must not raise
+
+    assert "skipping this run" in err.getvalue().lower()
 
 
 def test_homepage_serves_live_and_next_service(client):


### PR DESCRIPTION
## What

Fixes the Sentry error **[CLAYTONTV-2](https://sentry.tgo.dev/organizations/sentry/issues/135/)** — `ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))`, raised from `catalogue/youtube_live.py:api_get` and crashing the every-5-minute `sync_live_streams` cron on beta.

## Root cause

`api_get` retried on non-200 **status codes**, but a connection reset / SSL-handshake failure raises out of `session.get()` *before* any response object exists — so the transient error skipped the retry loop and propagated all the way up to `manage.py`, unhandled, and got reported to Sentry via `excepthook`.

## Fix (two layers)

- **`api_get`** now also retries `requests.RequestException` (connection resets, timeouts) — the existing 403-retry behaviour is unchanged — and wraps a persistent failure in `YoutubeApiError`.
- **`sync_live_streams`** catches `YoutubeApiError` and **warns + exits 0**, mirroring the existing missing-`YOUTUBE_API_KEY` path. A transient upstream blip on a cron that reruns in minutes shouldn't crash the run or page Sentry.

## Verification

- `uv run pytest` -> **185 passed**, coverage gate held.
- New regression tests: `test_transient_connection_resets_are_retried` (request-layer retry) and `test_sync_command_exits_cleanly_when_youtube_unavailable` (the CLAYTONTV-2 scenario — command must not raise).
- `ruff check` + `ruff format --check` clean.

Once merged + deployed I'll mark CLAYTONTV-2 resolved in Sentry (it'll regress-alert if it recurs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)