### PR TITLE
fix: remove placeholder auth user + prefetch watch-page relations

### DIFF
--- a/app/http/middleware/handle_inertia_requests.py
+++ b/app/http/middleware/handle_inertia_requests.py
@@ -5,7 +5,17 @@ from inertia import share
 
 from catalogue.youtube_live import is_live_now
 
-# from .models import User
+
+def _auth_user(user):
+    """Real signed-in user for Inertia, or None when anonymous. No placeholder —
+    the frontend treats a null user as logged-out (real auth lands in Epic 3)."""
+    if not user.is_authenticated:
+        return None
+    return {
+        "id": user.id,
+        "name": user.get_full_name() or user.get_username(),
+        "email": user.email,
+    }
 
 
 class HandleInertiaRequests:
@@ -17,13 +27,7 @@ class HandleInertiaRequests:
         share(
             request,
             name=os.getenv("APP_NAME"),
-            auth={
-                "user": {
-                    "id": request.user.id if request.user.is_authenticated else "123",
-                    "name": request.user.get_full_name() if request.user.is_authenticated else "Test User",
-                    "email": request.user.email if request.user.is_authenticated else "test@user.co",
-                }
-            },
+            auth={"user": _auth_user(request.user)},
             sidebarOpen=request.COOKIES.get("sidebar_state", "false") == "true",
             # Global flag for the "Live" nav indicator (one cheap exists()).
             # Skipped for JSON /api/ endpoints (e.g. the keystroke-hot palette)

--- a/app/views.py
+++ b/app/views.py
@@ -355,7 +355,14 @@ def _search_orm(searchquery, page_num):
 
 def video(request, id):
     try:
-        video_object = Video.objects.get(id=id)
+        # Prefetch the M2M relations the metadata + passage blocks walk, so the
+        # watch page's initial render stays a handful of queries (bible_book in
+        # particular is iterated twice).
+        video_object = (
+            Video.objects.select_related("channel")
+            .prefetch_related("topic", "ministry", "speaker", "bible_book", "demographic")
+            .get(id=id)
+        )
         video_metadata = {}
         # The Video.series FK is never populated; membership lives on Series.videos
         video_series = Series.objects.filter(videos=video_object).first()


### PR DESCRIPTION
Two pre-beta-testing stability/polish wins (snappier loads for the PostHog-monitored launch):

- **Remove the "Test User" stub** from Inertia shared props. Nothing in the frontend reads `auth.user` (verified), so anonymous now shares `user=null` — no fake identity, and the correct shape for real auth in Epic 3.
- **/video prefetch**: `select_related(channel)` + `prefetch_related(topic, ministry, speaker, bible_book, demographic)` on the Video fetch, so the initial render stops re-querying each relation (bible_book was hit twice). The heavy "up next" rail is already `defer()`'d.

Full suite green (209 passed). Note: the earlier `/video` worker SIGKILLs were diagnosed as deploy-time recycling, not slow requests — this is polish, not a critical fix.