### PR TITLE
fix(cache): drop django-redis-only CLIENT_CLASS from built-in RedisCache

### DIFF
--- a/app/production_settings.py
+++ b/app/production_settings.py
@@ -60,13 +60,16 @@ if not os.getenv("REDIS_URL"):
 
     logging.warning("REDIS_URL environment variable not set. Using local Redis instance which may not be available.")
 
+# Django's BUILT-IN Redis backend — it forwards unknown OPTIONS to the redis
+# client constructor, so the django-redis-only "CLIENT_CLASS" key raised
+# `TypeError: AbstractConnection.__init__() got an unexpected keyword argument
+# 'CLIENT_CLASS'` every time the pool opened a new connection (and a downstream
+# `IndexError: pop from empty list`). django-redis isn't installed; the built-in
+# backend needs no CLIENT_CLASS. Don't re-add it unless switching to django-redis.
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": os.getenv("REDIS_URL", "redis://localhost:6379/1"),
-        "OPTIONS": {
-            "CLIENT_CLASS": "django_redis.client.DefaultClient",
-        },
     }
 }
 

--- a/tests/test_settings_config.py
+++ b/tests/test_settings_config.py
@@ -1,0 +1,15 @@
+"""Guards against settings misconfigurations that have bitten us in production."""
+
+import importlib
+
+
+def test_production_redis_cache_has_no_django_redis_only_options():
+    # The built-in RedisCache forwards unknown OPTIONS to the redis client, so a
+    # django-redis-only "CLIENT_CLASS" raised TypeError on every new connection
+    # (and a downstream "pop from empty list" IndexError). django-redis isn't a
+    # dependency — keep CLIENT_CLASS out of the built-in backend's OPTIONS.
+    prod = importlib.import_module("app.production_settings")
+    cache = prod.CACHES["default"]
+
+    assert cache["BACKEND"] == "django.core.cache.backends.redis.RedisCache"
+    assert "CLIENT_CLASS" not in cache.get("OPTIONS", {})


### PR DESCRIPTION
**Fixes the concerning beta Sentry errors.** `gunicorn_error.log` had recurring `TypeError: AbstractConnection.__init__() got an unexpected keyword argument 'CLIENT_CLASS'` + a downstream `IndexError: pop from empty list`.

**Root cause:** production `CACHES` uses Django's **built-in** `django.core.cache.backends.redis.RedisCache` but passed `OPTIONS={"CLIENT_CLASS": "django_redis.client.DefaultClient"}` — a **django-redis** option (django-redis isn't even installed). The built-in backend forwards unknown `OPTIONS` to the redis client constructor, so every time the pool opened a *new* connection it threw (intermittent → the handful of Sentry hits). `SESSION_ENGINE` is the cache backend, so this hit real user requests.

**Fix:** remove the `OPTIONS` block (the built-in backend needs no `CLIENT_CLASS`) + a regression test.

Will verify on beta post-deploy: TypeError stops in the error log and a cache set/get round-trips. (Separately spotted: OOM SIGKILLs on `/video/<id>` — tracking that next, unrelated to this.)