### PR TITLE
feat(search): live-index the catalogue via signals (#213)

### DIFF
--- a/catalogue/apps.py
+++ b/catalogue/apps.py
@@ -4,3 +4,9 @@ from django.apps import AppConfig
 class CatalogueConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "catalogue"
+
+    def ready(self):
+        # Keep the Typesense index live as catalogue models change.
+        from catalogue import search_signals
+
+        search_signals.connect()

--- a/catalogue/search.py
+++ b/catalogue/search.py
@@ -19,12 +19,19 @@ import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+import httpx
 import typesense
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
 COLLECTION = "content"
+
+# What "Typesense is unavailable" looks like in practice: API-level errors AND the
+# raw httpx transport errors the client re-raises on a real outage (connection
+# refused, timeout) — those do NOT subclass TypesenseClientError. Catch both so an
+# outage is a quiet fallback, not an unexpected error.
+TYPESENSE_ERRORS = (typesense.exceptions.TypesenseClientError, httpx.HTTPError)
 
 # Canonical kinds stored on every doc. The views map these to their own display
 # labels ("Series", "Bible Book", …) — keep the index labels stable.
@@ -132,11 +139,13 @@ def build_category_doc(*, kind, pk, name, text, url, videos_count):
     }
 
 
-def iter_content_docs():
-    """Yield a Typesense doc for every searchable object. Counts mirror the view
-    queries exactly so the proxy returns identical numbers."""
-    from django.db.models import Count
-
+def _category_specs():
+    """Per-category-model indexing spec, the single source of truth for both the
+    full reindex and single-object upserts. Each entry:
+    ``model -> (kind, count_relation, name_fn, text_fn)``. ``count_relation`` is
+    the relation the views Count — Series via the ``videos`` M2M (the FK reverse
+    is never populated), everything else via the ``video`` reverse.
+    """
     from catalogue.ingest.normalize import clean_name, clean_topic_name
     from catalogue.models.bible_book import Bible_Book
     from catalogue.models.channel import Channel
@@ -145,82 +154,72 @@ def iter_content_docs():
     from catalogue.models.series import Series
     from catalogue.models.speaker import Speaker
     from catalogue.models.topic import Topic
+
+    return {
+        Series: (KIND_SERIES, "videos", lambda o: clean_name(o.name), lambda o: o.summary or ""),
+        Speaker: (KIND_SPEAKER, "video", lambda o: clean_name(o.name), lambda o: o.bio or ""),
+        Topic: (KIND_TOPIC, "video", lambda o: clean_topic_name(o.name), lambda o: o.summary or ""),
+        Bible_Book: (KIND_BOOK, "video", lambda o: o.get_name_display(), lambda o: o.summary or ""),
+        Channel: (KIND_CHANNEL, "video", lambda o: clean_name(o.name), lambda o: o.summary or ""),
+        Ministry: (KIND_MINISTRY, "video", lambda o: clean_name(o.name), lambda o: o.summary or ""),
+        Demographic: (KIND_AUDIENCE, "video", lambda o: clean_name(o.name), lambda o: o.summary or ""),
+    }
+
+
+def iter_content_docs():
+    """Yield a Typesense doc for every searchable object. Counts mirror the view
+    queries exactly so the proxy returns identical numbers."""
+    from django.db.models import Count
+
     from catalogue.models.video import Video
 
     for v in Video.objects.all().iterator():
         yield build_video_doc(v)
 
-    # Series videos live on the Series.videos M2M (the FK reverse is never set).
-    for s in Series.objects.annotate(n=Count("videos")).iterator():
-        yield build_category_doc(
-            kind=KIND_SERIES,
-            pk=s.pk,
-            name=clean_name(s.name),
-            text=s.summary or "",
-            url=s.get_absolute_url(),
-            videos_count=s.n,
-        )
+    for model, (kind, relation, name_fn, text_fn) in _category_specs().items():
+        for obj in model.objects.annotate(n=Count(relation)).iterator():
+            yield build_category_doc(
+                kind=kind,
+                pk=obj.pk,
+                name=name_fn(obj),
+                text=text_fn(obj),
+                url=obj.get_absolute_url(),
+                videos_count=obj.n,
+            )
 
