### PR TITLE
feat(analytics): enable session replay, heatmaps & autocapture on beta

### DIFF
--- a/resources/js/lib/analytics.ts
+++ b/resources/js/lib/analytics.ts
@@ -1,12 +1,19 @@
 import { router } from '@inertiajs/vue3';
 
 /**
- * Privacy-respecting analytics (self-hosted PostHog).
+ * Self-hosted PostHog analytics.
  *
  * Activates only when VITE_POSTHOG_KEY is present at build time, so local
- * dev and CI capture nothing. Configured cookieless: persistence lives in
- * memory only, no cross-visit identifiers, no person profiles for anonymous
- * visitors — usage trends without tracking individuals.
+ * dev and CI capture nothing — and prod stays clean until the key is added
+ * to the prod build env. Anonymous visitors still get no person profile
+ * (person_profiles: 'identified_only').
+ *
+ * NOTE (2026-06): session replay, heatmaps and autocapture are enabled, and
+ * persistence moved off 'memory' to 'localStorage+cookie' so a visit holds a
+ * stable id across page loads (replays/heatmaps are incoherent otherwise).
+ * This sets first-party storage/cookies → a cookie-consent banner is required
+ * before this ships to production. respect_dnt stays on; session inputs are
+ * masked in recordings. See PostHog "session replay" docs for masking knobs.
  *
  * posthog-js is heavy (~200 kB), so it loads as a lazy chunk after boot and
  * never ships in keyless builds.
@@ -22,12 +29,18 @@ export async function initializeAnalytics() {
 
     posthog.init(key, {
         api_host: import.meta.env.VITE_POSTHOG_HOST || 'https://posthog.tgo.dev',
-        persistence: 'memory',
+        persistence: 'localStorage+cookie',
         person_profiles: 'identified_only',
-        autocapture: false,
+        autocapture: true,
         capture_pageview: true,
-        capture_pageleave: false,
-        disable_session_recording: true,
+        capture_pageleave: true,
+        capture_heatmaps: true,
+        disable_session_recording: false,
+        session_recording: {
+            // Mask form inputs in recordings; keep general text visible so
+            // playback is useful (this is a sermon library, not a PII app).
+            maskAllInputs: true,
+        },
         respect_dnt: true,
     });
 


### PR DESCRIPTION
## What
Flips the PostHog SDK (`resources/js/lib/analytics.ts`) from cookieless / pageviews-only to **full product analytics** on the beta site:

- `disable_session_recording: false` — **session replay** on
- `autocapture: true` + `capture_heatmaps: true` — **heatmaps** + interaction events
- `capture_pageleave: true` — accurate session duration
- `persistence: 'memory' → 'localStorage+cookie'` — a visit keeps a stable id across page loads (replays/heatmaps fragment with memory-only)
- `session_recording.maskAllInputs: true` — form inputs masked in recordings
- `respect_dnt` stays on; anonymous visitors still get no person profile

PostHog project-side toggles (Record user sessions, Heatmaps) are already enabled on the beta project ("Clayton TV — Beta").

## ⚠️ Privacy / consent
This sets **first-party cookies + localStorage** and records sessions, so a **cookie-consent banner is required before this is enabled on production** (ties into #166). The PostHog key is only in the **beta** build env, so **production is unaffected** by merging this. Merging deploys to beta and begins recording real beta visitors.

## Test plan
- Beta deploy builds with `VITE_POSTHOG_KEY` (already set in the `beta` GH environment)
- After deploy: load beta, confirm a recording appears under Session replay and `$autocapture` / heatmap events arrive in PostHog

🤖 Generated with [Claude Code](https://claude.com/claude-code)