### PR TITLE
feat(studio): beta-only secret dev-login magic link

### DIFF
--- a/app/base_settings.py
+++ b/app/base_settings.py
@@ -127,6 +127,14 @@ TYPESENSE = {
     "connection_timeout_seconds": int(os.getenv("TYPESENSE_TIMEOUT", "2")),
 }
 
+# Studio dev login — BETA ONLY, NEVER set on production. A secret magic link:
+# GET /studio/dev-login?key=<STUDIO_DEV_LOGIN_KEY> one-click-signs-in the single
+# configured editor (STUDIO_DEV_LOGIN_USER) with NO credentials. The endpoint
+# 404s unless the key is set AND matches (so it's invisible without the secret).
+# Empty key (the default everywhere) = feature off. Remove at the prod cutover.
+STUDIO_DEV_LOGIN_KEY = os.getenv("STUDIO_DEV_LOGIN_KEY", "")
+STUDIO_DEV_LOGIN_USER = os.getenv("STUDIO_DEV_LOGIN_USER", "")
+
 # Logging
 LOGGING = {
     "version": 1,

--- a/app/studio/urls.py
+++ b/app/studio/urls.py
@@ -8,4 +8,6 @@ from . import views
 urlpatterns = [
     path("", views.index, name="studio_index"),
     path("login", views.login_view, name="studio_login"),
+    # Beta-only secret magic link (key-gated; 404 without the secret). See settings.
+    path("dev-login", views.dev_login, name="studio_dev_login"),
 ]

--- a/app/studio/views.py
+++ b/app/studio/views.py
@@ -4,11 +4,17 @@ House style: thin views. Auth lives in ``app.auth``/``app.studio.auth``; these
 just wire request → response.
 """
 
-from django.contrib.auth import authenticate, login
+import secrets
+
+from django.conf import settings
+from django.contrib.auth import authenticate, get_user_model, login
+from django.http import Http404
 from django.shortcuts import redirect
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import ensure_csrf_cookie
 from inertia import render, share
+
+from app.auth import can_edit_content
 
 from .auth import studio_required
 
@@ -58,6 +64,28 @@ def login_view(request):
 
 def _render_login(request):
     return render(request, "Studio/Login", {"next": _safe_next(request)})
+
+
+def dev_login(request):
+    """``/studio/dev-login?key=<secret>`` — BETA-ONLY secret magic link, NO
+    credentials. Signs in the single configured editor (``STUDIO_DEV_LOGIN_USER``).
+
+    Gated by a secret: 404 unless ``STUDIO_DEV_LOGIN_KEY`` is set AND the ``key``
+    query param matches it (constant-time) — so the endpoint is invisible without
+    the secret, even on beta. Only signs in an account that is actually an editor.
+    The key is set in beta's .env ONLY; NEVER set it on production. Remove at cutover.
+    """
+    key = getattr(settings, "STUDIO_DEV_LOGIN_KEY", "")
+    if not key or not secrets.compare_digest(request.GET.get("key", ""), key):
+        raise Http404
+    username = getattr(settings, "STUDIO_DEV_LOGIN_USER", "")
+    user = get_user_model().objects.filter(username=username).first()
+    if user is None or not can_edit_content(user):
+        raise Http404
+    # No password involved — set the session directly (the account may not even
+    # have a usable password yet). Specify the backend since we skip authenticate().
+    login(request, user, backend="django.contrib.auth.backends.ModelBackend")
+    return redirect(DEFAULT_REDIRECT)
 
 
 @studio_required

--- a/tests/test_studio_dev_login.py
+++ b/tests/test_studio_dev_login.py
@@ -1,0 +1,60 @@
+"""The beta-only secret dev-login magic link (/studio/dev-login?key=...).
+
+Off unless STUDIO_DEV_LOGIN_KEY is set; even then it 404s without the matching
+key, and only signs in an actual editor. Never enabled in tests by default.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.test import override_settings
+
+from app.auth import EDITORS_GROUP
+
+pytestmark = pytest.mark.django_db
+
+DEV_KEY = "test-magic-key-123"  # gitleaks:allow
+
+
+def _make_editor(username="ed"):
+    user = get_user_model().objects.create_user(username, f"{username}@example.com")
+    group, _ = Group.objects.get_or_create(name=EDITORS_GROUP)
+    user.groups.add(group)
+    return user
+
+
+def test_dev_login_404_when_key_not_configured(client):
+    # Default (no STUDIO_DEV_LOGIN_KEY) → the endpoint doesn't exist.
+    _make_editor("ed")
+    assert client.get("/studio/dev-login", {"key": "anything"}).status_code == 404
+
+
+@override_settings(STUDIO_DEV_LOGIN_KEY=DEV_KEY, STUDIO_DEV_LOGIN_USER="ed")
+def test_dev_login_404_on_wrong_or_missing_key(client):
+    _make_editor("ed")
+    assert client.get("/studio/dev-login", {"key": "wrong"}).status_code == 404
+    assert client.get("/studio/dev-login").status_code == 404
+    assert "_auth_user_id" not in client.session
+
+
+@override_settings(STUDIO_DEV_LOGIN_KEY=DEV_KEY, STUDIO_DEV_LOGIN_USER="ed")
+def test_dev_login_signs_in_the_configured_editor(client):
+    _make_editor("ed")
+    resp = client.get("/studio/dev-login", {"key": DEV_KEY})
+    assert resp.status_code == 302
+    assert resp.url == "/studio"
+    assert client.session.get("_auth_user_id")  # session is authenticated
+    # And the now-authenticated session reaches the gated Studio.
+    assert client.get("/studio/").status_code == 200
+
+
+@override_settings(STUDIO_DEV_LOGIN_KEY=DEV_KEY, STUDIO_DEV_LOGIN_USER="notaneditor")
+def test_dev_login_404_when_target_is_not_an_editor(client):
+    get_user_model().objects.create_user("notaneditor", "n@example.com")  # no Editors group
+    assert client.get("/studio/dev-login", {"key": DEV_KEY}).status_code == 404
+    assert "_auth_user_id" not in client.session
+
+
+@override_settings(STUDIO_DEV_LOGIN_KEY=DEV_KEY, STUDIO_DEV_LOGIN_USER="ghost")
+def test_dev_login_404_when_target_user_missing(client):
+    assert client.get("/studio/dev-login", {"key": DEV_KEY}).status_code == 404


### PR DESCRIPTION
A fenced one-click sign-in for **beta only** (per Jamie — lets him into Studio without entering credentials while his editor account has no password yet).

**It's a secret magic link, not a button:** `GET /studio/dev-login?key=<secret>` signs in the single configured editor.
- **404 unless `STUDIO_DEV_LOGIN_KEY` is set AND the `?key=` matches** (constant-time). No key (the default everywhere, incl. prod) → the endpoint doesn't exist. No visible button → invisible without the secret.
- Only signs in an actual **editor** (`can_edit_content`) — minimal blast radius.
- **Never set the key on production**; remove at cutover (noted in code).

Tests cover: unconfigured / wrong / missing key / non-editor / missing user → 404; correct key + real editor → 302 + authenticated session reaching gated /studio. Set on beta via `STUDIO_DEV_LOGIN_KEY` + `STUDIO_DEV_LOGIN_USER=thatgardnerone`.