### PR TITLE
fix(analytics): decode paths so entry browse_viewed/$pageview don't double-fire

### DIFF
--- a/resources/js/lib/analytics.ts
+++ b/resources/js/lib/analytics.ts
@@ -130,9 +130,26 @@ const BROWSE_TYPES: Record<string, string> = {
 // named future kids demographic would under-report rather than misfire.
 const KIDS_PATTERN = /kid|child|infant|toddler|tot|baby|family|young|youth|teen|junior/i;
 
+// Canonicalise a path for comparison and segmenting: drop query/hash + trailing
+// slash, then decode each segment. Decoding matters for the entry-dedup check —
+// window.location.pathname and Inertia's page.url encode reserved characters
+// differently (e.g. a speaker slug "Steele, Dominic" is "Steele,%20Dominic" vs
+// "Steele%2C%20Dominic"), so without decoding the entry path would never match
+// its own initial-visit navigate and browse_viewed/$pageview would double-fire.
+// Split before decode so an encoded slash inside a segment can't create one.
 function normalizePath(url: string): string {
-    const path = url.split('?')[0].split('#')[0];
-    return path.length > 1 ? path.replace(/\/+$/, '') : path;
+    const raw = url.split('?')[0].split('#')[0];
+    const trimmed = raw.length > 1 ? raw.replace(/\/+$/, '') : raw;
+    return trimmed
+        .split('/')
+        .map((segment) => {
+            try {
+                return decodeURIComponent(segment);
+            } catch {
+                return segment;
+            }
+        })
+        .join('/');
 }
 
 /**
@@ -143,10 +160,8 @@ function normalizePath(url: string): string {
  * topic / audience / ministry / channel detail pages.
  */
 function trackBrowseFromUrl(url: string) {
-    const segments = normalizePath(url)
-        .split('/')
-        .filter(Boolean)
-        .map((segment) => decodeURIComponent(segment));
+    // normalizePath already decodes each segment, so don't decode again here.
+    const segments = normalizePath(url).split('/').filter(Boolean);
 
     const browseType = segments.length ? BROWSE_TYPES[segments[0]] : undefined;
     if (!browseType) return;


### PR DESCRIPTION
Follow-up hotfix to #267 (Phase 2), found during the browser integration test on beta.

## Bug
On a **direct load** of any browse URL whose slug contains reserved characters, `browse_viewed` and `$pageview` fired **twice**. The entry dedup compared `normalizePath(window.location.pathname)` to `normalizePath(`Inertia's `page.url)`, but the two encode reserved chars differently:
- `window.location.pathname` → `/speaker/Steele,%20Dominic`
- Inertia `page.url` → `/speaker/Steele%2C%20Dominic`

The strings never matched, so the initial-visit navigate wasn't swallowed → duplicate events. **Speaker names are always "Surname, First"**, so every speaker page (a core P3 browse dimension) double-counted; clean slugs (e.g. `/topic/Apologetics`) were already correct.

## Fix
`normalizePath` now decodes each path segment (splitting *before* decoding so an encoded `/` can't spawn a segment), so the entry path matches its own initial navigate. `trackBrowseFromUrl` no longer decodes a second time.

## Verification
- Confirmed on beta: clean slugs fire one `browse_viewed` + one `$pageview`; the speaker URL (comma+space) double-fired.
- No server redirect involved (both encodings return HTTP 200) — purely the client-side comparison.
- Local gate green: prettier, eslint, `vue-tsc`, `vite build`. Will re-verify the speaker page fires once after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)