-    for sp in Speaker.objects.annotate(n=Count("video")).iterator():
-        yield build_category_doc(
-            kind=KIND_SPEAKER,
-            pk=sp.pk,
-            name=clean_name(sp.name),
-            text=sp.bio or "",
-            url=sp.get_absolute_url(),
-            videos_count=sp.n,
-        )
 
-    for t in Topic.objects.annotate(n=Count("video")).iterator():
-        yield build_category_doc(
-            kind=KIND_TOPIC,
-            pk=t.pk,
-            name=clean_topic_name(t.name),
-            text=t.summary or "",
-            url=t.get_absolute_url(),
-            videos_count=t.n,
-        )
+def kind_for(model):
+    """The index ``kind`` for a model class, or ``None`` if it isn't indexed."""
+    from catalogue.models.video import Video
 
-    # Bible books: the display name lives behind a choice code; index that.
-    for b in Bible_Book.objects.annotate(n=Count("video")).iterator():
-        yield build_category_doc(
-            kind=KIND_BOOK,
-            pk=b.pk,
-            name=b.get_name_display(),
-            text=b.summary or "",
-            url=b.get_absolute_url(),
-            videos_count=b.n,
-        )
+    if model is Video:
+        return KIND_VIDEO
+    spec = _category_specs().get(model)
+    return spec[0] if spec else None
 
-    for c in Channel.objects.annotate(n=Count("video")).iterator():
-        yield build_category_doc(
-            kind=KIND_CHANNEL,
-            pk=c.pk,
-            name=clean_name(c.name),
-            text=c.summary or "",
-            url=c.get_absolute_url(),
-            videos_count=c.n,
-        )
 
-    for m in Ministry.objects.annotate(n=Count("video")).iterator():
-        yield build_category_doc(
-            kind=KIND_MINISTRY,
-            pk=m.pk,
-            name=clean_name(m.name),
-            text=m.summary or "",
-            url=m.get_absolute_url(),
-            videos_count=m.n,
-        )
+def build_doc_for(obj):
+    """Build the content doc for a single instance (video or category), or
+    ``None`` if its model isn't indexed. Category counts are computed fresh."""
+    from django.db.models import Count
 
-    for a in Demographic.objects.annotate(n=Count("video")).iterator():
-        yield build_category_doc(
-            kind=KIND_AUDIENCE,
-            pk=a.pk,
-            name=clean_name(a.name),
-            text=a.summary or "",
-            url=a.get_absolute_url(),
-            videos_count=a.n,
-        )
+    from catalogue.models.video import Video
+
+    if isinstance(obj, Video):
+        return build_video_doc(obj)
+    spec = _category_specs().get(type(obj))
+    if spec is None:
+        return None
+    kind, relation, name_fn, text_fn = spec
+    count = type(obj).objects.filter(pk=obj.pk).aggregate(n=Count(relation))["n"] or 0
+    return build_category_doc(
+        kind=kind,
+        pk=obj.pk,
+        name=name_fn(obj),
+        text=text_fn(obj),
+        url=obj.get_absolute_url(),
+        videos_count=count,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -262,6 +261,40 @@ def reindex(*, batch_size=500, log=None):
     if batch:
         total += _import_batch(client, batch)
     return total
+
+
+def index_object(obj):
+    """Upsert one object's doc. Best-effort: returns ``False`` (never raises)
+    when Typesense is unconfigured or unreachable, so the model save it's wired
+    to via a signal can't be blocked by a search outage."""
+    client = get_client()
+    if client is None:
+        return False
+    doc = build_doc_for(obj)
+    if doc is None:
+        return False
+    try:
+        client.collections[COLLECTION].documents.upsert(doc)
+    except TYPESENSE_ERRORS as exc:
+        logger.warning("Typesense upsert failed for %s: %s", doc.get("id"), exc)
+        return False
+    return True
+
+
+def delete_object(kind, pk):
+    """Delete one object's doc. Best-effort (see :func:`index_object`); a missing
+    doc counts as success."""
+    client = get_client()
+    if client is None:
+        return False
+    try:
+        client.collections[COLLECTION].documents[f"{kind}:{pk}"].delete()
+    except typesense.exceptions.ObjectNotFound:
+        return True
+    except TYPESENSE_ERRORS as exc:
+        logger.warning("Typesense delete failed for %s:%s: %s", kind, pk, exc)
+        return False
+    return True
 
 
 # --------------------------------------------------------------------------- #
@@ -309,7 +342,7 @@ def search_videos(query, *, page=1, per_page=24):
                 "include_fields": "pk,name,url,date_display,is_livestream,kind,videos_count",
             }
         )
