### PR TITLE
feat(search): Typesense index foundation — unified content collection (#213)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,13 @@ VITE_PORT=5173
 INERTIA_SSR_ENABLED=False
 # INERTIA_SSR_URL=http://127.0.0.1:13714
 
+# Typesense search (optional locally: `docker compose up typesense` then set the
+# key below to match; leave empty to fall back to ORM search). Loopback only.
+TYPESENSE_API_KEY=
+TYPESENSE_HOST=127.0.0.1
+TYPESENSE_PORT=8108
+TYPESENSE_PROTOCOL=http
+
 # Observability (leave empty locally; set on servers / CI)
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=

--- a/app/base_settings.py
+++ b/app/base_settings.py
@@ -114,6 +114,18 @@ MEDIA_ROOT = BASE_DIR / "media"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
+# Typesense search backend (catalogue/search.py). Optional everywhere: when
+# unconfigured (no API key) or unreachable, the search views fall back to ORM
+# icontains, so search never hard-fails. Beta/prod run a loopback-only container
+# (docs/DEPLOYMENT.md); local dev uses docker-compose.yml.
+TYPESENSE = {
+    "api_key": os.getenv("TYPESENSE_API_KEY", ""),
+    "host": os.getenv("TYPESENSE_HOST", "127.0.0.1"),
+    "port": os.getenv("TYPESENSE_PORT", "8108"),
+    "protocol": os.getenv("TYPESENSE_PROTOCOL", "http"),
+    "connection_timeout_seconds": int(os.getenv("TYPESENSE_TIMEOUT", "2")),
+}
+
 # Logging
 LOGGING = {
     "version": 1,

--- a/catalogue/management/commands/reindex_search.py
+++ b/catalogue/management/commands/reindex_search.py
@@ -1,0 +1,32 @@
+"""Rebuild the Typesense ``content`` search index from the database.
+
+Run after the destructive importers (they delete-all-then-reload) and whenever
+the index drifts. Safe to run repeatedly — it drops and recreates the
+collection. No-op-safe: errors loudly if Typesense is unconfigured/unreachable.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from catalogue.search import COLLECTION, SearchUnavailableError, reindex
+
+
+class Command(BaseCommand):
+    help = "Rebuild the Typesense search index from the database."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--batch-size",
+            type=int,
+            default=500,
+            help="Documents per import request (default: 500).",
+        )
+
+    def handle(self, *args, **options):
+        self.stdout.write(f"Rebuilding the '{COLLECTION}' Typesense collection…")
+        try:
+            total = reindex(batch_size=options["batch_size"], log=self.stdout.write)
+        except SearchUnavailableError as exc:
+            raise CommandError(
+                f"Typesense unavailable ({exc}). Set TYPESENSE_API_KEY/HOST and ensure the container is running."
+            ) from exc
+        self.stdout.write(self.style.SUCCESS(f"Indexed {total} documents into '{COLLECTION}'."))

--- a/catalogue/search.py
+++ b/catalogue/search.py
@@ -1,0 +1,339 @@
+"""Typesense search backend for the catalogue.
+
+A single unified ``content`` collection holds every searchable thing — videos
+and the category models (series, speakers, topics, Bible books, channels,
+ministries, audiences) — each tagged with a ``kind``. The search views
+(``app/views.py``: ``palette``, ``search``) query this collection and **fall
+back to ORM ``icontains``** when Typesense is unconfigured or unreachable, so
+search never hard-fails.
+
+Video counts are baked into each category doc at index time, using the *same*
+relation the views count (Series via the ``Series.videos`` M2M, everything else
+via the ``video`` reverse — the ``Video.series`` FK is a decoy that is never
+populated). A search therefore returns ranked results *and* the per-category
+video counts with zero per-hit ORM queries.
+"""
+
+import contextlib
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import typesense
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+COLLECTION = "content"
+
+# Canonical kinds stored on every doc. The views map these to their own display
+# labels ("Series", "Bible Book", …) — keep the index labels stable.
+KIND_VIDEO = "video"
+KIND_SERIES = "series"
+KIND_SPEAKER = "speaker"
+KIND_TOPIC = "topic"
+KIND_BOOK = "book"
+KIND_CHANNEL = "channel"
+KIND_MINISTRY = "ministry"
+KIND_AUDIENCE = "audience"
+
+# `name` carries more signal than the long description/bio/summary `text`.
+QUERY_BY = "name,text"
+QUERY_BY_WEIGHTS = "4,1"
+
+CONTENT_SCHEMA = {
+    "name": COLLECTION,
+    "fields": [
+        {"name": "kind", "type": "string", "facet": True},
+        {"name": "pk", "type": "string", "index": False, "optional": True},
+        {"name": "name", "type": "string"},
+        {"name": "text", "type": "string"},
+        {"name": "url", "type": "string", "index": False, "optional": True},
+        {"name": "videos_count", "type": "int32"},
+        {"name": "date_epoch", "type": "int64", "optional": True},
+        {"name": "date_display", "type": "string", "index": False, "optional": True},
+        {"name": "is_livestream", "type": "bool", "facet": True, "optional": True},
+    ],
+    # Global tiebreaker: more-watched categories rank first when relevance ties.
+    "default_sorting_field": "videos_count",
+}
+
+# Church-domain synonyms so a search for one term matches its siblings. Multi-way
+# set: any term finds documents containing any other.
+SYNONYMS = {
+    "talk": ["talk", "sermon", "message", "address", "preaching"],
+}
+
+
+class SearchUnavailableError(Exception):
+    """Typesense is unconfigured or unreachable. Callers catch this and fall
+    back to the ORM query so search keeps working."""
+
+
+def get_client():
+    """Build a Typesense client from settings, or ``None`` when no API key is
+    configured (the signal to use the ORM fallback)."""
+    cfg = getattr(settings, "TYPESENSE", None) or {}
+    if not cfg.get("api_key"):
+        return None
+    return typesense.Client(
+        {
+            "api_key": cfg["api_key"],
+            "nodes": [{"host": cfg["host"], "port": str(cfg["port"]), "protocol": cfg["protocol"]}],
+            "connection_timeout_seconds": cfg.get("connection_timeout_seconds", 2),
+        }
+    )
+
+
+def _require_client():
+    client = get_client()
+    if client is None:
+        raise SearchUnavailableError("Typesense is not configured")
+    return client
+
+
+# --------------------------------------------------------------------------- #
+# Document builders
+# --------------------------------------------------------------------------- #
+
+
+def _epoch(d):
+    """A timezone-stable UTC-midnight epoch for a ``date`` (or ``None``)."""
+    if d is None:
+        return None
+    return int(datetime(d.year, d.month, d.day, tzinfo=UTC).timestamp())
+
+
+def build_video_doc(video):
+    recorded = video.date_recorded or video.date_created
+    return {
+        "id": f"{KIND_VIDEO}:{video.pk}",
+        "kind": KIND_VIDEO,
+        "pk": str(video.pk),
+        "name": video.name or "",
+        "text": video.description or "",
+        "url": f"/video/{video.pk}",
+        "videos_count": 0,
+        "date_epoch": _epoch(recorded),
+        "date_display": recorded.isoformat() if recorded else None,
+        "is_livestream": bool(video.is_livestream),
+    }
+
+
+def build_category_doc(*, kind, pk, name, text, url, videos_count):
+    return {
+        "id": f"{kind}:{pk}",
+        "kind": kind,
+        "pk": str(pk),
+        "name": name or "",
+        "text": text or "",
+        "url": url or "",
+        "videos_count": int(videos_count or 0),
+    }
+
+
+def iter_content_docs():
+    """Yield a Typesense doc for every searchable object. Counts mirror the view
+    queries exactly so the proxy returns identical numbers."""
+    from django.db.models import Count
+
+    from catalogue.ingest.normalize import clean_name, clean_topic_name
+    from catalogue.models.bible_book import Bible_Book
+    from catalogue.models.channel import Channel
+    from catalogue.models.demograpic import Demographic
+    from catalogue.models.ministry import Ministry
+    from catalogue.models.series import Series
+    from catalogue.models.speaker import Speaker
+    from catalogue.models.topic import Topic
+    from catalogue.models.video import Video
+
+    for v in Video.objects.all().iterator():
+        yield build_video_doc(v)
+
+    # Series videos live on the Series.videos M2M (the FK reverse is never set).
+    for s in Series.objects.annotate(n=Count("videos")).iterator():
+        yield build_category_doc(
+            kind=KIND_SERIES,
+            pk=s.pk,
+            name=clean_name(s.name),
+            text=s.summary or "",
+            url=s.get_absolute_url(),
+            videos_count=s.n,
+        )
+
+    for sp in Speaker.objects.annotate(n=Count("video")).iterator():
+        yield build_category_doc(
+            kind=KIND_SPEAKER,
+            pk=sp.pk,
+            name=clean_name(sp.name),
+            text=sp.bio or "",
+            url=sp.get_absolute_url(),
+            videos_count=sp.n,
+        )
+
+    for t in Topic.objects.annotate(n=Count("video")).iterator():
+        yield build_category_doc(
+            kind=KIND_TOPIC,
+            pk=t.pk,
+            name=clean_topic_name(t.name),
+            text=t.summary or "",
+            url=t.get_absolute_url(),
+            videos_count=t.n,
+        )
+
+    # Bible books: the display name lives behind a choice code; index that.
+    for b in Bible_Book.objects.annotate(n=Count("video")).iterator():
+        yield build_category_doc(
+            kind=KIND_BOOK,
+            pk=b.pk,
+            name=b.get_name_display(),
+            text=b.summary or "",
+            url=b.get_absolute_url(),
+            videos_count=b.n,
+        )
+
+    for c in Channel.objects.annotate(n=Count("video")).iterator():
+        yield build_category_doc(
+            kind=KIND_CHANNEL,
+            pk=c.pk,
+            name=clean_name(c.name),
+            text=c.summary or "",
+            url=c.get_absolute_url(),
+            videos_count=c.n,
+        )
+
+    for m in Ministry.objects.annotate(n=Count("video")).iterator():
+        yield build_category_doc(
+            kind=KIND_MINISTRY,
+            pk=m.pk,
+            name=clean_name(m.name),
+            text=m.summary or "",
+            url=m.get_absolute_url(),
+            videos_count=m.n,
+        )
+
+    for a in Demographic.objects.annotate(n=Count("video")).iterator():
+        yield build_category_doc(
+            kind=KIND_AUDIENCE,
+            pk=a.pk,
+            name=clean_name(a.name),
+            text=a.summary or "",
+            url=a.get_absolute_url(),
+            videos_count=a.n,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Index lifecycle
+# --------------------------------------------------------------------------- #
+
+
+def recreate_collection(client):
+    """Drop and recreate the ``content`` collection, then (re)apply synonyms."""
+    with contextlib.suppress(typesense.exceptions.ObjectNotFound):
+        client.collections[COLLECTION].delete()
+    client.collections.create(CONTENT_SCHEMA)
+    for name, terms in SYNONYMS.items():
+        client.collections[COLLECTION].synonyms.upsert(name, {"synonyms": terms})
+
+
+def _import_batch(client, batch):
+    results = client.collections[COLLECTION].documents.import_(batch, {"action": "upsert"})
+    failures = [r for r in results if isinstance(r, dict) and not r.get("success", True)]
+    for f in failures:
+        logger.warning("Typesense import failure: %s", f.get("error", f))
+    return len(batch) - len(failures)
+
+
+def reindex(*, batch_size=500, log=None):
+    """Full rebuild of the search index from the database. Returns the number of
+    documents successfully indexed."""
+    log = log or (lambda *_: None)
+    client = _require_client()
+    recreate_collection(client)
+
+    total, batch = 0, []
+    for doc in iter_content_docs():
+        batch.append(doc)
+        if len(batch) >= batch_size:
+            total += _import_batch(client, batch)
+            log(f"  …{total} indexed")
+            batch = []
+    if batch:
+        total += _import_batch(client, batch)
+    return total
+
+
+# --------------------------------------------------------------------------- #
+# Query helpers (used by the view proxy; raise SearchUnavailableError on any
+# Typesense error so the view can fall back to ORM)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class Hit:
+    kind: str
+    pk: str
+    name: str
+    url: str
+    videos_count: int
+    date_display: str | None = None
+    is_livestream: bool = False
+
+
+def _hit(doc):
+    return Hit(
+        kind=doc.get("kind", ""),
+        pk=doc.get("pk", ""),
+        name=doc.get("name", ""),
+        url=doc.get("url", ""),
+        videos_count=doc.get("videos_count", 0),
+        date_display=doc.get("date_display"),
+        is_livestream=doc.get("is_livestream", False),
+    )
+
+
+def search_videos(query, *, page=1, per_page=24):
+    """Ranked video hits for ``query``. Returns ``(hits, found)``."""
+    client = _require_client()
+    try:
+        res = client.collections[COLLECTION].documents.search(
+            {
+                "q": query,
+                "query_by": QUERY_BY,
+                "query_by_weights": QUERY_BY_WEIGHTS,
+                "filter_by": f"kind:={KIND_VIDEO}",
+                "page": page,
+                "per_page": per_page,
+                "sort_by": "_text_match:desc,date_epoch:desc",
+                "include_fields": "pk,name,url,date_display,is_livestream,kind,videos_count",
+            }
+        )
+    except typesense.exceptions.TypesenseClientError as e:
+        raise SearchUnavailableError(str(e)) from e
+    return [_hit(h["document"]) for h in res.get("hits", [])], res.get("found", 0)
+
+
+def search_categories(query, *, kinds, per_kind=6):
+    """Up to ``per_kind`` ranked hits per kind, across the requested ``kinds``."""
+    client = _require_client()
+    try:
+        res = client.collections[COLLECTION].documents.search(
+            {
+                "q": query,
+                "query_by": QUERY_BY,
+                "query_by_weights": QUERY_BY_WEIGHTS,
+                "filter_by": f"kind:[{','.join(kinds)}]",
+                "group_by": "kind",
+                "group_limit": per_kind,
+                "per_page": 50,
+                "sort_by": "_text_match:desc,videos_count:desc",
+                "include_fields": "pk,name,url,kind,videos_count",
+            }
+        )
+    except typesense.exceptions.TypesenseClientError as e:
+        raise SearchUnavailableError(str(e)) from e
+    hits = []
+    for group in res.get("grouped_hits", []):
+        hits.extend(_hit(h["document"]) for h in group.get("hits", []))
+    return hits

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+# Local Typesense for search development only. Beta/prod run their own
+# persistent container provisioned on the server (see docs/DEPLOYMENT.md) — this
+# file is not used there. Bound to loopback so it is never exposed off-machine.
+#
+#   docker compose up typesense      # or: uv run poe typesense
+#   uv run poe manage reindex_search
+#
+# Set TYPESENSE_API_KEY in your .env to the same value (default: dev-typesense-key).
+services:
+  typesense:
+    image: typesense/typesense:28.0
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8108:8108"
+    volumes:
+      - typesense-data:/data
+    command: "--data-dir /data --api-key=${TYPESENSE_API_KEY:-dev-typesense-key} --enable-cors"
+
+volumes:
+  typesense-data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "django-vite>=3.1",
     "sentry-sdk>=2.62.0",
     "beautifulsoup4>=4.15.0",
+    "typesense>=2.0.0",
 ]
 
 [dependency-groups]
@@ -85,6 +86,10 @@ sequence = ["lint", "format"]
 [tool.poe.tasks.test]
 help = "Run the test suite"
 cmd = "pytest"
+
+[tool.poe.tasks.typesense]
+help = "Run a local Typesense container for search development"
+cmd = "docker compose up typesense"
 
 [tool.poe.tasks.generate-key]
 help = "Generate a Django secret key and write it to the .env file if SECRET_KEY is empty"

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -1,0 +1,149 @@
+"""Typesense index building (catalogue/search.py).
+
+These tests are pure-Python doc-shape + count checks and a guarded live
+round-trip. The doc/count tests need no Typesense; the live test skips unless a
+reachable Typesense is configured (TYPESENSE_API_KEY set + container up), so CI
+without a container stays green.
+"""
+
+import datetime
+
+import pytest
+
+from catalogue import search
+from tests.factories import (
+    BibleBookFactory,
+    SeriesFactory,
+    SpeakerFactory,
+    TopicFactory,
+    VideoFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_get_client_is_none_without_api_key(settings):
+    settings.TYPESENSE = {**settings.TYPESENSE, "api_key": ""}
+    assert search.get_client() is None
+
+
+def test_build_video_doc_shape():
+    video = VideoFactory(
+        name="Romans 8",
+        description="The Spirit and adoption.",
+        is_livestream=True,
+        date_recorded=datetime.date(2026, 3, 4),
+    )
+
+    doc = search.build_video_doc(video)
+
+    assert doc["id"] == f"video:{video.pk}"
+    assert doc["kind"] == search.KIND_VIDEO
+    assert doc["name"] == "Romans 8"
+    assert doc["text"] == "The Spirit and adoption."
+    assert doc["url"] == f"/video/{video.pk}"
+    assert doc["videos_count"] == 0
+    assert doc["is_livestream"] is True
+    assert doc["date_display"] == "2026-03-04"
+    assert isinstance(doc["date_epoch"], int)
+
+
+def test_video_doc_falls_back_to_date_created_when_unrecorded():
+    video = VideoFactory(date_recorded=None, date_created=datetime.date(2026, 2, 1))
+
+    doc = search.build_video_doc(video)
+
+    assert doc["date_display"] == "2026-02-01"
+
+
+def test_build_category_doc_shape():
+    doc = search.build_category_doc(
+        kind=search.KIND_SERIES, pk="S007", name="Romans", text="A study.", url="/series/S007", videos_count=12
+    )
+
+    assert doc == {
+        "id": "series:S007",
+        "kind": "series",
+        "pk": "S007",
+        "name": "Romans",
+        "text": "A study.",
+        "url": "/series/S007",
+        "videos_count": 12,
+    }
+
+
+def test_iter_content_docs_counts_series_via_m2m_not_the_decoy_fk():
+    # The decoy: Video.series FK is never populated. A series' real video count
+    # lives on the Series.videos M2M — the same relation the views Count.
+    series = SeriesFactory(name="Romans for Everyone")
+    series.videos.add(VideoFactory(), VideoFactory())
+    VideoFactory(series=series)  # FK-linked only: must NOT inflate the count
+
+    docs = {d["id"]: d for d in search.iter_content_docs()}
+
+    assert docs[f"series:{series.pk}"]["videos_count"] == 2
+    assert docs[f"series:{series.pk}"]["kind"] == "series"
+
+
+def test_iter_content_docs_covers_each_kind_with_counts():
+    speaker = SpeakerFactory(name="Paul")
+    speaker.video_set.add(VideoFactory())
+    topic = TopicFactory(name="Grace")
+    VideoFactory().topic.add(topic)
+    book = BibleBookFactory()  # GEN / "Genesis"
+    VideoFactory().bible_book.add(book)
+
+    docs = {d["id"]: d for d in search.iter_content_docs()}
+
+    assert docs[f"speaker:{speaker.pk}"]["videos_count"] == 1
+    assert docs[f"topic:{topic.pk}"]["videos_count"] == 1
+    # Bible books index the display name, not the choice code.
+    assert docs[f"book:{book.pk}"]["name"] == "Genesis"
+    assert docs[f"book:{book.pk}"]["videos_count"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# Guarded live round-trip — skipped unless a reachable Typesense is configured.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def live_client():
+    client = search.get_client()
+    if client is None:
+        pytest.skip("Typesense not configured (set TYPESENSE_API_KEY)")
+    try:
+        client.collections.retrieve()
+    except Exception:
+        pytest.skip("Typesense not reachable")
+    return client
+
+
+def test_reindex_then_typo_and_synonym_search(live_client):
+    VideoFactory(name="The Sermon on the Mount", description="Matthew 5-7")
+    VideoFactory(name="Unrelated clip")
+
+    indexed = search.reindex()
+    assert indexed >= 2
+
+    # Typo tolerance: "sermom" → "sermon".
+    hits, found = search.search_videos("sermom", per_page=10)
+    assert any("Sermon on the Mount" in h.name for h in hits)
+    assert found >= 1
+
+    # Synonym: "talk" is configured as a synonym of "sermon".
+    hits, _ = search.search_videos("talk on the mount", per_page=10)
+    assert any("Sermon on the Mount" in h.name for h in hits)
+
+
+def test_reindex_then_category_search_groups_by_kind_with_counts(live_client):
+    series = SeriesFactory(name="Galatians Unpacked")
+    series.videos.add(VideoFactory(), VideoFactory())
+
+    search.reindex()
+
+    hits = search.search_categories("galatins", kinds=[search.KIND_SERIES, search.KIND_SPEAKER])
+    match = next(h for h in hits if h.name == "Galatians Unpacked")
+    assert match.kind == "series"
+    assert match.videos_count == 2  # baked in — no per-hit ORM query
+    assert match.url

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,18 @@ revision = 3
 requires-python = ">=3.14"
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
@@ -99,6 +111,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "redis" },
     { name = "sentry-sdk" },
+    { name = "typesense" },
     { name = "whitenoise" },
 ]
 
@@ -125,6 +138,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.1" },
     { name = "redis", specifier = ">=5.2" },
     { name = "sentry-sdk", specifier = ">=2.62.0" },
+    { name = "typesense", specifier = ">=2.0.0" },
     { name = "whitenoise", specifier = ">=6.9" },
 ]
 
@@ -276,6 +290,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -604,6 +655,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+]
+
+[[package]]
+name = "typesense"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/92/ca06da7ad7e771804fe21fdcfbc99d24079bedb9ab0ceaedac7ea1001263/typesense-2.0.0.tar.gz", hash = "sha256:9a306e328bf0c0030679c154730ec142efbf07fd0c33845b3efae10291e983e7", size = 79292, upload-time = "2026-02-16T16:37:56.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/a5/a392604f3eeed45d3d72f8f10b45a80082a826338609e62187d9e3614001/typesense-2.0.0-py3-none-any.whl", hash = "sha256:7eecc672e4049f7b5777e1cf1e7900d2d1ae2d28a670eda6545b568d1cde1700", size = 140736, upload-time = "2026-02-16T16:37:55.256Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Slice 1 of the Typesense hybrid-search epic (#213).** Kicks off the rebuild from `docs/TYPESENSE_HANDOVER.md`, harvesting the working approach from @mtbu's spike #167 but rebuilt on `beta` (uv, strict-encoder-safe shapes, correct counts, graceful fallback).

This slice is the **index layer only — no view changes**, so live search behaviour is unchanged until the proxy lands in Slice 2.

### What's here
- **`catalogue/search.py`** — thin Typesense client (`get_client()` returns `None` when unconfigured → the ORM-fallback signal), one **unified `content` collection** (every doc tagged with a `kind`), doc builders, and query helpers (`search_videos`, grouped `search_categories`) that raise `SearchUnavailableError` on any Typesense error for the caller to fall back on.
- **Counts baked into the index.** Each category doc carries `videos_count` computed via the *same* relation the views count — `Count("videos")` for Series, `Count("video")` elsewhere — so the proxy will return identical counts with **zero per-hit ORM queries**, sidestepping the decoy `Video.series` FK (#167's series counts returned 0).
- **`reindex_search`** management command (batched full rebuild).
- **Config**: `TYPESENSE_*` in `base_settings` + `.env.example`; local **`docker-compose.yml`** (loopback only) + `poe typesense`.

### Verification
- `uv run poe test` green (199 passed); `poe fix` clean.
- Doc-shape + count-parity tests need no Typesense (incl. the series-decoy trap); a **guarded live round-trip** proves typo + synonym + grouped-category search (skips in CI without a container).
- Validated against the **full local catalogue — 12,931 docs indexed**; `genisis`→Genesis, `forgivness`→forgiveness typo-match at scale, baked counts correct (book Romans = 159).

Part of #213. Supersedes the approach in #167 (left open for @mtbu).