### PR TITLE
feat(analytics): browse, navigation & orientation events (Phase 2)

### DIFF
--- a/resources/js/components/layouts/AppHeader.vue
+++ b/resources/js/components/layouts/AppHeader.vue
@@ -10,6 +10,7 @@ import { Link, usePage } from '@inertiajs/vue3';
 import { ChevronDown, Menu, Search } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { usePalette } from '~/composables/usePalette';
+import { EVENTS, track } from '~/lib/analytics';
 
 // Calm primary bar for the elderly-first audience: Home · Browse · Latest ·
 // Live. Everything directory-shaped folds under "Browse" so the top stays
@@ -34,9 +35,14 @@ const liveNow = computed(() => page.props.live_now === true);
 
 const { paletteOpen, helpOpen } = usePalette();
 
+// Attribute which primary-nav affordance started a journey — the destination's
+// pageview/browse_viewed can't tell the header from the hero from the palette.
+const trackNav = (item: string) => track(EVENTS.navClicked, { item });
+
 const openPalette = () => {
     mobileNavOpen.value = false;
     paletteOpen.value = true;
+    trackNav('search');
 };
 
 // Global shortcuts — never while typing (the palette's own input included)
@@ -81,11 +87,17 @@ const navLink = (active: boolean) =>
             </Link>
 
             <nav class="hidden items-center gap-1 lg:flex" aria-label="Primary">
-                <Link href="/" prefetch :class="navLink(isCurrent('/'))" :aria-current="isCurrent('/') ? 'page' : undefined">Home</Link>
+                <Link href="/" prefetch :class="navLink(isCurrent('/'))" :aria-current="isCurrent('/') ? 'page' : undefined" @click="trackNav('home')"
+                    >Home</Link
+                >
 
                 <!-- Browse: click-triggered panel of the directories (not a hover mega-menu) -->
                 <DropdownMenu>
-                    <DropdownMenuTrigger :class="navLink(isBrowseSection())" :aria-current="isBrowseSection() ? 'page' : undefined">
+                    <DropdownMenuTrigger
+                        :class="navLink(isBrowseSection())"
+                        :aria-current="isBrowseSection() ? 'page' : undefined"
+                        @click="trackNav('browse')"
+                    >
                         Browse
                         <ChevronDown class="h-4 w-4 opacity-70" aria-hidden="true" />
                     </DropdownMenuTrigger>
@@ -99,7 +111,12 @@ const navLink = (active: boolean) =>
                     </DropdownMenuContent>
                 </DropdownMenu>
 
-                <Link href="/latest" prefetch :class="navLink(isCurrent('/latest'))" :aria-current="isCurrent('/latest') ? 'page' : undefined"
+                <Link
+                    href="/latest"
+                    prefetch
+                    :class="navLink(isCurrent('/latest'))"
+                    :aria-current="isCurrent('/latest') ? 'page' : undefined"
+                    @click="trackNav('latest')"
                     >Latest</Link
                 >
 
@@ -108,6 +125,7 @@ const navLink = (active: boolean) =>
                     prefetch
                     :class="navLink(isCurrent('/livestreams'))"
                     :aria-current="isCurrent('/livestreams') ? 'page' : undefined"
+                    @click="trackNav('live')"
                 >
                     Live
                     <span v-if="liveNow" class="relative flex h-2 w-2" title="A service is live now">
@@ -153,7 +171,10 @@ const navLink = (active: boolean) =>
                     <nav class="flex flex-col gap-1 px-2" aria-label="Mobile">
                         <Link
                             href="/"
-                            @click="mobileNavOpen = false"
+                            @click="
+                                mobileNavOpen = false;
+                                trackNav('home');
+                            "
                             :class="isCurrent('/') ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'"
                             class="focus-visible:ring-ring hover:bg-accent hover:text-foreground rounded-md px-4 py-3 text-base font-medium outline-none focus-visible:ring-2"
                         >
@@ -175,7 +196,10 @@ const navLink = (active: boolean) =>
                         <p class="text-muted-foreground px-4 pt-3 pb-1 text-xs font-semibold tracking-wider uppercase">Watch</p>
                         <Link
                             href="/latest"
-                            @click="mobileNavOpen = false"
+                            @click="
+                                mobileNavOpen = false;
+                                trackNav('latest');
+                            "
                             :class="isCurrent('/latest') ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'"
                             class="focus-visible:ring-ring hover:bg-accent hover:text-foreground rounded-md px-4 py-3 text-base font-medium outline-none focus-visible:ring-2"
                         >
@@ -183,7 +207,10 @@ const navLink = (active: boolean) =>
                         </Link>
                         <Link
                             href="/livestreams"
