### PR TITLE
fix(analytics): coerce video_metadata group to array (hotfix #254)

### DIFF
--- a/resources/js/pages/WatchVideo.vue
+++ b/resources/js/pages/WatchVideo.vue
@@ -28,9 +28,14 @@ const { resumePoint } = useWatchHistory();
 const placeholderEl = ref(null);
 const resumedFrom = ref(0);
 
-// Pull display names out of a video_metadata group (items are {name, url}) so
-// the player can tag video_* analytics with speaker/series/topic/bible_book.
-const metaNames = (key) => (props.video_metadata?.[key] ?? []).map((entry) => entry?.name ?? entry).filter(Boolean);
+// Pull display names out of a video_metadata group so the player can tag video_*
+// analytics with speaker/series/topic/bible_book. A group can be an array OR a
+// single object (mirrors entries() below), so coerce before mapping.
+const metaNames = (key) => {
+    const value = props.video_metadata?.[key];
+    if (!value) return [];
+    return (Array.isArray(value) ? value : [value]).map((entry) => entry?.name ?? entry).filter(Boolean);
+};
 
 vueWatch(
     () => props.video.id,


### PR DESCRIPTION
Hotfix for #254 (Phase 1 analytics). `metaNames` in `WatchVideo.vue` assumed every `video_metadata` group is an array, but a group can be a **single object** for some videos — so `.map` threw and the watch page hit its error boundary ("Something went wrong"). Now coerces the same way the existing `entries()` helper does (array OR single object → array) before mapping.

**Caught by the beta integration test** on `/video/9962`. type-check + build + prettier pass.