### PR TITLE
fix(player): working mini-player controls + reel seek bar + mobile full-width bar

### DIFF
--- a/resources/js/components/organisms/PersistentPlayer.vue
+++ b/resources/js/components/organisms/PersistentPlayer.vue
@@ -100,7 +100,57 @@ const onEnded = () => playNext();
 // ----- mini chrome -----
 const expand = () => router.visit(`/video/${dock.current.value.id}`);
 
-const onScrub = (event) => dock.controls.value?.seekTo(Number(event.target.value));
+// ----- reel-style seek bar -----
+// A native <input type=range> only scrubs by grabbing its (invisible) thumb —
+// iOS Safari won't even click-to-seek on the track. So we drive a custom
+// slider: press or drag anywhere on the bar to seek, plus full keyboard support.
+const scrubbing = ref(false);
+const dragPercent = ref(null);
+
+// Drives the fill: the finger position while scrubbing, else live playback.
+const progressPercent = computed(() => {
+    if (dragPercent.value !== null) return dragPercent.value;
+    const duration = dock.duration.value;
+    if (!duration) return 0;
+    return Math.min(100, (dock.position.value / duration) * 100);
+});
+
+const fractionFromEvent = (event) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    return Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width));
+};
+
+const onScrubDown = (event) => {
+    scrubbing.value = true;
+    dragPercent.value = fractionFromEvent(event) * 100;
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+};
+const onScrubMove = (event) => {
+    if (scrubbing.value) dragPercent.value = fractionFromEvent(event) * 100;
+};
+const onScrubUp = (event) => {
+    if (!scrubbing.value) return;
+    const duration = dock.duration.value;
+    if (duration) dock.controls.value?.seekTo(fractionFromEvent(event) * duration);
+    scrubbing.value = false;
+    dragPercent.value = null;
+};
+const onScrubKey = (event) => {
+    if (!dock.duration.value) return;
+    if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        dock.controls.value?.seekBy(-5);
+    } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        dock.controls.value?.seekBy(5);
+    } else if (event.key === 'Home') {
+        event.preventDefault();
+        dock.controls.value?.seekTo(0);
+    } else if (event.key === 'End') {
+        event.preventDefault();
+        dock.controls.value?.seekTo(dock.duration.value);
+    }
+};
 
 const formatTime = (totalSeconds) => {
     const minutes = Math.floor(totalSeconds / 60);
@@ -140,10 +190,12 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
         :class="
             dock.mode.value === 'docked'
                 ? 'border-border z-10 overflow-hidden rounded-xl border'
-                : 'mini-in border-input bg-card fixed right-[calc(1rem+env(safe-area-inset-right))] bottom-[calc(1rem+env(safe-area-inset-bottom))] z-50 w-[min(340px,calc(100vw-2rem))] overflow-hidden rounded-xl border shadow-2xl'
+                : 'mini-in bg-card fixed inset-x-0 bottom-0 z-50 flex h-[calc(4.5rem+env(safe-area-inset-bottom))] flex-row items-stretch overflow-hidden border-t border-border pb-[env(safe-area-inset-bottom)] sm:inset-x-auto sm:right-[calc(1rem+env(safe-area-inset-right))] sm:bottom-[calc(1rem+env(safe-area-inset-bottom))] sm:h-auto sm:w-[min(340px,calc(100vw-2rem))] sm:flex-col sm:rounded-xl sm:border sm:border-input sm:pb-0 sm:shadow-2xl'
         "
     >
-        <div :class="dock.mode.value === 'docked' ? 'h-full w-full' : 'aspect-video w-full'">
+        <!-- One persistent iframe, reflowed: a compact thumbnail on the mobile
+             bar, the full-width video on the desktop card. -->
+        <div :class="dock.mode.value === 'docked' ? 'h-full w-full' : 'h-[4.5rem] w-32 shrink-0 sm:aspect-video sm:h-auto sm:w-full'">
             <PlayerFrame
                 :key="dock.current.value.id"
                 :video="dock.current.value"
@@ -153,25 +205,52 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
             />
         </div>
 
-        <!-- Mini control bar -->
-        <div v-if="dock.mode.value === 'mini'" class="flex flex-col gap-1 px-3 pt-2 pb-2.5">
+        <!-- Reel-style seek bar: a near-invisible 2px track that fills with
+             playback and grows on hover/focus. Press or drag anywhere on it to
+             seek (custom pointer handling — a native range only scrubs via its
+             invisible thumb, which fails on iOS Safari). On mobile it pins to the
+             top edge of the full-width bar (like YouTube); on desktop it sits
+             flush under the video. -->
+        <div
+            v-if="dock.mode.value === 'mini'"
+            class="group/scrub absolute inset-x-0 top-0 z-10 h-3 cursor-pointer touch-none select-none sm:relative sm:inset-x-auto sm:top-auto"
+            role="slider"
+            tabindex="0"
+            aria-label="Seek"
+            :aria-valuemin="0"
+            :aria-valuemax="Math.floor(dock.duration.value) || 0"
+            :aria-valuenow="Math.floor(dock.position.value) || 0"
+            :aria-valuetext="`${formatTime(dock.position.value)} of ${formatTime(dock.duration.value)}`"
+            @pointerdown="onScrubDown"
+            @pointermove="onScrubMove"
+            @pointerup="onScrubUp"
+            @pointercancel="onScrubUp"
+            @keydown="onScrubKey"
+        >
+            <div
+                class="bg-foreground/15 pointer-events-none absolute inset-x-0 top-0 h-[2px] transition-[height] duration-200 ease-out group-focus-within/scrub:h-1 group-hover/scrub:h-1 motion-reduce:transition-none"
+            >
+                <div
+                    class="bg-primary h-full transition-[width] duration-150 ease-linear motion-reduce:transition-none"
+                    :style="{ width: `${progressPercent}%`, transitionDuration: scrubbing ? '0s' : undefined }"
+                ></div>
+            </div>
+        </div>
+
+        <!-- Mini control bar: a horizontal strip beside the thumbnail on mobile,
+             a stacked block under the video on desktop. -->
+        <div
+            v-if="dock.mode.value === 'mini'"
+            class="flex min-w-0 flex-1 items-center gap-1 px-2 sm:flex-col sm:items-stretch sm:gap-1 sm:px-3 sm:pt-1.5 sm:pb-2.5"
+        >
             <button
                 @click="expand"
-                class="focus-visible:ring-ring text-foreground cursor-pointer truncate text-left text-sm font-medium outline-none hover:underline focus-visible:ring-2"
+                class="focus-visible:ring-ring text-foreground line-clamp-2 min-w-0 flex-1 cursor-pointer text-left text-sm font-medium outline-none hover:underline focus-visible:ring-2 sm:flex-none sm:truncate"
                 :title="dock.current.value.name"
             >
                 {{ dock.current.value.name }}
             </button>
-            <input
-                type="range"
-                min="0"
-                :max="Math.max(1, Math.floor(dock.duration.value))"
-                :value="Math.floor(dock.position.value)"
-                @input="onScrub"
-                class="accent-primary h-1.5 w-full cursor-pointer"
-                aria-label="Seek"
-            />
-            <div class="flex items-center gap-1">
+            <div class="flex shrink-0 items-center gap-0.5 sm:w-full sm:gap-1">
                 <button
                     @click="dock.controls.value?.toggle()"
                     class="focus-visible:ring-ring text-foreground hover:bg-accent hover:text-foreground inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2"
@@ -189,12 +268,12 @@ onBeforeUnmount(() => window.removeEventListener('keydown', onKeydown));
                 >
                     <IconPlayerTrackNext class="h-5 w-5" aria-hidden="true" />
                 </button>
-                <span class="text-muted-foreground ml-1 text-xs tabular-nums">
+                <span class="text-muted-foreground ml-1 hidden text-xs tabular-nums sm:inline">
                     {{ formatTime(dock.position.value) }}<template v-if="dock.duration.value"> / {{ formatTime(dock.duration.value) }}</template>
                 </span>
                 <button
                     @click="expand"
-                    class="focus-visible:ring-ring text-muted-foreground hover:bg-accent hover:text-foreground ml-auto inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2"
+                    class="focus-visible:ring-ring text-muted-foreground hover:bg-accent hover:text-foreground ml-auto hidden h-10 w-10 cursor-pointer items-center justify-center rounded-md outline-none focus-visible:ring-2 sm:inline-flex"
                     aria-label="Open watch page"
                 >
                     <IconArrowsDiagonal class="h-5 w-5" aria-hidden="true" />

--- a/resources/js/composables/usePlayer.ts
+++ b/resources/js/composables/usePlayer.ts
@@ -124,25 +124,39 @@ export function usePlayer(iframe: Ref<HTMLIFrameElement | null>, videoUrl: strin
         if (provider === 'vimeo') attachVimeo();
     };
 
+    // Commands → the YouTube embed go via the low-level postMessage protocol the
+    // IFrame API speaks, NOT youtube.playVideo()/seekTo(). The API reliably
+    // *receives* events from our persistent iframe (state flows back), but the
+    // player object's command methods are flaky against an iframe it didn't
+    // create itself — controlling it from the mini-player silently no-ops.
+    // Posting commands straight to contentWindow is robust to that. Getters
+    // (getCurrentTime/getDuration) still come off the YT.Player via infoDelivery.
+    const ytCommand = (func: string, args: unknown[] = []) => {
+        iframe.value?.contentWindow?.postMessage(JSON.stringify({ event: 'command', func, args }), '*');
+    };
+
     const play = () => {
-        youtube?.playVideo?.();
+        ytCommand('playVideo');
         vimeo?.play().catch(() => {});
     };
     const pause = () => {
-        youtube?.pauseVideo?.();
+        ytCommand('pauseVideo');
         vimeo?.pause().catch(() => {});
     };
     const toggle = () => (playing.value ? pause() : play());
     const seekTo = (seconds: number) => {
         const target = Math.max(0, seconds);
-        youtube?.seekTo?.(target, true);
+        ytCommand('seekTo', [target, true]);
         vimeo?.setCurrentTime(target).catch(() => {});
         position.value = target;
+        // Reflect the new spot immediately (the heartbeat is paused while paused,
+        // so without this the mini-player bar wouldn't move until playback resumes)
+        callbacks.onProgress?.(target, duration.value);
     };
     const seekBy = (seconds: number) => seekTo(position.value + seconds);
     const toggleMute = () => {
-        if (youtube) {
-            muted.value ? youtube.unMute?.() : youtube.mute?.();
+        if (provider === 'youtube') {
+            ytCommand(muted.value ? 'unMute' : 'mute');
             muted.value = !muted.value;
         }
         vimeo?.getMuted().then((m) => {


### PR DESCRIPTION
## What

Three connected fixes to the persistent mini-player, all verified in Claude Preview (mobile, both themes).

### 1. Mini-player controls now actually work (the important one)
Pause/scrub/next from the mini-player silently did nothing. Root cause: `usePlayer` wraps our *persistent* iframe with `new YT.Player(iframe)`. That reliably **receives** events (state flows back — which is why YouTube's own controls updated our UI), but the player object's command methods (`playVideo`/`pauseVideo`/`seekTo`) no-op against an iframe the API didn't create itself. Fix: send commands via the low-level postMessage protocol the IFrame API speaks, straight to `contentWindow`. Getters (`getCurrentTime`/`getDuration`) still come off `YT.Player` via infoDelivery.

### 2. Reel-style seek bar (replaces the chunky red slider)
A near-invisible 2px translucent track that fills with playback and grows to 4px on hover/focus. A native `<input type=range>` only scrubs by grabbing its invisible thumb (and iOS Safari won't even click-to-seek), so it's now a custom **press/drag-anywhere** slider (`role="slider"`, pointer + keyboard `←/→/Home/End`, `prefers-reduced-motion` aware).

### 3. Full-width bottom bar on mobile (like the YouTube app)
On phones the mini-player docks as a full-width bottom bar — compact thumbnail + title + controls, progress pinned to the top edge. Desktop keeps the floating corner card. One persistent iframe, reflowed responsively (no duplicate player).

`seekTo` also pushes the new position to the dock immediately, so the bar reflects a seek even while paused.

## Files
- `resources/js/composables/usePlayer.ts` — postMessage command channel + immediate seek feedback
- `resources/js/components/organisms/PersistentPlayer.vue` — custom slider + responsive layout

## Verification
Claude Preview @375px: full-width bar (375px, pinned bottom); **our Pause button pauses the embed** (state flips, position freezes); tap/drag seeks; track 2px→4px on focus. Production `build-only` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)