### PR TITLE
feat(player): restore mini-player across page refresh

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -4,6 +4,7 @@ import { createInertiaApp, router } from '@inertiajs/vue3';
 import { createApp, createSSRApp, type DefineComponent, h } from 'vue';
 import { initializeTheme } from '~/composables/useAppearance';
 import { useFlash } from '~/composables/useFlash';
+import { usePlayerDock } from '~/composables/usePlayerDock';
 import { initializeTextScale } from '~/composables/useTextScale';
 import { initializeAnalytics } from '~/lib/analytics';
 import { resolvePageComponent } from '~/lib/inertia-helper';
@@ -65,3 +66,7 @@ router.on('networkError', () => {
 initializeTheme();
 initializeTextScale();
 initializeAnalytics();
+// Bring back the mini-player if a video was playing before a refresh (paused,
+// at the saved timecode). A watch page re-docks itself, so this only floats it
+// on other pages.
+usePlayerDock().restore();

--- a/resources/js/composables/usePlayerDock.ts
+++ b/resources/js/composables/usePlayerDock.ts
@@ -1,4 +1,4 @@
-import { computed, ref, shallowRef } from 'vue';
+import { computed, ref, shallowRef, watch } from 'vue';
 
 /**
  * Shared state for the persistent player (the "dock"). The iframe lives in
@@ -36,6 +36,39 @@ const controls = shallowRef<DockControls | null>(null);
 
 const mode = computed(() => (current.value ? (placeholder.value ? 'docked' : 'mini') : 'hidden'));
 
+// ----- survive a page refresh -----
+// The dock is in-memory, so a reload would drop whatever's playing. Mirror the
+// active video + position to localStorage (client-side; nothing to do with the
+// Django session) and rehydrate on boot via restore(). Cleared on close().
+const STORAGE_KEY = 'ctv:active-player';
+
+const persist = () => {
+    if (typeof localStorage === 'undefined') return;
+    if (!current.value) {
+        localStorage.removeItem(STORAGE_KEY);
+        return;
+    }
+    localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+            id: current.value.id,
+            name: current.value.name,
+            url: current.value.url,
+            position: Math.floor(position.value),
+        }),
+    );
+};
+
+// Save when the video changes (incl. clear on close) and as playback advances,
+// throttled so we're not writing every heartbeat tick.
+let lastSavedAt = 0;
+watch(current, persist);
+watch(position, (seconds) => {
+    if (!current.value || Math.abs(seconds - lastSavedAt) < 5) return;
+    lastSavedAt = seconds;
+    persist();
+});
+
 export function usePlayerDock() {
     /** Make this the playing video. Returns false (no-op) when it already is —
      * that's the seamless maximize: same iframe, playback never stops. */
@@ -63,6 +96,27 @@ export function usePlayerDock() {
         if (!el && !playing.value) close();
     };
 
+    /** Rehydrate the dock from localStorage on app boot (paused, at the saved
+     * timecode). No-op if nothing was playing or it's already restored. Called
+     * once from app.ts. */
+    const restore = () => {
+        if (typeof localStorage === 'undefined' || current.value) return;
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return;
+        try {
+            const saved = JSON.parse(raw);
+            if (saved?.id && saved?.url) {
+                load({ id: saved.id, name: saved.name, url: saved.url }, { startAt: saved.position || 0 });
+                // load() zeroes position; seed it with the saved timecode so the
+                // bar shows the right spot (and a paused restore doesn't persist 0
+                // back over the saved value before the heartbeat catches up).
+                position.value = saved.position || 0;
+            }
+        } catch {
+            localStorage.removeItem(STORAGE_KEY);
+        }
+    };
+
     return {
         current,
         next,
@@ -77,5 +131,6 @@ export function usePlayerDock() {
         load,
         close,
         setPlaceholder,
+        restore,
     };
 }


### PR DESCRIPTION
## What
The persistent mini-player now survives a page refresh — reload and it returns, paused, at the same timecode.

The dock state is purely in-memory Vue (`usePlayerDock`), so a reload dropped it. This mirrors the active video + position to **localStorage** (client-side — *not* the Django/Redis session) and rehydrates on boot.

- `usePlayerDock`: persist `{id, name, url, position}` on video change + as playback advances (throttled ~5s); cleared on `close()`. New `restore()` loads it back with `startAt`, and seeds `position` so the bar shows the right spot (and a paused restore doesn't write `0` over the saved value before the heartbeat catches up).
- `app.ts`: call `restore()` on boot. A watch page re-docks itself, so this only floats the mini-player on other pages.

## Verification (Claude Preview)
- Reload → mini-player returns at the saved timecode, paused (`embed ?start=125`, `autoplay=0`); seek bar shows the position.
- Timecode **survives repeated refreshes** (no `0` clobber).
- **Close → player gone + localStorage cleared** (won't resurrect on next reload).

type-check, lint, format, build all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)