### PR TITLE
feat(search): serve palette + search via Typesense with ORM fallback (#213)

### DIFF
--- a/app/test_settings.py
+++ b/app/test_settings.py
@@ -1,6 +1,7 @@
 import os
 
 from .base_settings import *  # noqa: F403
+from .base_settings import TYPESENSE
 
 SECRET_KEY = os.environ.get("SECRET_KEY", "unit-test-key")
 
@@ -24,3 +25,9 @@ DJANGO_VITE = {
         "dev_mode": True,
     },
 }
+
+# Search runs through the ORM fallback by default so the suite is deterministic
+# regardless of a developer's environment (test data is never indexed). The
+# guarded live search tests re-enable Typesense from the environment for their
+# own test only.
+TYPESENSE = {**TYPESENSE, "api_key": ""}

--- a/app/views.py
+++ b/app/views.py
@@ -1,6 +1,9 @@
+import logging
+import math
 from collections import Counter
 from urllib.parse import unquote  # Import for URL decoding
 
+import sentry_sdk
 from django.core.paginator import Paginator
 from django.db.models import Count, F, Q, Sum
 from django.http import JsonResponse
@@ -10,6 +13,7 @@ from app.browse import browse_props
 from app.cards import video_card_props
 from app.feed import latest_feed
 from app.sanitize import sanitize_description
+from catalogue import search as search_index
 from catalogue.ingest.normalize import clean_name, clean_topic_name
 from catalogue.models.bible_book import Bible_Book
 from catalogue.models.channel import Channel
@@ -24,10 +28,34 @@ from catalogue.youtube_live import homepage_live_props, live_streams, upcoming_s
 
 pagination_per_page = 24
 
+logger = logging.getLogger(__name__)
+
 # Newest first with undated entries at the END on both engines: Postgres
 # defaults DESC to NULLS FIRST (undated videos would top every rail),
 # SQLite to nulls last — the mismatch hid this locally.
 RECENT_FIRST = F("date_recorded").desc(nulls_last=True)
+
+# Index `kind` → the display label each surface uses. The palette and the search
+# page label the same kinds differently (kept for output parity).
+PALETTE_KIND_LABELS = {
+    search_index.KIND_SERIES: "Series",
+    search_index.KIND_SPEAKER: "Speaker",
+    search_index.KIND_TOPIC: "Topic",
+    search_index.KIND_MINISTRY: "Ministry",
+    search_index.KIND_BOOK: "Book",
+}
+SEARCH_KIND_LABELS = {
+    search_index.KIND_CHANNEL: "Channels",
+    search_index.KIND_AUDIENCE: "Demographics",
+    search_index.KIND_MINISTRY: "Ministries",
+    search_index.KIND_SERIES: "Series",
+    search_index.KIND_SPEAKER: "Speakers",
+    search_index.KIND_TOPIC: "Topics",
+    search_index.KIND_BOOK: "Bible Book",
+}
+# Per-kind cap for the full search page (the ORM path is uncapped; Typesense
+# ranks by relevance so a generous cap keeps the chip list useful but bounded).
+SEARCH_CATEGORY_LIMIT = 20
 
 
 def index(request):