-    except typesense.exceptions.TypesenseClientError as e:
+    except TYPESENSE_ERRORS as e:
         raise SearchUnavailableError(str(e)) from e
     return [_hit(h["document"]) for h in res.get("hits", [])], res.get("found", 0)
 
@@ -331,7 +364,7 @@ def search_categories(query, *, kinds, per_kind=6):
                 "include_fields": "pk,name,url,kind,videos_count",
             }
         )
-    except typesense.exceptions.TypesenseClientError as e:
+    except TYPESENSE_ERRORS as e:
         raise SearchUnavailableError(str(e)) from e
     hits = []
     for group in res.get("grouped_hits", []):

--- a/catalogue/search_signals.py
+++ b/catalogue/search_signals.py
@@ -1,0 +1,62 @@
+"""Keep the Typesense index live as the catalogue changes.
+
+Wired in ``CatalogueConfig.ready()``. On every save of an indexed model we upsert
+its doc; on delete we remove it. Everything is **best-effort** — the handlers
+swallow errors and no-op when Typesense is unconfigured/unreachable, so a search
+outage can never block a model save (the hourly admin sync, the admin UI, etc.).
+
+Counts on *related* category docs (e.g. a series' video count when a video is
+linked) are not updated here — those self-heal on the nightly reconcile
+(`reindex_search`); the directly-saved object is always fresh.
+"""
+
+import logging
+
+from django.db.models.signals import post_delete, post_save
+
+from catalogue import search
+
+logger = logging.getLogger(__name__)
+
+
+def _index(instance):
+    try:
+        search.index_object(instance)
+    except Exception:
+        logger.warning("Typesense index_object raised for %r", instance, exc_info=True)
+
+
+def _deindex(instance):
+    kind = search.kind_for(type(instance))
+    if kind is None:
+        return
+    try:
+        search.delete_object(kind, instance.pk)
+    except Exception:
+        logger.warning("Typesense delete_object raised for %r", instance, exc_info=True)
+
+
+def _on_save(sender, instance, **kwargs):
+    _index(instance)
+
+
+def _on_delete(sender, instance, **kwargs):
+    _deindex(instance)
+
+
+def connect():
+    """Connect post_save/post_delete for every indexed model. Idempotent via
+    dispatch_uid, so a double-import won't double-fire."""
+    from catalogue.models.bible_book import Bible_Book
+    from catalogue.models.channel import Channel
+    from catalogue.models.demograpic import Demographic
+    from catalogue.models.ministry import Ministry
+    from catalogue.models.series import Series
+    from catalogue.models.speaker import Speaker
+    from catalogue.models.topic import Topic
+    from catalogue.models.video import Video
+
+    models = [Video, Series, Speaker, Topic, Bible_Book, Channel, Ministry, Demographic]
+    for model in models:
+        post_save.connect(_on_save, sender=model, dispatch_uid=f"typesense_index_{model.__name__}")
+        post_delete.connect(_on_delete, sender=model, dispatch_uid=f"typesense_deindex_{model.__name__}")

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -28,6 +28,21 @@ def test_get_client_is_none_without_api_key(settings):
     assert search.get_client() is None
 
 
