### PR TITLE
feat(analytics): cookie-consent banner + consent-gated replay/heatmaps (#250)

### DIFF
--- a/resources/js/app.ts
+++ b/resources/js/app.ts
@@ -3,6 +3,7 @@ import '../css/app.css';
 import { createInertiaApp, router } from '@inertiajs/vue3';
 import { createApp, createSSRApp, type DefineComponent, h } from 'vue';
 import { initializeTheme } from '~/composables/useAppearance';
+import { initializeCookieConsent } from '~/composables/useCookieConsent';
 import { useFlash } from '~/composables/useFlash';
 import { usePlayerDock } from '~/composables/usePlayerDock';
 import { initializeTextScale } from '~/composables/useTextScale';
@@ -65,6 +66,9 @@ router.on('networkError', () => {
 
 initializeTheme();
 initializeTextScale();
+// Read any stored cookie choice before analytics inits, so PostHog starts in the
+// right mode (cookieless until the visitor opts in).
+initializeCookieConsent();
 initializeAnalytics();
 // Bring back the mini-player if a video was playing before a refresh (paused,
 // at the saved timecode). A watch page re-docks itself, so this only floats it

--- a/resources/js/components/layouts/AppFooter.vue
+++ b/resources/js/components/layouts/AppFooter.vue
@@ -5,8 +5,13 @@ import TextSizeControl from '@/molecules/TextSizeControl.vue';
 import ThemeToggle from '@/molecules/ThemeToggle.vue';
 import { Link } from '@inertiajs/vue3';
 import { Github, Youtube } from 'lucide-vue-next';
+import { useCookieConsent } from '~/composables/useCookieConsent';
 
 const year = new Date().getFullYear();
+
+// Let visitors revisit their cookie choice at any time (a PECR expectation).
+// Only shown in builds that actually ship analytics.
+const { reopen: reopenCookieSettings, enabled: cookieConsentEnabled } = useCookieConsent();
 
 const socials = [
     { name: 'YouTube', href: 'https://www.youtube.com/channel/UCvME6kEF02MqliB5TNHFLZA', icon: Youtube },
@@ -63,7 +68,17 @@ const columns = [
         </div>
         <div class="border-border border-t">
             <div class="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-3 px-4 py-5 lg:px-8">
-                <p class="text-muted-foreground text-xs">© {{ year }} Clayton TV</p>
+                <div class="flex items-center gap-3">
+                    <p class="text-muted-foreground text-xs">© {{ year }} Clayton TV</p>
+                    <button
+                        v-if="cookieConsentEnabled"
+                        type="button"
+                        @click="reopenCookieSettings"
+                        class="focus-visible:ring-ring text-muted-foreground hover:text-foreground rounded text-xs underline-offset-4 outline-none hover:underline focus-visible:ring-2"
+                    >
+                        Cookie settings
+                    </button>
+                </div>
                 <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
                     <div class="flex items-center gap-2">
                         <span class="text-muted-foreground text-xs">Theme</span>

--- a/resources/js/components/layouts/AppLayout.vue
+++ b/resources/js/components/layouts/AppLayout.vue
@@ -2,6 +2,7 @@
 import ErrorBoundary from '@/ErrorBoundary.vue';
 import AppFooter from '@/layouts/AppFooter.vue';
 import AppHeader from '@/layouts/AppHeader.vue';
+import CookieConsent from '@/organisms/CookieConsent.vue';
 import PersistentPlayer from '@/organisms/PersistentPlayer.vue';
 import Toaster from '@/organisms/Toaster.vue';
 </script>
@@ -29,5 +30,6 @@ import Toaster from '@/organisms/Toaster.vue';
         <!-- The shared player + toasts outlive page navigations (persistent layout) -->
         <PersistentPlayer />
         <Toaster />
+        <CookieConsent />
     </div>
 </template>

--- a/resources/js/components/organisms/CookieConsent.vue
+++ b/resources/js/components/organisms/CookieConsent.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { Button } from '@/ui/button';
+import { Switch } from '@/ui/switch';
+import { Cookie } from 'lucide-vue-next';
+import { ref, watch } from 'vue';
+import { useCookieConsent } from '~/composables/useCookieConsent';
+
+// PECR / UK-GDPR consent banner. Non-blocking (not a modal): visitors can keep
+// reading while they decide. "Necessary" is always on; "Analytics" is opt-in and
+// off by default, but "Accept all" is the prominent call to action.
+const { open, analyticsGranted, acceptAll, rejectNonEssential, savePreferences } = useCookieConsent();
+
+// Local mirror of the analytics toggle. Off by default; when the banner is
+// reopened from the footer it reflects the visitor's current choice.
+const analytics = ref(analyticsGranted.value);
+
+watch(open, (isOpen) => {
+    if (isOpen) analytics.value = analyticsGranted.value;
+});
+
+const PRIVACY_URL = 'https://clayton.tv/Clayton_TV_Data_Privacy_Notice.pdf';
+</script>
+
+<template>
+    <Transition
+        enter-active-class="transition duration-300 ease-out motion-reduce:transition-none"
+        enter-from-class="translate-y-6 opacity-0"
+        enter-to-class="translate-y-0 opacity-100"
+        leave-active-class="transition duration-200 ease-in motion-reduce:transition-none"
+        leave-from-class="translate-y-0 opacity-100"
+        leave-to-class="translate-y-6 opacity-0"
+    >
+        <div v-if="open" class="pb-safe px-safe fixed inset-x-0 bottom-0 z-50 p-4" role="region" aria-label="Cookie consent">
+            <div class="border-border bg-background/95 mx-auto max-w-3xl rounded-2xl border p-5 shadow-2xl backdrop-blur-md sm:p-6">
+                <div class="flex items-start gap-3">
+                    <span class="bg-primary/10 text-primary flex h-10 w-10 flex-none items-center justify-center rounded-full" aria-hidden="true">
+                        <Cookie class="h-5 w-5" />
+                    </span>
+                    <div class="min-w-0">
+                        <h2 class="font-display text-foreground text-base font-bold">A note on cookies</h2>
+                        <p class="text-muted-foreground mt-1 text-sm leading-relaxed">
+                            To improve the site we measure how people find and watch teaching. The essentials work without cookies; accepting also
+                            enables cookies, heatmaps and masked session replays for richer insight. You can change this anytime.
+                            <a
+                                :href="PRIVACY_URL"
+                                rel="noopener"
+                                target="_blank"
+                                class="text-primary focus-visible:ring-ring rounded font-medium underline-offset-4 outline-none hover:underline focus-visible:ring-2"
+                            >
+                                Privacy notice
+                            </a>
+                        </p>
+                    </div>
+                </div>
+
+                <!-- Categories: necessary is locked on; analytics is opt-in -->
+                <div class="border-border mt-4 grid gap-2.5 border-t pt-4">
+                    <div class="flex items-center justify-between gap-4">
+                        <div class="min-w-0">
+                            <p class="text-foreground text-sm font-medium">Strictly necessary</p>
+                            <p class="text-muted-foreground text-xs">Remembers your choices (theme, text size, this consent). Always on.</p>
+                        </div>
+                        <Switch :model-value="true" disabled aria-label="Strictly necessary cookies (always on)" />
+                    </div>
+                    <div class="flex items-center justify-between gap-4">
+                        <div class="min-w-0">
+                            <p class="text-foreground text-sm font-medium">Analytics &amp; session insights</p>
+                            <p class="text-muted-foreground text-xs">
+                                Usage trends, heatmaps and masked session replays that show where the site helps or frustrates.
+                            </p>
+                        </div>
+                        <Switch v-model="analytics" aria-label="Analytics and session insights cookies" />
+                    </div>
+                </div>
+
+                <div class="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:items-center">
+                    <!-- Rejecting non-essential cookies is one click and as prominent as accepting (ICO). -->
+                    <Button variant="outline" class="sm:mr-auto sm:min-w-32" @click="rejectNonEssential"> Reject all </Button>
+                    <Button variant="outline" class="sm:min-w-32" @click="savePreferences(analytics)"> Save preferences </Button>
+                    <Button class="sm:min-w-40" @click="acceptAll"> Accept all cookies </Button>
+                </div>
+            </div>
+        </div>
+    </Transition>
+</template>

--- a/resources/js/components/ui/switch/Switch.vue
+++ b/resources/js/components/ui/switch/Switch.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils';
+import { SwitchRoot, type SwitchRootEmits, type SwitchRootProps, SwitchThumb, useForwardPropsEmits } from 'reka-ui';
+import { computed, type HTMLAttributes } from 'vue';
+
+const props = defineProps<SwitchRootProps & { class?: HTMLAttributes['class'] }>();
+const emits = defineEmits<SwitchRootEmits>();
+
+const delegatedProps = computed(() => {
+    const { class: _, ...delegated } = props;
+    return delegated;
+});
+
+const forwarded = useForwardPropsEmits(delegatedProps, emits);
+</script>
+
+<template>
+    <SwitchRoot
+        data-slot="switch"
+        v-bind="forwarded"
+        :class="
+            cn(
+                'peer focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=unchecked]:bg-input inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none',
+                props.class,
+            )
+        "
+    >
+        <SwitchThumb
+            data-slot="switch-thumb"
+            class="bg-background pointer-events-none block h-5 w-5 rounded-full shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0 motion-reduce:transition-none"
+        />
+    </SwitchRoot>
+</template>

--- a/resources/js/components/ui/switch/index.ts
+++ b/resources/js/components/ui/switch/index.ts
@@ -1,0 +1,1 @@
+export { default as Switch } from './Switch.vue';

--- a/resources/js/composables/useCookieConsent.ts
+++ b/resources/js/composables/useCookieConsent.ts
@@ -1,0 +1,130 @@
+import { readonly, ref } from 'vue';
+
+/**
+ * Cookie-consent state (PECR / UK-GDPR).
+ *
+ * Two categories:
+ *  - "necessary" — always on. We keep no necessary *tracking* cookies; this
+ *    covers the visitor's own preferences (theme, text size, this choice).
+ *  - "analytics" — opt-in. Until granted, PostHog runs cookieless (in-memory,
+ *    no cross-visit id, no session recording). On consent it upgrades to
+ *    localStorage+cookie persistence + session replay + heatmaps + autocapture.
+ *    See lib/analytics.ts, which reads getAnalyticsConsent() and listens via
+ *    onConsentChange() so a decision takes effect without a reload.
+ *
+ * The decision itself is stored in localStorage (a strictly-necessary use), so
+ * the banner only shows until the visitor chooses — and again if we add a new
+ * category (bump CONSENT_VERSION).
+ */
+const STORAGE_KEY = 'ctv:cookieConsent';
+// Bump when the set of categories changes, to re-ask everyone.
+const CONSENT_VERSION = 1;
+
+type StoredConsent = { analytics: boolean; version: number; ts: string };
+
+// Module-level singletons so the banner, the footer link and analytics all
+// share one source of truth.
+const analytics = ref(false);
+const decided = ref(false);
+const open = ref(false);
+// True only in builds that actually ship analytics (VITE_POSTHOG_KEY present).
+// Without it nothing non-essential runs, so there's nothing to consent to and we
+// suppress the banner + footer link entirely (keeps dev and the current
+// uninstrumented prod clean).
+const enabled = ref(false);
+
+const listeners = new Set<(analyticsAllowed: boolean) => void>();
+
+function read(): StoredConsent | null {
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw) as StoredConsent;
+        // Treat an older-version record as "no decision" so we re-ask.
+        return parsed && parsed.version === CONSENT_VERSION ? parsed : null;
+    } catch {
+        return null;
+    }
+}
+
+function persist(analyticsAllowed: boolean) {
+    try {
+        const record: StoredConsent = {
+            analytics: analyticsAllowed,
+            version: CONSENT_VERSION,
+            // Timestamp passed in via the host clock — stored as ISO for audit.
+            ts: new Date().toISOString(),
+        };
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(record));
+    } catch {
+        // Private mode / storage disabled — the choice still holds this session.
+    }
+}
+
+/** Apply + remember a decision, then notify analytics (and any other listener). */
+function decide(analyticsAllowed: boolean) {
+    analytics.value = analyticsAllowed;
+    decided.value = true;
+    open.value = false;
+    persist(analyticsAllowed);
+    listeners.forEach((cb) => cb(analyticsAllowed));
+}
+
+/** Read any stored decision on boot; show the banner only if none exists yet. */
+export function initializeCookieConsent() {
+    if (typeof window === 'undefined') return;
+
+    // No analytics in this build → nothing non-essential to consent to.
+    if (!import.meta.env.VITE_POSTHOG_KEY) {
+        enabled.value = false;
+        decided.value = true;
+        open.value = false;
+        return;
+    }
+    enabled.value = true;
+
+    const stored = read();
+    if (stored) {
+        analytics.value = stored.analytics;
+        decided.value = true;
+        open.value = false;
+    } else {
+        analytics.value = false;
+        decided.value = false;
+        open.value = true;
+    }
+}
+
+/** Current analytics consent — false until the visitor actively opts in. */
+export function getAnalyticsConsent(): boolean {
+    return decided.value && analytics.value;
+}
+
+/** Subscribe to consent changes (analytics.ts uses this to flip PostHog live). */
+export function onConsentChange(cb: (analyticsAllowed: boolean) => void) {
+    listeners.add(cb);
+    return () => listeners.delete(cb);
+}
+
+export function useCookieConsent() {
+    return {
+        open: readonly(open),
+        enabled: readonly(enabled),
+        analyticsGranted: readonly(analytics),
+        decided: readonly(decided),
+        // Primary CTA: accept everything.
+        acceptAll: () => decide(true),
+        // Decline non-essential (also the effect of "necessary only").
+        rejectNonEssential: () => decide(false),
+        // Save whatever the visitor toggled in the banner.
+        savePreferences: (analyticsAllowed: boolean) => decide(analyticsAllowed),
+        // Footer "Cookie settings" — let them revisit the choice (no-op in builds
+        // without analytics, where there's nothing to consent to).
+        reopen: () => {
+            if (enabled.value) open.value = true;
+        },
+        dismiss: () => {
+            open.value = false;
+        },
+    };
+}

--- a/resources/js/lib/analytics.ts
+++ b/resources/js/lib/analytics.ts
@@ -1,13 +1,21 @@
 import { router } from '@inertiajs/vue3';
 import type { PostHog } from 'posthog-js';
+import { getAnalyticsConsent, onConsentChange } from '~/composables/useCookieConsent';
 
 /**
  * Privacy-respecting analytics (self-hosted PostHog).
  *
  * Activates only when VITE_POSTHOG_KEY is present at build time, so local
- * dev and CI capture nothing. Configured cookieless: persistence lives in
- * memory only, no cross-visit identifiers, no person profiles for anonymous
- * visitors — usage trends without tracking individuals.
+ * dev and CI capture nothing — and prod stays clean until the key is added.
+ *
+ * Consent-gated (PECR / UK-GDPR — see useCookieConsent):
+ *  - No analytics consent → COOKIELESS: in-memory persistence, no cross-visit
+ *    id, no autocapture, no heatmaps, no session recording. Sets no cookies.
+ *  - Analytics consent → localStorage+cookie persistence (stable per-visit id),
+ *    autocapture, heatmaps and masked session replay. The consent banner flips
+ *    this live via applyAnalyticsConsent() (persistence + recording apply
+ *    immediately; autocapture/heatmaps are init-time, so they engage on the
+ *    next page load). respect_dnt and person_profiles:'identified_only' always.
  *
  * posthog-js is heavy (~200 kB), so it loads as a lazy chunk after boot and
  * never ships in keyless builds.
@@ -50,18 +58,33 @@ export async function initializeAnalytics() {
 
     const { default: ph } = await import('posthog-js');
 
+    // Choose the initial config from any stored consent. Autocapture/heatmaps are
+    // init-time only, so a returning visitor who already opted in gets the full
+    // set from the first load; everyone else starts cookieless.
+    const consented = getAnalyticsConsent();
+
     ph.init(key, {
         api_host: import.meta.env.VITE_POSTHOG_HOST || 'https://posthog.tgo.dev',
-        persistence: 'memory',
+        persistence: consented ? 'localStorage+cookie' : 'memory',
         person_profiles: 'identified_only',
-        autocapture: false,
+        autocapture: consented,
         capture_pageview: true,
-        capture_pageleave: false,
-        disable_session_recording: true,
+        capture_pageleave: consented,
+        capture_heatmaps: consented,
+        disable_session_recording: !consented,
+        session_recording: {
+            // Mask form inputs in recordings; general text stays visible so
+            // playback is useful (this is a sermon library, not a PII app).
+            maskAllInputs: true,
+        },
         respect_dnt: true,
     });
 
     posthog = ph;
+
+    // React to consent decisions made after boot (the banner on first visit, or
+    // the footer "Cookie settings" later).
+    onConsentChange(applyAnalyticsConsent);
 
     // Remember the entry surface so isEntryView() can flag a landing-page click.
     entryPath = normalizePath(window.location.pathname);
@@ -95,6 +118,27 @@ export async function initializeAnalytics() {
  */
 export function track(event: string, properties?: Record<string, unknown>) {
     posthog?.capture(event, properties);
+}
+
+/**
+ * Apply a consent decision to the live PostHog instance. Persistence and session
+ * recording can switch at runtime, so they take effect immediately; autocapture
+ * and heatmaps are init-time options and engage on the next page load (the
+ * decision is persisted, so the next init picks the full config). No-op until
+ * posthog-js has loaded — initializeAnalytics() seeds the correct initial state.
+ */
+function applyAnalyticsConsent(analyticsAllowed: boolean) {
+    if (!posthog) return;
+    if (analyticsAllowed) {
+        posthog.set_config({ persistence: 'localStorage+cookie' });
+        posthog.startSessionRecording();
+    } else {
+        // Revoked (or never granted): stop recording, drop the stored id and any
+        // cookies, and fall back to in-memory so nothing persists across visits.
+        posthog.stopSessionRecording();
+        posthog.set_config({ persistence: 'memory' });
+        posthog.reset();
+    }
 }
 
 /**


### PR DESCRIPTION
Implements the **cookie-consent gate** (#250) and folds in **session replay + heatmaps + autocapture** (what #245 wanted) — but **behind consent** instead of always-on. **Supersedes #245** (it predated Phase 1/2 and was unconditional).

## Behaviour
| State | PostHog |
|---|---|
| No opt-in (default) | **Cookieless** — `persistence:'memory'`, no autocapture/heatmaps/recording. **Sets no cookies.** Anonymous pageviews + custom events only. |
| Analytics accepted | `localStorage+cookie` + autocapture + heatmaps + **masked** session replay. |

- **`useCookieConsent`** (localStorage, mirrors `useTextScale`): `necessary` (always on) + `analytics` (opt-in, off by default). Versioned to re-ask on change. **Suppressed when the build has no `VITE_POSTHOG_KEY`** (dev + current prod → nothing to consent to, no banner).
- **`analytics.ts`** reads consent at init and via `onConsentChange` flips PostHog live — persistence + recording apply immediately, autocapture/heatmaps engage next load (init-time options; decision is persisted). **Revoke clears the `ph_*` cookies** (`set_config('memory')` before `reset()` — verified against the posthog-js bundle internals).
- **`CookieConsent.vue`**: shadcn-styled, reka-ui `Switch` toggles, slide-up microanimation (reduced-motion safe). Necessary locked on; analytics off by default; **"Accept all" is the primary CTA**, with an **equal-prominence "Reject all"** (ICO) + "Save preferences". Footer **"Cookie settings"** reopens it.
- `respect_dnt` + `person_profiles:'identified_only'` stay on throughout.

## Review
Adversarial sub-agent review (verified against the installed posthog-js@1.386.6 bundle): pre-consent is genuinely cookieless; revoke really expires the `ph_*` cookies; no decision-race; reka-ui/Vue wiring correct. Two SHOULD-FIX items addressed: added equal-prominence **Reject all**, and made the banner copy honest about anonymous pre-consent analytics. Local gate green (prettier, oxlint, eslint, vue-tsc, vite build).

## Before prod (not in this PR — policy)
- Enable **"Discard client IP"** in PostHog project settings (will do during beta verification).
- A **privacy notice** (#166) covering anonymous pre-consent analytics; confirm Jamie/legal are happy with cookieless-analytics-before-consent (the established "cookieless fallback" from the strategy doc).

Closes #250. On beta this gives a real consent gate to test; prod stays uninstrumented until its build gets the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)