@@ -158,11 +186,38 @@ PALETTE_LIMIT = 6
 
 def palette(request):
     """Grouped name-only search for the ⌘K command palette. Fired on every
-    keystroke, so: no description scans, hard caps, JSON not Inertia."""
+    keystroke, so: hard caps, JSON not Inertia. Served by Typesense (typo- and
+    synonym-tolerant) with a graceful ORM fallback so it never hard-fails."""
     query = request.GET.get("q", "").strip()
     if not query:
         return JsonResponse({"videos": [], "categories": []})
 
+    try:
+        payload = _palette_typesense(query)
+    except search_index.SearchUnavailableError as exc:
+        logger.info("palette: Typesense unavailable, using ORM fallback (%s)", exc)
+        payload = _palette_orm(query)
+    except Exception:
+        logger.warning("palette: Typesense proxy error, using ORM fallback", exc_info=True)
+        sentry_sdk.capture_exception()
+        payload = _palette_orm(query)
+
+    return JsonResponse(payload)
+
+
+def _palette_typesense(query):
+    video_hits, _ = search_index.search_videos(query, page=1, per_page=PALETTE_LIMIT)
+    videos = [{"id": h.pk, "name": h.name, "url": h.url, "date": h.date_display} for h in video_hits]
+
+    categories = [
+        {"kind": PALETTE_KIND_LABELS[h.kind], "name": h.name, "url": h.url, "count": h.videos_count}
+        for h in search_index.search_categories(query, kinds=list(PALETTE_KIND_LABELS), per_kind=PALETTE_LIMIT)
+    ]
+    return {"videos": videos, "categories": categories}
+
+
+def _palette_orm(query):
+    """Name-only ORM search — the fallback when Typesense is unavailable."""
     videos = [
         {"id": v.id, "name": v.name, "url": f"/video/{v.id}", "date": v.date_recorded or v.date_created}
         for v in Video.objects.filter(name__icontains=query).order_by(RECENT_FIRST)[:PALETTE_LIMIT]
@@ -185,7 +240,7 @@ def palette(request):
         for b in Bible_Book.objects.filter(summary__icontains=query).annotate(n=Count("video"))[:PALETTE_LIMIT]
     ]
 
-    return JsonResponse({"videos": videos, "categories": categories})
+    return {"videos": videos, "categories": categories}
 
 
 def browse_faceted(request):
@@ -195,17 +250,71 @@ def browse_faceted(request):
 
 
 def search(request):
+    """Full-page search. Served by Typesense (relevance-ranked, typo- and
+    synonym-tolerant) with a graceful ORM fallback so search never hard-fails.
+    Categories appear on page 1 only; both engines return the same prop shape."""
     searchquery = request.GET["search"]
-    page_num = 1
     try:
         page_num = int(request.GET.get("page", 1))
     except ValueError:
         page_num = 1
+
+    try:
+        props = _search_typesense(searchquery, page_num)
+    except search_index.SearchUnavailableError as exc:
+        logger.info("search: Typesense unavailable, using ORM fallback (%s)", exc)
+        props = _search_orm(searchquery, page_num)
+    except Exception:
+        logger.warning("search: Typesense proxy error, using ORM fallback", exc_info=True)
+        sentry_sdk.capture_exception()
+        props = _search_orm(searchquery, page_num)
+
+    return render(request, "Search", props)
+
+
+def _search_typesense(searchquery, page_num):
+    hits, found = search_index.search_videos(searchquery, page=page_num, per_page=pagination_per_page)
+    # Hydrate the ranked ids in one query, preserving Typesense's relevance order.
+    by_id = {str(v.id): v for v in Video.objects.filter(id__in=[h.pk for h in hits])}
+    ordered = [by_id[h.pk] for h in hits if h.pk in by_id]
+
+    total_pages = max(1, math.ceil(found / pagination_per_page))
+    props = {
+        "title": f"Search for '{searchquery}'",
+        "description": f"Found {found} {'video' if found == 1 else 'videos'} (page {page_num} of {total_pages})",
+        "videos": video_card_props(ordered),
+        "has_prev_page": page_num > 1,
+        "has_next_page": page_num * pagination_per_page < found,
+    }
+    if page_num == 1:
+        cat_hits = search_index.search_categories(
+            searchquery, kinds=list(SEARCH_KIND_LABELS), per_kind=SEARCH_CATEGORY_LIMIT
+        )
+        props["categories"] = [
+            {"category": SEARCH_KIND_LABELS[h.kind], "name": h.name, "videosCount": h.videos_count, "url": h.url}
+            for h in cat_hits
+        ]
+    return props
+
+
+def _search_orm(searchquery, page_num):
+    """ORM ``icontains`` search — the fallback when Typesense is unavailable."""
     video_results = []
     video_results += Video.objects.filter(name__icontains=searchquery)
     video_results += [v for v in Video.objects.filter(description__icontains=searchquery) if v not in video_results]
     paginator = Paginator(video_results, pagination_per_page)
     paginated = paginator.page(page_num)
+    description = (
+        f"Found {len(video_results)} {'video' if len(video_results) == 1 else 'videos'} "
+        f"(page {page_num} of {paginator.num_pages})"
+    )
+    props = {
+        "title": f"Search for '{searchquery}'",
+        "description": description,
+        "videos": video_card_props(paginated.object_list),
+        "has_prev_page": paginated.has_previous(),
+        "has_next_page": paginated.has_next(),
+    }
     if page_num == 1:
         category_results = []
         for model, model_name in [
@@ -240,32 +349,8 @@ def search(request):
             }
             for x in Bible_Book.objects.filter(summary__icontains=searchquery).annotate(n=Count("video"))
         ]
-        return render(
-            request,
-            "Search",
-            {
-                "title": f"Search for '{searchquery}'",
-                "description": f"Found {len(video_results)} {'video' if len(video_results) == 1 else 'videos'} \
-(page {page_num} of {paginator.num_pages})",
-                "videos": video_card_props(paginated.object_list),
-                "categories": category_results,
-                "has_prev_page": paginated.has_previous(),
-                "has_next_page": paginated.has_next(),
-            },
-        )
-    else:
-        return render(
-            request,
-            "Search",
-            {
-                "title": f"Search for '{searchquery}'",
-                "description": f"Found {len(video_results)} {'video' if len(video_results) == 1 else 'videos'} \
-(page {page_num} of {paginator.num_pages})",
-                "videos": video_card_props(paginated.object_list),
-                "has_prev_page": paginated.has_previous(),
-                "has_next_page": paginated.has_next(),
-            },
-        )
+        props["categories"] = category_results
+    return props
 
 
 def video(request, id):

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -18,6 +18,7 @@ from tests.factories import (
     TopicFactory,
     VideoFactory,
 )
+from tests.utils import typesense_env_config
 
 pytestmark = pytest.mark.django_db
 
@@ -108,10 +109,14 @@ def test_iter_content_docs_covers_each_kind_with_counts():
 
 
 @pytest.fixture
-def live_client():
-    client = search.get_client()
-    if client is None:
+def live_client(settings):
+    # test_settings disables Typesense; opt back in from the environment for this
+    # test only so the rest of the suite stays deterministic on the ORM path.
+    config = typesense_env_config()
+    if config is None:
         pytest.skip("Typesense not configured (set TYPESENSE_API_KEY)")
+    settings.TYPESENSE = config
+    client = search.get_client()
     try:
         client.collections.retrieve()
     except Exception:

--- a/tests/test_search_proxy.py
+++ b/tests/test_search_proxy.py
@@ -1,0 +1,150 @@
+"""The search proxy: palette + search served by Typesense with an ORM fallback.
+
+The Typesense path is exercised by monkeypatching the ``catalogue.search`` query
+helpers (no live server needed); the fallback path is exercised by making those
+helpers raise. A guarded live section hits the real endpoints over HTTP to prove
+typo/synonym tolerance end-to-end (skips without a container).
+"""
+
+import pytest
+
+from catalogue import search
+from catalogue.search import Hit, SearchUnavailableError
+from tests.factories import VideoFactory
+from tests.utils import inertia_page, typesense_env_config
+
+pytestmark = pytest.mark.django_db
+
+
+# --------------------------------------------------------------------------- #
+# Palette
+# --------------------------------------------------------------------------- #
+
+
+def test_palette_uses_typesense_when_available(client, monkeypatch):
+    video = Hit(kind="video", pk="7", name="Romans 8", url="/video/7", videos_count=0, date_display="2026-01-01")
+    monkeypatch.setattr(search, "search_videos", lambda q, **kw: ([video], 1))
+    monkeypatch.setattr(
+        search,
+        "search_categories",
+        lambda q, **kw: [
+            Hit(kind="series", pk="9", name="Romans", url="/series/9", videos_count=3),
+            Hit(kind="book", pk="45", name="Romans", url="/book/ROM", videos_count=120),
+        ],
+    )
+
+    data = client.get("/api/palette", {"q": "romans"}).json()
+
+    # The date round-trips from the index doc to the payload (cross-path parity).
+    assert data["videos"] == [{"id": "7", "name": "Romans 8", "url": "/video/7", "date": "2026-01-01"}]
+    by_kind = {(c["kind"], c["name"]): c for c in data["categories"]}
+    assert by_kind[("Series", "Romans")]["count"] == 3
+    assert by_kind[("Book", "Romans")]["count"] == 120
+
+
+def test_palette_falls_back_to_orm_when_typesense_unavailable(client, monkeypatch):
+    def boom(*a, **k):
+        raise SearchUnavailableError("down")
+
+    monkeypatch.setattr(search, "search_videos", boom)
+    VideoFactory(name="Grace Abounding")
+
+    data = client.get("/api/palette", {"q": "grace"}).json()
+
+    assert [v["name"] for v in data["videos"]] == ["Grace Abounding"]
+
+
+def test_palette_reports_unexpected_errors_to_sentry(client, monkeypatch):
+    captured = []
+
+    def boom(*a, **k):
+        raise ValueError("bug in proxy")
+
+    monkeypatch.setattr(search, "search_videos", boom)
+    monkeypatch.setattr("app.views.sentry_sdk.capture_exception", lambda *a, **k: captured.append(True))
+    VideoFactory(name="Grace Abounding")
+
+    data = client.get("/api/palette", {"q": "grace"}).json()
+
+    assert captured == [True]  # unexpected error reported
+    assert [v["name"] for v in data["videos"]] == ["Grace Abounding"]  # still served
+
+
+# --------------------------------------------------------------------------- #
+# Search page
+# --------------------------------------------------------------------------- #
+
+
+def test_search_uses_typesense_and_hydrates_in_relevance_order(client, monkeypatch):
+    v1 = VideoFactory(name="First")
+    v2 = VideoFactory(name="Second")
+    v3 = VideoFactory(name="Third")
+    ranked = [v3, v1, v2]  # Typesense relevance order, not DB order
+    hits = [Hit(kind="video", pk=str(v.id), name=v.name, url=f"/video/{v.id}", videos_count=0) for v in ranked]
+
+    monkeypatch.setattr(search, "search_videos", lambda q, **kw: (hits, 50))
+    monkeypatch.setattr(
+        search,
+        "search_categories",
+        lambda q, **kw: [Hit(kind="series", pk="9", name="A Series", url="/series/9", videos_count=4)],
+    )
+
+    props = inertia_page(client.get("/search", {"search": "x"}))["props"]
+
+    assert [v["id"] for v in props["videos"]] == [str(v3.id), str(v1.id), str(v2.id)]
+    assert props["description"] == "Found 50 videos (page 1 of 3)"
+    assert props["has_prev_page"] is False
+    assert props["has_next_page"] is True  # 24 < 50
+    assert props["categories"][0] == {"category": "Series", "name": "A Series", "videosCount": 4, "url": "/series/9"}
+
+
+def test_search_page_two_has_no_categories(client, monkeypatch):
+    monkeypatch.setattr(search, "search_videos", lambda q, **kw: ([], 50))
+    monkeypatch.setattr(search, "search_categories", lambda q, **kw: [])
+
+    props = inertia_page(client.get("/search", {"search": "x", "page": "2"}))["props"]
+
+    assert "categories" not in props
+    assert props["has_prev_page"] is True
+
+
+def test_search_falls_back_to_orm_when_typesense_unavailable(client, monkeypatch):
+    def boom(*a, **k):
+        raise SearchUnavailableError("down")
+
+    monkeypatch.setattr(search, "search_videos", boom)
+    VideoFactory(name="Unique Sermon Title")
+
+    props = inertia_page(client.get("/search", {"search": "Unique Sermon"}))["props"]
+
+    assert [v["name"] for v in props["videos"]] == ["Unique Sermon Title"]
+
+
+# --------------------------------------------------------------------------- #
+# Guarded live round-trip over HTTP — skipped without a reachable Typesense.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def live_index(settings):
+    # test_settings disables Typesense; opt back in from the environment so the
+    # view itself routes through Typesense for this test only.
+    config = typesense_env_config()
+    if config is None:
+        pytest.skip("Typesense not configured (set TYPESENSE_API_KEY)")
+    settings.TYPESENSE = config
+    client_ = search.get_client()
+    try:
+        client_.collections.retrieve()
+    except Exception:
+        pytest.skip("Typesense not reachable")
+    return client_
+
+
+def test_palette_typo_tolerance_over_http(client, live_index):
+    VideoFactory(name="The Sermon on the Mount")
+    search.reindex()
+
+    data = client.get("/api/palette", {"q": "sermom"}).json()  # typo
+
+    assert any("Sermon on the Mount" in v["name"] for v in data["videos"])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 
 PAGE_SCRIPT_RE = re.compile(
@@ -12,3 +13,21 @@ def inertia_page(response):
     match = PAGE_SCRIPT_RE.search(response.content)
     assert match, "Response contains no Inertia page payload"
     return json.loads(match.group(1))
+
+
+def typesense_env_config():
+    """Typesense settings from the environment, or ``None`` if no API key is set.
+
+    test_settings disables Typesense so the suite is deterministic on the ORM
+    fallback; the guarded live search tests use this to opt into a real server.
+    """
+    api_key = os.environ.get("TYPESENSE_API_KEY")
+    if not api_key:
+        return None
+    return {
+        "api_key": api_key,
+        "host": os.environ.get("TYPESENSE_HOST", "127.0.0.1"),
+        "port": os.environ.get("TYPESENSE_PORT", "8108"),
+        "protocol": os.environ.get("TYPESENSE_PROTOCOL", "http"),
+        "connection_timeout_seconds": 2,
+    }


### PR DESCRIPTION
**Slice 2 of the Typesense hybrid-search epic (#213).** Builds on the index from #235. Rewrites the `palette` and `search` view bodies to query the `content` index (relevance-ranked, typo- and synonym-tolerant) with a **graceful ORM fallback** so search never hard-fails. Response shapes are unchanged → the frontend is untouched.

### How it works
- `palette` / `search` are now thin orchestrators:
  - try the Typesense path → `except SearchUnavailableError` → **quiet** ORM fallback (covers "no container yet" / local dev without Typesense);
  - `except Exception` → **Sentry capture** + ORM fallback (covers any proxy bug).
- The previous ORM bodies are preserved verbatim as `_palette_orm` / `_search_orm`.
- **Zero N+1**: categories + their video counts come straight from the index (counts baked in at reindex time in #235). Search videos are hydrated in **one `id__in` query**, reordered to Typesense's relevance order, then fed to the existing `video_card_props()`.
- Real pagination from Typesense `found`.

### De-risked rollout
With no Typesense container on `beta` yet (that's Slice 3), **every request takes the fallback and behaves exactly like today**. It flips to Typesense automatically once the container is up — so this is safe to merge and deploy now.

### Verification
- Existing `test_palette` / `test_search` suites pass **unchanged via the fallback path** (byte-parity).
- New `test_search_proxy`: Typesense path (mocked hits + in-order hydration), fallback path, Sentry-on-unexpected-error, page-2-has-no-categories, and a guarded live typo round-trip.
- Verified against the **full local catalogue over HTTP**: `romans` → 183 ranked hits (page 1 of 8, Book Romans = 159); `romsn` / `forgivness` typo-tolerant.

Part of #213. Supersedes #167's view rewrite (no fallback, N+1, model-as-props).