+def test_search_raises_unavailable_on_connection_failure(settings):
+    # Configured but unreachable (dead port). The client raises a raw httpx
+    # transport error; the helper must convert it to SearchUnavailableError so
+    # the view treats an outage as a quiet ORM fallback, not a Sentry-worthy bug.
+    settings.TYPESENSE = {
+        "api_key": "x",
+        "host": "127.0.0.1",
+        "port": "9",  # discard port — connection refused immediately
+        "protocol": "http",
+        "connection_timeout_seconds": 1,
+    }
+    with pytest.raises(search.SearchUnavailableError):
+        search.search_videos("anything")
+
+
 def test_build_video_doc_shape():
     video = VideoFactory(
         name="Romans 8",

--- a/tests/test_search_signals.py
+++ b/tests/test_search_signals.py
@@ -1,0 +1,75 @@
+"""Live indexing via post_save/post_delete signals (catalogue/search_signals.py).
+
+The inert-when-unavailable test runs with no Typesense (the default in
+test_settings) and is the important guarantee: a model save must never be broken
+by a search outage. The live tests prove the signal actually upserts/deletes.
+"""
+
+import pytest
+
+from catalogue import search
+from tests.factories import SeriesFactory, VideoFactory
+from tests.utils import typesense_env_config
+
+pytestmark = pytest.mark.django_db
+
+
+def test_saving_a_video_never_raises_when_typesense_unavailable():
+    # test_settings disables Typesense; the signal must no-op, not raise.
+    video = VideoFactory(name="Nahum Note")
+    assert video.pk  # the save itself succeeded
+
+
+def test_deleting_a_video_never_raises_when_typesense_unavailable():
+    video = VideoFactory(name="Obadiah One")
+    video.delete()  # signal fires; must be inert, not raise
+    assert not type(video).objects.filter(pk=video.pk).exists()
+
+
+# --------------------------------------------------------------------------- #
+# Guarded live tests — prove the signal actually keeps the index in sync.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def live_index(settings):
+    config = typesense_env_config()
+    if config is None:
+        pytest.skip("Typesense not configured (set TYPESENSE_API_KEY)")
+    settings.TYPESENSE = config
+    client = search.get_client()
+    try:
+        client.collections.retrieve()
+    except Exception:
+        pytest.skip("Typesense not reachable")
+    search.recreate_collection(client)  # start from a clean, empty collection
+    return client
+
+
+def test_post_save_upserts_the_video_doc(live_index):
+    VideoFactory(name="Habakkuk Hope")  # no reindex() — the signal indexes it
+
+    hits, found = search.search_videos("habakkuk", per_page=5)
+
+    assert found >= 1
+    assert any("Habakkuk Hope" in h.name for h in hits)
+
+
+def test_post_delete_removes_the_video_doc(live_index):
+    video = VideoFactory(name="Zephaniah Zeal")
+    video.delete()
+
+    hits, _ = search.search_videos("zephaniah", per_page=5)
+
+    assert not any("Zephaniah" in h.name for h in hits)
+
+
+def test_post_save_indexes_a_category_with_its_count(live_index):
+    series = SeriesFactory(name="Haggai Harvest")
+    series.videos.add(VideoFactory(), VideoFactory())
+    series.save()  # re-fire the signal so the doc carries the fresh count
+
+    hits = search.search_categories("haggai", kinds=[search.KIND_SERIES])
+
+    match = next(h for h in hits if h.name == "Haggai Harvest")
+    assert match.videos_count == 2


### PR DESCRIPTION
**Slice 4 of the Typesense epic (#213).** Keeps the index fresh as content changes, so new videos from the hourly admin sync become searchable without a manual reindex.

- **`catalogue/search_signals.py`**: `post_save` → upsert, `post_delete` → delete for `Video` + every category model, wired in `CatalogueConfig.ready()`. **Best-effort** — handlers swallow errors and no-op when Typesense is unconfigured/unreachable, so a search outage can never block a model save (admin sync, admin UI, etc.).
- **`search.py`**: refactored the per-category logic into one `_category_specs()` source of truth (kind, count relation, name/text builders) shared by the full reindex and the new `index_object()`/`delete_object()`/`build_doc_for()`/`kind_for()` helpers. Category counts computed fresh per upsert.
- Related-category count drift (e.g. a series' count when a video is linked) self-heals on the nightly reconcile (next: cron); the directly-saved object is always fresh.

**Tests**: a model save/delete **never raises with Typesense down** (the key guarantee); guarded live tests prove `post_save` upserts, `post_delete` removes, and a category doc carries its fresh count — all without calling `reindex()`.

Part of #213. Next: nightly reconcile cron + the palette loading state (Slice 5).