-                            @click="mobileNavOpen = false"
+                            @click="
+                                mobileNavOpen = false;
+                                trackNav('live');
+                            "
                             :class="isCurrent('/livestreams') ? 'bg-accent text-accent-foreground' : 'text-muted-foreground'"
                             class="focus-visible:ring-ring hover:bg-accent hover:text-foreground inline-flex items-center gap-2 rounded-md px-4 py-3 text-base font-medium outline-none focus-visible:ring-2"
                         >

--- a/resources/js/lib/analytics.ts
+++ b/resources/js/lib/analytics.ts
@@ -29,7 +29,17 @@ export const EVENTS = {
     videoPlay: 'video_play',
     videoProgress: 'video_progress',
     videoComplete: 'video_complete',
+    browseViewed: 'browse_viewed',
+    navClicked: 'nav_clicked',
+    heroCtaClicked: 'hero_cta_clicked',
+    kidsPathViewed: 'kids_path_viewed',
 } as const;
+
+// Where the visitor first landed this session, and whether they've since moved
+// on. Lets hero_cta_clicked flag an entry-page click with no persistent storage
+// (we stay cookieless), so is_first_visit is privacy-safe by construction.
+let entryPath: string | null = null;
+let hasLeftEntry = false;
 
 export async function initializeAnalytics() {
     const key = import.meta.env.VITE_POSTHOG_KEY;
@@ -53,9 +63,29 @@ export async function initializeAnalytics() {
 
     posthog = ph;
 
-    // Inertia SPA visits don't reload the page; report them as pageviews.
+    // Remember the entry surface so isEntryView() can flag a landing-page click.
+    entryPath = normalizePath(window.location.pathname);
+
+    // Report the entry surface's browse_viewed here. posthog-js already captures
+    // the entry $pageview itself on init (capture_pageview: true), so the landing
+    // page gets browse_viewed only — not a duplicate $pageview.
+    trackBrowseFromUrl(window.location.pathname + window.location.search);
+
+    // Inertia v3 fires 'navigate' on the INITIAL visit too — not just later SPA
+    // visits — and that event races with this lazily-imported posthog chunk (it
+    // may arrive after we register, or before we ever subscribed). We've already
+    // reported the entry surface above, so ignore any navigate that's still on
+    // the entry path until the visitor actually leaves: that dedupes the initial
+    // visit either way the race resolves, without a fragile one-shot latch. Once
+    // they've left, a later return to the entry path is a real visit and fires.
     router.on('navigate', (event) => {
-        posthog?.capture('$pageview', { $current_url: event.detail.page.url });
+        const url = event.detail.page.url;
+        if (!hasLeftEntry && normalizePath(url) === entryPath) {
+            return;
+        }
+        hasLeftEntry = true;
+        posthog?.capture('$pageview', { $current_url: url });
+        trackBrowseFromUrl(url);
     });
 }
 
@@ -65,4 +95,66 @@ export async function initializeAnalytics() {
  */
 export function track(event: string, properties?: Record<string, unknown>) {
     posthog?.capture(event, properties);
+}
+
+/**
+ * True until the visitor navigates away from the page they entered on. Used as
+ * hero_cta_clicked's `is_first_visit`: an honest, storage-free proxy meaning
+ * "first/entry page of this session" — not a cross-visit identity (we keep none).
+ */
+export function isEntryView(): boolean {
+    return !hasLeftEntry;
+}
+
+// First path segment → the browse_type we report. Detail pages add the slug as
+// `value`; index pages report value: null.
+const BROWSE_TYPES: Record<string, string> = {
+    series: 'series',
+    speaker: 'speaker',
+    topic: 'topic',
+    book: 'bible_book',
+    audience: 'audience',
+    demographic: 'audience', // legacy alias that redirects to /audience
+    ministry: 'ministry',
+    channel: 'channel',
+    latest: 'latest',
+    browse: 'all',
+};
+
+// Audience "slugs" are the demographic's free-text name, URL-encoded (e.g.
+// /audience/Kids — see Demographic.get_absolute_url). The current set is
+// Kids / Youth / Adults; this heuristic flags the kids/family ones (plus the
+// audience index, which always fires) for the dedicated P4 "can they find the
+// kids path?" event. Adults and unrelated demographics (e.g. searchers) don't
+// match. It's a best-effort match over admin-editable names, so an unusually
+// named future kids demographic would under-report rather than misfire.
+const KIDS_PATTERN = /kid|child|infant|toddler|tot|baby|family|young|youth|teen|junior/i;
+
+function normalizePath(url: string): string {
+    const path = url.split('?')[0].split('#')[0];
+    return path.length > 1 ? path.replace(/\/+$/, '') : path;
+}
+
+/**
+ * Emit a typed browse_viewed (and kids_path_viewed where relevant) for any
+ * directory or entity surface, derived purely from the URL. URL-driven on
+ * purpose: it can't break on an unexpected page-prop shape, and it covers every
+ * browse page from one place — including the generic Browse.vue that backs the
+ * topic / audience / ministry / channel detail pages.
+ */
+function trackBrowseFromUrl(url: string) {
+    const segments = normalizePath(url)
+        .split('/')
+        .filter(Boolean)
+        .map((segment) => decodeURIComponent(segment));
+
+    const browseType = segments.length ? BROWSE_TYPES[segments[0]] : undefined;
+    if (!browseType) return;
+
+    const value = segments.length > 1 ? segments[1] : null;
+    track(EVENTS.browseViewed, { browse_type: browseType, value });
+
+    if (browseType === 'audience' && (value === null || KIDS_PATTERN.test(value))) {
+        track(EVENTS.kidsPathViewed, { source: value ?? 'index' });
+    }
 }

--- a/resources/js/pages/Welcome.vue
+++ b/resources/js/pages/Welcome.vue
@@ -7,6 +7,7 @@ import { Skeleton } from '@/ui/skeleton';
 import { Link, WhenVisible } from '@inertiajs/vue3';
 import { ArrowRight, Baby, Book, LayoutGrid, Mic, SlidersHorizontal, Tag } from 'lucide-vue-next';
 import { useEntrance } from '~/composables/useEntrance';
+import { EVENTS, isEntryView, track } from '~/lib/analytics';
 
 const findBy = [
     { label: 'Filter all', href: '/browse', icon: SlidersHorizontal },
@@ -31,6 +32,10 @@ const latestVideoUrl = props.latest_videos.length ? `/video/${props.latest_video
 // Shared staggered page entrance (see useEntrance) — information hierarchy,
 // reduced-motion safe.
 const { entrance } = useEntrance();
+
+// The hero is the P2 "explorer" entry point: capture which CTA they take and
+// whether it was their landing (entry) view of the session.
+const trackHeroCta = (cta) => track(EVENTS.heroCtaClicked, { cta, is_first_visit: isEntryView() });
 </script>
 
 <template>
@@ -49,12 +54,14 @@ const { entrance } = useEntrance();
                     <Link
                         :href="latestVideoUrl"
                         class="bg-primary text-primary-foreground focus-visible:ring-ring hover:bg-primary/90 focus-visible:ring-offset-background inline-flex min-h-12 items-center rounded-lg px-5 text-sm font-semibold transition-colors duration-150 outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                        @click="trackHeroCta('watch_latest')"
                     >
                         Watch latest sermon
                     </Link>
                     <Link
                         href="/series"
                         class="focus-visible:ring-ring border-input text-foreground hover:border-ring hover:text-foreground inline-flex min-h-12 items-center rounded-lg border px-5 text-sm font-medium transition-colors duration-150 outline-none focus-visible:ring-2"
+                        @click="trackHeroCta('browse_series')"
                     >
                         Browse series
                     </Link>


### PR DESCRIPTION
**Phase 2** of the analytics buildout (Epic #252). Builds on `beta` (Phase 1 #254 + hotfix #266). Closes #247.

## What this adds
| Event | Where | Properties |
|---|---|---|
| `browse_viewed` | every directory/entity surface | `browse_type` (series/speaker/topic/bible_book/audience/ministry/channel/latest/all), `value` (slug, or `null` for index pages) |
| `kids_path_viewed` | audience index + kids/family demographics | `source` (`index` or slug) |
| `nav_clicked` | header nav (desktop + mobile) + search palette | `item` (home/browse/latest/live/search) |
| `hero_cta_clicked` | home hero buttons | `cta` (watch_latest/browse_series), `is_first_visit` |

## Design notes
- **`browse_viewed`/`kids_path_viewed` are URL-derived in `analytics.ts`**, not per-page. Topic/audience/ministry/channel detail pages all render the generic `Browse.vue`, so a per-page approach would be inconsistent and prop-fragile (the #266 `metaNames` lesson). URL-driven = one source of truth, covers every surface, can't break on prop shape.
- **No double-fire / no double `$pageview`.** Inertia v3.4 fires `navigate` on the *initial* visit too, and that races the lazily-imported posthog-js chunk. The entry surface reports `browse_viewed` once on init (posthog's own `capture_pageview:true` supplies the entry `$pageview`), and the navigate handler ignores the entry path until the visitor leaves — so each surface reports exactly once regardless of how the race resolves. This also removes a *pre-existing* double `$pageview` on the landing page.
- **`is_first_visit` is storage-free** (`isEntryView()` = entry page of the session). We stay cookieless — no cross-visit identity is kept.
- **`identify()` is intentionally deferred** to the auth epic — `auth.user` is always null today, so it'd be dead, untestable code.

## Verification
- Local gate green: prettier, oxlint, eslint, `vue-tsc`, `vite build`.
- Adversarial sub-agent review (2 rounds): caught the initial-navigate race → fixed; confirmed event counts (1 `browse_viewed` + 1 `$pageview` per surface) across both chunk-load orderings.
- Browser integration test on beta to follow once CI is green (multiple surfaces, per the #266 lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)