### PR TITLE
feat(studio): Add a video — paste-a-URL intake (Epic 3 Slice 3)

### DIFF
--- a/app/base_settings.py
+++ b/app/base_settings.py
@@ -89,6 +89,16 @@ STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles_collected"
 
 INERTIA_LAYOUT = "app.html"
+
+# CSRF ↔ Inertia. Inertia's request client reads the ``XSRF-TOKEN`` cookie and
+# echoes it as the ``X-XSRF-TOKEN`` header on every POST/PUT/PATCH/DELETE. Point
+# Django's CSRF machinery at those names so Inertia submissions (the Studio
+# login + mutations, Add-a-video) carry a valid token out of the box — otherwise
+# Django looks for ``csrftoken``/``X-CSRFToken`` and rejects every Inertia POST
+# with a 403. The cookie must stay JS-readable (HTTPONLY False, the default) so
+# Inertia can read it; pair with ``@ensure_csrf_cookie`` on the pages that POST.
+CSRF_COOKIE_NAME = "XSRF-TOKEN"
+CSRF_HEADER_NAME = "HTTP_X_XSRF_TOKEN"
 # Fail loud if a view passes a raw model/queryset as a prop (see the encoder
 # docstring): the default encoder would recurse on our cyclic relations.
 from app.inertia_encoder import StrictInertiaJsonEncoder  # noqa: E402

--- a/app/studio/services.py
+++ b/app/studio/services.py
@@ -13,9 +13,16 @@ published alike — so these queries use ``Video.objects`` unfiltered, NOT
 import logging
 
 from django.core.paginator import Paginator
+from django.db.models import Q
+from django.utils import timezone
 
 from catalogue import search as search_index
+from catalogue.models.bible_book import Bible_Book
+from catalogue.models.demograpic import Demographic
+from catalogue.models.ministry import Ministry
 from catalogue.models.series import Series
+from catalogue.models.speaker import Speaker
+from catalogue.models.topic import Topic
 from catalogue.models.video import DRAFT, PUBLISHED, Video
 
 logger = logging.getLogger(__name__)
@@ -176,3 +183,143 @@ def delete_videos(video_ids):
         video.delete()
         deleted += 1
     return deleted
+
+
+# --------------------------------------------------------------------------- #
+# Add a video (paste-a-URL intake — Slice 3)
+# --------------------------------------------------------------------------- #
+
+
+class DuplicateVideoError(Exception):
+    """The URL is already in the catalogue. Carries the existing row so the view
+    can offer a friendly "already in library — open it" link."""
+
+    def __init__(self, video):
+        self.video = video
+        super().__init__(f"Video already exists: {video.id}")
+
+
+def find_duplicate(url):
+    """The existing video at this exact URL as a ``{id, name}`` dict, or None.
+
+    A light pre-check so the Add form can warn *before* the editor fills in
+    classification. ``Video.url`` is unique, so this is the authoritative match;
+    ``create_video`` re-checks at save time to close the race.
+    """
+    existing = Video.objects.filter(url=(url or "").strip()).only("id", "name").first()
+    return {"id": existing.id, "name": existing.name} if existing else None
+
+
+def taxonomy_options():
+    """Every classification choice the Add form offers, as plain ``{id, name}``
+    lists keyed by relation. Small enough (a few thousand rows total) to ship to
+    the page once and filter client-side."""
+    return {
+        "speakers": _options(Speaker),
+        "series": _options(Series),
+        "topics": _options(Topic),
+        "bible_books": _options(Bible_Book),
+        "demographics": _options(Demographic),
+        "ministries": _options(Ministry),
+    }
+
+
+def _options(model):
+    return [{"id": str(pk), "name": name} for pk, name in model.objects.order_by("name").values_list("pk", "name")]
+
+
+def create_video(
+    *,
+    url,
+    name,
+    description="",
+    thumbnail=None,
+    duration_seconds=None,
+    date_recorded=None,
+    status=DRAFT,
+    speaker_ids=(),
+    topic_ids=(),
+    bible_book_ids=(),
+    demographic_ids=(),
+    ministry_ids=(),
+    series_id=None,
+):
+    """Create a Studio video and link its classification. Returns the Video.
+
+    Mirrors the legacy importer (``catalogue/ingest/legacy.py``): mint an ``id``
+    + ``id_number``, create the row, then link relations via ``.set()`` — and
+    crucially link series through ``Series.videos`` (the M2M), never the decoy
+    ``Video.series`` FK. Raises ``DuplicateVideoError`` if the URL already
+    exists. New content defaults to ``draft``; the post_save signal indexes it.
+    """
+    url = (url or "").strip()
+    existing = Video.objects.filter(url=url).first()
+    if existing is not None:
+        raise DuplicateVideoError(existing)
+
+    if status not in (DRAFT, PUBLISHED):
+        status = DRAFT
+
+    video_id = _mint_video_id()
+    video = Video.objects.create(
+        id=video_id,
+        id_number=video_id,  # unique by construction; legacy uses the ref, we have none
+        name=(name or "").strip()[:200] or "Untitled",
+        description=description or "",
+        url=url,
+        thumbnail=thumbnail,
+        duration_seconds=duration_seconds,
+        date_recorded=date_recorded,
+        date_created=timezone.now().date(),
+        status=status,
+    )
+
+    _link_relations(
+        video,
+        speaker_ids=speaker_ids,
+        topic_ids=topic_ids,
+        bible_book_ids=bible_book_ids,
+        demographic_ids=demographic_ids,
+        ministry_ids=ministry_ids,
+        series_id=series_id,
+    )
+    # M2M writes don't fire Video.post_save, so re-save once relations are linked
+    # to (re)index a doc that actually reflects its speaker/series/topic facets.
+    video.save()
+    return video
+
+
+def _mint_video_id():
+    """A unique, non-colliding primary key for a Studio-created video.
+
+    Legacy ids are bare numeric strings; ours are ``S`` + a zero-padded counter
+    (``S0000001``) so they never clash with a legacy id — even one the dying
+    live-admin feed imports later — and fit the 10-char ``id`` column.
+    """
+    n = Video.objects.filter(id__startswith="S").count() + 1
+    while True:
+        candidate = f"S{n:07d}"
+        if not Video.objects.filter(Q(id=candidate) | Q(id_number=candidate)).exists():
+            return candidate
+        n += 1
+
+
+def _link_relations(
+    video, *, speaker_ids, topic_ids, bible_book_ids, demographic_ids, ministry_ids, series_id
+):
+    """Wire the M2M classifications. Unknown ids are silently dropped (the form
+    only ever submits ids it was given). Series goes through ``Series.videos``."""
+    if speaker_ids:
+        video.speaker.set(Speaker.objects.filter(pk__in=list(speaker_ids)))
+    if topic_ids:
+        video.topic.set(Topic.objects.filter(pk__in=list(topic_ids)))
+    if bible_book_ids:
+        video.bible_book.set(Bible_Book.objects.filter(pk__in=list(bible_book_ids)))
+    if demographic_ids:
+        video.demographic.set(Demographic.objects.filter(pk__in=list(demographic_ids)))
+    if ministry_ids:
+        video.ministry.set(Ministry.objects.filter(pk__in=list(ministry_ids)))
+    if series_id:
+        series = Series.objects.filter(pk=series_id).first()
+        if series is not None:
+            series.videos.add(video)

--- a/app/studio/services.py
+++ b/app/studio/services.py
@@ -304,9 +304,7 @@ def _mint_video_id():
         n += 1
 
 
-def _link_relations(
-    video, *, speaker_ids, topic_ids, bible_book_ids, demographic_ids, ministry_ids, series_id
-):
+def _link_relations(video, *, speaker_ids, topic_ids, bible_book_ids, demographic_ids, ministry_ids, series_id):
     """Wire the M2M classifications. Unknown ids are silently dropped (the form
     only ever submits ids it was given). Series goes through ``Series.videos``."""
     if speaker_ids:

--- a/app/studio/urls.py
+++ b/app/studio/urls.py
@@ -7,10 +7,15 @@ from . import views
 
 urlpatterns = [
     path("", views.library, name="studio_library"),
+    path("add", views.add_video, name="studio_add_video"),
     path("login", views.login_view, name="studio_login"),
+    path("logout", views.logout_view, name="studio_logout"),
     # Beta-only secret magic link (key-gated; 404 without the secret). See settings.
     path("dev-login", views.dev_login, name="studio_dev_login"),
+    # JSON metadata preview for the Add form (not Inertia).
+    path("api/fetch-metadata", views.fetch_metadata_api, name="studio_fetch_metadata"),
     # Library mutations (all @studio_required + POST + CSRF).
+    path("videos/create", views.create_video, name="studio_create_video"),
     path("videos/bulk-status", views.bulk_status, name="studio_bulk_status"),
     path("videos/delete", views.delete_videos, name="studio_delete_videos"),
     path("videos/<str:id>/status", views.set_status, name="studio_set_status"),

--- a/app/studio/views.py
+++ b/app/studio/views.py
@@ -5,12 +5,13 @@ Library's data assembly and mutations live in ``app.studio.services``; these
 just wire request → service → response.
 """
 
+import json
 import secrets
 
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import authenticate, get_user_model, login
-from django.http import Http404
+from django.contrib.auth import authenticate, get_user_model, login, logout
+from django.http import Http404, JsonResponse
 from django.shortcuts import redirect
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -18,6 +19,7 @@ from django.views.decorators.http import require_POST
 from inertia import render, share
 
 from app.auth import can_edit_content
+from catalogue.metadata import MetadataError, fetch_metadata
 from catalogue.models.video import DRAFT, PUBLISHED
 
 from . import services
@@ -28,8 +30,47 @@ from .auth import studio_required
 DEFAULT_REDIRECT = "/studio"
 
 
+class _Payload:
+    """Read POST fields from an Inertia request body.
+
+    Inertia serialises a plain-object POST as a **JSON body** (Content-Type
+    ``application/json``), so ``request.POST`` is empty for real browser
+    submissions — only form-encoded posts (e.g. Django's test client) populate
+    it. This normaliser reads either: JSON when that's what arrived, else
+    ``request.POST``. ``get`` returns a scalar; ``getlist`` always a list, and
+    accepts both ``key`` and ``key[]`` forms.
+    """
+
+    def __init__(self, request):
+        content_type = (request.content_type or "").lower()
+        if content_type.startswith("application/json"):
+            try:
+                self._json = json.loads(request.body or "{}")
+            except (ValueError, TypeError):
+                self._json = {}
+        else:
+            self._json = None
+            self._post = request.POST
+
+    def get(self, key, default=None):
+        if self._json is not None:
+            value = self._json.get(key, default)
+            return value if value is not None else default
+        return self._post.get(key, default)
+
+    def getlist(self, key):
+        if self._json is not None:
+            value = self._json.get(key)
+            if value is None:
+                value = self._json.get(f"{key}[]")
+            if value is None:
+                return []
+            return value if isinstance(value, list) else [value]
+        return self._post.getlist(f"{key}[]") or self._post.getlist(key)
+
+
 def _safe_next(request):
-    nxt = request.POST.get("next") or request.GET.get("next") or ""
+    nxt = _Payload(request).get("next") or request.GET.get("next") or ""
     if nxt and url_has_allowed_host_and_scheme(nxt, allowed_hosts={request.get_host()}):
         return nxt
     return DEFAULT_REDIRECT
@@ -40,8 +81,8 @@ def login_view(request):
     """``/studio/login``.
 
     GET renders the Inertia login page. ``ensure_csrf_cookie`` is load-bearing:
-    it guarantees the ``csrftoken`` cookie is set so Inertia's axios echoes it
-    back as ``X-CSRFToken`` on the POST (inertia-django POSTs rely on this).
+    it guarantees the XSRF cookie is set so Inertia's client echoes it back as
+    the ``X-XSRF-TOKEN`` header on the POST (CSRF names aligned in settings).
 
     POST authenticates and logs in, then redirects to ``next`` (or ``/studio``).
     On bad credentials we share an error and re-render the page — inertia-django
@@ -52,8 +93,9 @@ def login_view(request):
         return redirect(_safe_next(request))
 
     if request.method == "POST":
-        username = (request.POST.get("username") or "").strip()
-        password = request.POST.get("password") or ""
+        payload = _Payload(request)
+        username = (payload.get("username") or "").strip()
+        password = payload.get("password") or ""
         user = authenticate(request, username=username, password=password)
         if user is None:
             # Manual error-bag shim until inertia-django ships one (issue #49):
@@ -93,6 +135,17 @@ def dev_login(request):
     return redirect(DEFAULT_REDIRECT)
 
 
+@require_POST
+def logout_view(request):
+    """``POST /studio/logout`` — end the session and return to the login page.
+
+    POST-only (a GET logout is CSRF-prone and lets a stray link sign editors
+    out). The Studio "Sign out" button posts here via Inertia.
+    """
+    logout(request)
+    return redirect("/studio/login")
+
+
 # --------------------------------------------------------------------------- #
 # Library (the editor content list)
 # --------------------------------------------------------------------------- #
@@ -112,9 +165,14 @@ def _library_filters(request):
 
 
 @studio_required
+@ensure_csrf_cookie
 def library(request):
     """``/studio`` — the Library: every video (all statuses), filterable,
-    searchable, paginated. The Studio's home base."""
+    searchable, paginated. The Studio's home base.
+
+    ``ensure_csrf_cookie`` guarantees the XSRF cookie is present so the row/bulk
+    mutations (Inertia POSTs) carry a valid CSRF token — including for a session
+    that landed here straight from the magic link."""
     q, status, page = _library_filters(request)
     result = services.list_videos(search=q, status=status, page=page)
     return render(
@@ -128,19 +186,19 @@ def library(request):
     )
 
 
-def _back_to_library(request):
+def _back_to_library(request, payload=None):
     """Redirect back to the Library, preserving the editor's current filters so a
     mutation doesn't bounce them out of their search/status/page context. Inertia
     treats the redirect as a navigation and re-fetches the (now-updated) list."""
-    nxt = request.POST.get("next") or "/studio"
+    nxt = (payload or _Payload(request)).get("next") or "/studio"
     if url_has_allowed_host_and_scheme(nxt, allowed_hosts={request.get_host()}):
         return redirect(nxt)
     return redirect("/studio")
 
 
-def _posted_status(request):
+def _posted_status(payload):
     """The ``status`` from a mutation body, or None if not a valid choice."""
-    status = request.POST.get("status")
+    status = payload.get("status")
     return status if status in (DRAFT, PUBLISHED) else None
 
 
@@ -148,40 +206,121 @@ def _posted_status(request):
 @require_POST
 def set_status(request, id):
     """Publish/unpublish a single video. Saving re-fires the search signal."""
-    status = _posted_status(request)
+    payload = _Payload(request)
+    status = _posted_status(payload)
     if status is None:
         messages.error(request, "Unknown status.")
-        return _back_to_library(request)
+        return _back_to_library(request, payload)
     if services.set_video_status(id, status):
         messages.success(request, "Published." if status == PUBLISHED else "Moved to drafts.")
     else:
         messages.error(request, "That video could not be found.")
-    return _back_to_library(request)
+    return _back_to_library(request, payload)
 
 
 @studio_required
 @require_POST
 def bulk_status(request):
     """Publish/unpublish many videos at once."""
-    status = _posted_status(request)
-    ids = request.POST.getlist("ids[]") or request.POST.getlist("ids")
+    payload = _Payload(request)
+    status = _posted_status(payload)
+    ids = payload.getlist("ids")
     if status is None or not ids:
         messages.error(request, "Nothing to update.")
-        return _back_to_library(request)
+        return _back_to_library(request, payload)
     count = services.set_videos_status(ids, status)
     verb = "Published" if status == PUBLISHED else "Moved to drafts"
     messages.success(request, f"{verb} {count} {'video' if count == 1 else 'videos'}.")
-    return _back_to_library(request)
+    return _back_to_library(request, payload)
 
 
 @studio_required
 @require_POST
 def delete_videos(request):
     """Delete one or more videos. The post_delete signal drops them from search."""
-    ids = request.POST.getlist("ids[]") or request.POST.getlist("ids")
+    payload = _Payload(request)
+    ids = payload.getlist("ids")
     if not ids:
         messages.error(request, "Nothing to delete.")
-        return _back_to_library(request)
+        return _back_to_library(request, payload)
     count = services.delete_videos(ids)
     messages.success(request, f"Deleted {count} {'video' if count == 1 else 'videos'}.")
-    return _back_to_library(request)
+    return _back_to_library(request, payload)
+
+
+# --------------------------------------------------------------------------- #
+# Add a video (paste-a-URL intake — Slice 3)
+# --------------------------------------------------------------------------- #
+
+
+@studio_required
+@ensure_csrf_cookie
+def add_video(request):
+    """``/studio/add`` — the paste-a-URL intake form, with the classification
+    choices the editor picks from. ``ensure_csrf_cookie`` guarantees the XSRF
+    cookie is set so the page's fetch() metadata call can echo it."""
+    return render(request, "Studio/AddVideo", {"taxonomy": services.taxonomy_options()})
+
+
+@studio_required
+@require_POST
+def fetch_metadata_api(request):
+    """``POST /studio/api/fetch-metadata`` {url} → JSON metadata preview.
+
+    A plain JSON endpoint (not Inertia) the Add page calls as the editor pastes:
+    returns ``{ok: true, metadata: {...}}``, or ``{ok: false, error}`` for an
+    unsupported/failed URL, plus ``duplicate`` when the URL is already in the
+    library so the form can warn before they fill anything in.
+    """
+    try:
+        url = (json.loads(request.body or "{}").get("url") or "").strip()
+    except (ValueError, TypeError):
+        url = ""
+
+    try:
+        metadata = fetch_metadata(url)
+    except MetadataError as exc:
+        return JsonResponse({"ok": False, "error": str(exc)}, status=200)
+
+    return JsonResponse({"ok": True, "metadata": metadata, "duplicate": services.find_duplicate(metadata["url"])})
+
+
+def _int_or_none(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+@studio_required
+@require_POST
+def create_video(request):
+    """``POST /studio/videos/create`` — create a Studio video from the Add form.
+
+    On a duplicate URL we keep the editor on the form with an inline error (their
+    typed-in form state survives via Inertia's ``useForm``); on success we land
+    them in the Library with a flash so they can see the new row."""
+    post = _Payload(request)
+    try:
+        video = services.create_video(
+            url=post.get("url", ""),
+            name=post.get("name", ""),
+            description=post.get("description", ""),
+            thumbnail=post.get("thumbnail") or None,
+            duration_seconds=_int_or_none(post.get("duration_seconds")),
+            date_recorded=post.get("date_recorded") or None,
+            status=post.get("status", DRAFT),
+            speaker_ids=post.getlist("speaker_ids"),
+            topic_ids=post.getlist("topic_ids"),
+            bible_book_ids=post.getlist("bible_book_ids"),
+            demographic_ids=post.getlist("demographic_ids"),
+            ministry_ids=post.getlist("ministry_ids"),
+            series_id=post.get("series_id") or None,
+        )
+    except services.DuplicateVideoError as exc:
+        share(request, errors={"url": f"“{exc.video.name}” is already in the library."})
+        return render(request, "Studio/AddVideo", {"taxonomy": services.taxonomy_options()})
+
+    verb = "Published" if video.status == PUBLISHED else "Saved as draft"
+    messages.success(request, f"{verb}: “{video.name}”.")
+    return redirect("/studio")

--- a/catalogue/metadata.py
+++ b/catalogue/metadata.py
@@ -1,0 +1,108 @@
+"""Fetch a video's metadata from its hosting platform, for the Studio's
+paste-a-URL intake (Epic 3, Slice 3).
+
+Given a YouTube or Vimeo URL we return a small normalised dict — title,
+description, thumbnail, runtime, recorded date — that the editor previews and
+confirms before saving. Deliberately reuses the existing, battle-tested helpers
+rather than growing new API clients:
+
+- YouTube: ``youtube_live.api_get`` (the retrying ``videos.list`` client; 1
+  quota unit) + ``durations.parse_iso8601_duration``.
+- Vimeo: the public oEmbed endpoint (no auth), same source ``harvest_durations``
+  already uses for runtimes.
+
+Network failures / unknown URLs raise ``MetadataError`` with a human-readable
+message; the view turns that into a friendly inline error.
+"""
+
+import requests
+
+from catalogue import durations, youtube_live
+
+VIMEO_OEMBED = "https://vimeo.com/api/oembed.json"
+
+
+class MetadataError(Exception):
+    """A URL we can't turn into video metadata (unsupported host, not found,
+    or the platform API failed). The message is safe to show an editor."""
+
+
+def fetch_metadata(url, session=None):
+    """Normalised metadata for a YouTube/Vimeo ``url``.
+
+    Returns a dict: ``platform``, ``platform_id``, ``url`` (canonical),
+    ``name``, ``description``, ``thumbnail``, ``duration_seconds``,
+    ``date_recorded`` (``YYYY-MM-DD`` or None). Raises ``MetadataError`` for an
+    unsupported URL or a failed fetch.
+    """
+    url = (url or "").strip()
+    if not url:
+        raise MetadataError("Paste a video URL to get started.")
+
+    session = session or requests.Session()
+
+    if durations.youtube_id(url):
+        return _fetch_youtube(url, session)
+    if "vimeo.com" in url:
+        return _fetch_vimeo(url, session)
+    raise MetadataError("That doesn't look like a YouTube or Vimeo link.")
+
+
+def _fetch_youtube(url, session):
+    yid = durations.youtube_id(url)
+    try:
+        data = youtube_live.api_get(session, "videos", part="snippet,contentDetails", id=yid)
+    except youtube_live.YoutubeApiError as exc:
+        raise MetadataError("Couldn't reach YouTube just now — try again in a moment.") from exc
+    except KeyError as exc:  # YOUTUBE_API_KEY not configured in this environment
+        raise MetadataError("YouTube lookups aren't configured here — try a Vimeo link.") from exc
+
+    items = data.get("items") or []
+    if not items:
+        raise MetadataError("No YouTube video found at that link (it may be private or deleted).")
+
+    snippet = items[0].get("snippet", {})
+    details = items[0].get("contentDetails", {})
+    published = snippet.get("publishedAt") or ""
+    return {
+        "platform": "youtube",
+        "platform_id": yid,
+        "url": f"https://www.youtube.com/watch?v={yid}",
+        "name": snippet.get("title", ""),
+        "description": snippet.get("description", ""),
+        "thumbnail": _best_youtube_thumbnail(snippet.get("thumbnails", {})),
+        "duration_seconds": durations.parse_iso8601_duration(details.get("duration")),
+        "date_recorded": published[:10] or None,
+    }
+
+
+def _best_youtube_thumbnail(thumbnails):
+    """Highest-resolution thumbnail YouTube offers for this video."""
+    for size in ("maxres", "standard", "high", "medium", "default"):
+        if size in thumbnails:
+            return thumbnails[size].get("url")
+    return None
+
+
+def _fetch_vimeo(url, session):
+    try:
+        response = session.get(VIMEO_OEMBED, params={"url": url}, timeout=15)
+    except requests.RequestException as exc:
+        raise MetadataError("Couldn't reach Vimeo just now — try again in a moment.") from exc
+    if response.status_code != 200:
+        raise MetadataError("No Vimeo video found at that link (it may be private or deleted).")
+
+    data = response.json()
+    platform_id = str(data.get("video_id") or "")
+    duration = data.get("duration")
+    upload_date = data.get("upload_date") or ""  # "2014-05-30 12:00:00"
+    return {
+        "platform": "vimeo",
+        "platform_id": platform_id,
+        "url": f"https://vimeo.com/{platform_id}" if platform_id else url,
+        "name": data.get("title", ""),
+        "description": data.get("description", "") or "",
+        "thumbnail": data.get("thumbnail_url"),
+        "duration_seconds": int(duration) if duration else None,
+        "date_recorded": upload_date[:10] or None,
+    }

--- a/resources/js/components/molecules/TaxonomySelect.vue
+++ b/resources/js/components/molecules/TaxonomySelect.vue
@@ -1,0 +1,193 @@
+<script setup lang="ts">
+import { onClickOutside } from '@vueuse/core';
+import { Check, ChevronsUpDown, X } from 'lucide-vue-next';
+import { computed, nextTick, ref } from 'vue';
+
+/**
+ * A searchable picker for one taxonomy (speakers, series, topics…). Single- or
+ * multi-select. Options are filtered client-side and capped so even the ~2,600
+ * series list stays snappy — the editor narrows with the search box.
+ *
+ * Self-contained on purpose (no popover/combobox dependency): a labelled
+ * trigger button opens a panel with a search field and a scrollable result
+ * list. Keyboard: Enter picks the top match, Escape closes.
+ */
+
+interface Option {
+    id: string;
+    name: string;
+}
+
+const props = withDefaults(
+    defineProps<{
+        id: string;
+        label: string;
+        options: Option[];
+        // string[] when multiple, string | null when single.
+        modelValue: string[] | string | null;
+        multiple?: boolean;
+        placeholder?: string;
+        searchPlaceholder?: string;
+        hint?: string;
+    }>(),
+    {
+        multiple: false,
+        placeholder: 'Select…',
+        searchPlaceholder: 'Search…',
+        hint: '',
+    },
+);
+
+const emit = defineEmits<{ 'update:modelValue': [value: string[] | string | null] }>();
+
+const MAX_RESULTS = 50;
+
+const open = ref(false);
+const query = ref('');
+const root = ref<HTMLElement | null>(null);
+const searchInput = ref<HTMLInputElement | null>(null);
+
+onClickOutside(root, () => (open.value = false));
+
+// Normalise the model to a Set of ids regardless of single/multiple shape.
+const selectedIds = computed(() => {
+    if (props.multiple) return new Set((props.modelValue as string[]) || []);
+    return new Set(props.modelValue ? [props.modelValue as string] : []);
+});
+
+const byId = computed(() => new Map(props.options.map((o) => [o.id, o])));
+const selectedOptions = computed(() => [...selectedIds.value].map((id) => byId.value.get(id)).filter(Boolean) as Option[]);
+
+const filtered = computed(() => {
+    const q = query.value.trim().toLowerCase();
+    const matches = q ? props.options.filter((o) => o.name.toLowerCase().includes(q)) : props.options;
+    return matches.slice(0, MAX_RESULTS);
+});
+
+const overflow = computed(() => {
+    const q = query.value.trim().toLowerCase();
+    const total = q ? props.options.filter((o) => o.name.toLowerCase().includes(q)).length : props.options.length;
+    return Math.max(0, total - MAX_RESULTS);
+});
+
+async function toggleOpen() {
+    open.value = !open.value;
+    if (open.value) {
+        await nextTick();
+        searchInput.value?.focus();
+    }
+}
+
+function isSelected(id: string) {
+    return selectedIds.value.has(id);
+}
+
+function pick(option: Option) {
+    if (props.multiple) {
+        const next = new Set(selectedIds.value);
+        if (next.has(option.id)) next.delete(option.id);
+        else next.add(option.id);
+        emit('update:modelValue', [...next]);
+    } else {
+        emit('update:modelValue', isSelected(option.id) ? null : option.id);
+        open.value = false;
+        query.value = '';
+    }
+}
+
+function remove(id: string) {
+    if (props.multiple) {
+        emit(
+            'update:modelValue',
+            [...selectedIds.value].filter((x) => x !== id),
+        );
+    } else {
+        emit('update:modelValue', null);
+    }
+}
+
+function onEnter() {
+    if (filtered.value.length) pick(filtered.value[0]);
+}
+</script>
+
+<template>
+    <div ref="root" class="relative">
+        <label :for="id" class="text-foreground mb-1.5 block text-sm font-medium">{{ label }}</label>
+
+        <!-- Trigger -->
+        <button
+            :id="id"
+            type="button"
+            @click="toggleOpen"
+            :aria-expanded="open"
+            aria-haspopup="listbox"
+            class="border-input bg-background hover:bg-accent/40 focus-visible:ring-ring flex min-h-11 w-full items-center justify-between gap-2 rounded-lg border px-3 py-2 text-left text-base transition-colors outline-none focus-visible:ring-2"
+        >
+            <span v-if="!selectedOptions.length" class="text-muted-foreground">{{ placeholder }}</span>
+            <!-- Selected: chips for multiple, plain text for single -->
+            <span v-else-if="multiple" class="flex flex-wrap gap-1.5">
+                <span
+                    v-for="opt in selectedOptions"
+                    :key="opt.id"
+                    class="bg-secondary text-secondary-foreground inline-flex items-center gap-1 rounded-md py-0.5 pr-1 pl-2 text-sm"
+                >
+                    {{ opt.name }}
+                    <span
+                        role="button"
+                        :aria-label="`Remove ${opt.name}`"
+                        tabindex="0"
+                        @click.stop="remove(opt.id)"
+                        @keydown.enter.stop.prevent="remove(opt.id)"
+                        class="hover:bg-background/60 rounded p-0.5"
+                    >
+                        <X class="size-3.5" aria-hidden="true" />
+                    </span>
+                </span>
+            </span>
+            <span v-else class="text-foreground truncate">{{ selectedOptions[0].name }}</span>
+
+            <ChevronsUpDown class="text-muted-foreground size-4 shrink-0" aria-hidden="true" />
+        </button>
+
+        <p v-if="hint" class="text-muted-foreground mt-1 text-xs">{{ hint }}</p>
+
+        <!-- Panel -->
+        <Transition
+            enter-active-class="transition duration-150 ease-out motion-reduce:transition-none"
+            enter-from-class="opacity-0 -translate-y-1"
+            leave-active-class="transition duration-100 ease-in motion-reduce:transition-none"
+            leave-to-class="opacity-0"
+        >
+            <div v-if="open" class="bg-popover absolute z-20 mt-1.5 w-full overflow-hidden rounded-lg border shadow-lg">
+                <div class="border-b p-2">
+                    <input
+                        ref="searchInput"
+                        v-model="query"
+                        type="search"
+                        :placeholder="searchPlaceholder"
+                        @keydown.enter.prevent="onEnter"
+                        @keydown.esc="open = false"
+                        class="bg-background focus-visible:ring-ring w-full rounded-md border px-3 py-2 text-base outline-none focus-visible:ring-2"
+                    />
+                </div>
+                <ul role="listbox" class="max-h-64 overflow-y-auto p-1">
+                    <li v-if="!filtered.length" class="text-muted-foreground px-3 py-6 text-center text-sm">No matches</li>
+                    <li v-for="opt in filtered" :key="opt.id">
+                        <button
+                            type="button"
+                            role="option"
+                            :aria-selected="isSelected(opt.id)"
+                            @click="pick(opt)"
+                            class="hover:bg-accent flex w-full items-center justify-between gap-2 rounded-md px-3 py-2 text-left text-sm transition-colors"
+                        >
+                            <span class="truncate">{{ opt.name }}</span>
+                            <Check v-if="isSelected(opt.id)" class="text-primary size-4 shrink-0" aria-hidden="true" />
+                        </button>
+                    </li>
+                    <li v-if="overflow" class="text-muted-foreground px-3 py-2 text-center text-xs">+{{ overflow }} more — keep typing to narrow</li>
+                </ul>
+            </div>
+        </Transition>
+    </div>
+</template>

--- a/resources/js/lib/csrf.ts
+++ b/resources/js/lib/csrf.ts
@@ -1,0 +1,14 @@
+/**
+ * Read the CSRF token from the `XSRF-TOKEN` cookie.
+ *
+ * Django is configured (CSRF_COOKIE_NAME / CSRF_HEADER_NAME in base_settings)
+ * to use the `XSRF-TOKEN` cookie + `X-XSRF-TOKEN` header that Inertia's client
+ * uses by default. Inertia's own POSTs send this automatically; this helper is
+ * for the handful of plain `fetch()` calls to JSON endpoints (e.g. the Studio's
+ * Add-a-video metadata preview). The page must set the cookie first — we use
+ * `@ensure_csrf_cookie` on those views.
+ */
+export function getCsrfToken(): string {
+    const match = document.cookie.match(/(?:^|;\s*)XSRF-TOKEN=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+}

--- a/resources/js/pages/Studio/AddVideo.vue
+++ b/resources/js/pages/Studio/AddVideo.vue
@@ -1,0 +1,284 @@
+<script setup lang="ts">
+import TaxonomySelect from '@/molecules/TaxonomySelect.vue';
+import { Button } from '@/ui/button';
+import { Input } from '@/ui/input';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+import { useDebounceFn } from '@vueuse/core';
+import { ArrowLeft, CircleAlert, LoaderCircle } from 'lucide-vue-next';
+import { computed, ref, watch } from 'vue';
+import { getCsrfToken } from '~/lib/csrf';
+import { formatDuration } from '~/lib/duration';
+
+interface Option {
+    id: string;
+    name: string;
+}
+
+const props = defineProps<{
+    taxonomy: {
+        speakers: Option[];
+        series: Option[];
+        topics: Option[];
+        bible_books: Option[];
+        demographics: Option[];
+        ministries: Option[];
+    };
+}>();
+
+// One form for the whole intake. Metadata fetch fills the descriptive fields;
+// the editor confirms/edits and classifies, then saves as draft or publishes.
+const form = useForm<{
+    url: string;
+    name: string;
+    description: string;
+    thumbnail: string;
+    duration_seconds: number | null;
+    date_recorded: string;
+    status: 'draft' | 'published';
+    speaker_ids: string[];
+    topic_ids: string[];
+    bible_book_ids: string[];
+    demographic_ids: string[];
+    ministry_ids: string[];
+    series_id: string | null;
+}>({
+    url: '',
+    name: '',
+    description: '',
+    thumbnail: '',
+    duration_seconds: null,
+    date_recorded: '',
+    status: 'draft',
+    speaker_ids: [],
+    topic_ids: [],
+    bible_book_ids: [],
+    demographic_ids: [],
+    ministry_ids: [],
+    series_id: null,
+});
+
+// --- metadata preview (fetched as the editor pastes) ---------------------
+interface Preview {
+    platform: string;
+    thumbnail: string | null;
+    duration_seconds: number | null;
+    date_recorded: string | null;
+}
+
+const fetching = ref(false);
+const fetchError = ref('');
+const preview = ref<Preview | null>(null);
+const duplicate = ref<{ id: string; name: string } | null>(null);
+
+async function fetchMetadata() {
+    const url = form.url.trim();
+    if (!url) {
+        preview.value = null;
+        fetchError.value = '';
+        duplicate.value = null;
+        return;
+    }
+    fetching.value = true;
+    fetchError.value = '';
+    try {
+        const res = await fetch('/studio/api/fetch-metadata', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-XSRF-TOKEN': getCsrfToken() },
+            body: JSON.stringify({ url }),
+        });
+        const data = await res.json();
+        if (!data.ok) {
+            fetchError.value = data.error || 'Could not read that video.';
+            preview.value = null;
+            duplicate.value = null;
+            return;
+        }
+        const m = data.metadata;
+        form.name = m.name || '';
+        form.description = m.description || '';
+        form.thumbnail = m.thumbnail || '';
+        form.duration_seconds = m.duration_seconds ?? null;
+        form.date_recorded = m.date_recorded || '';
+        form.url = m.url || url; // canonical form
+        preview.value = m;
+        duplicate.value = data.duplicate;
+    } catch {
+        fetchError.value = 'Something went wrong fetching that video. Check the link and try again.';
+        preview.value = null;
+    } finally {
+        fetching.value = false;
+    }
+}
+
+const debouncedFetch = useDebounceFn(fetchMetadata, 600);
+watch(() => form.url, debouncedFetch);
+
+// --- save ----------------------------------------------------------------
+const canSave = computed(() => !!preview.value && !!form.name.trim() && !duplicate.value);
+
+function save(status: 'draft' | 'published') {
+    form.status = status;
+    form.post('/studio/videos/create', { preserveScroll: true });
+}
+
+const recordedLabel = computed(() => (preview.value?.date_recorded ? preview.value.date_recorded : null));
+</script>
+
+<template>
+    <Head title="Studio — Add a video" />
+
+    <div class="mx-auto max-w-3xl px-4 py-8 lg:px-8">
+        <Link
+            href="/studio"
+            class="text-muted-foreground hover:text-foreground focus-visible:ring-ring -ml-1 inline-flex items-center gap-1.5 rounded text-sm transition-colors outline-none focus-visible:ring-2"
+        >
+            <ArrowLeft class="size-4" aria-hidden="true" />
+            Back to Library
+        </Link>
+
+        <h1 class="font-display text-foreground mt-3 text-2xl font-bold sm:text-3xl">Add a video</h1>
+        <p class="text-muted-foreground mt-1 text-sm">Paste a YouTube or Vimeo link and we'll fetch the details. Review, classify, then save.</p>
+
+        <!-- Step 1: the URL -->
+        <div class="mt-8 space-y-1.5">
+            <label for="video-url" class="text-foreground block text-sm font-medium">Video link</label>
+            <div class="relative">
+                <Input
+                    id="video-url"
+                    v-model="form.url"
+                    type="url"
+                    inputmode="url"
+                    placeholder="https://www.youtube.com/watch?v=…"
+                    class="pr-10 text-base"
+                    autofocus
+                    :aria-invalid="!!fetchError || undefined"
+                />
+                <LoaderCircle
+                    v-if="fetching"
+                    class="text-muted-foreground absolute top-1/2 right-3 size-4 -translate-y-1/2 animate-spin motion-reduce:animate-none"
+                    aria-label="Fetching"
+                />
+            </div>
+            <p v-if="fetchError" role="alert" class="text-destructive flex items-center gap-1.5 text-sm">
+                <CircleAlert class="size-4 shrink-0" aria-hidden="true" />
+                {{ fetchError }}
+            </p>
+            <p v-if="form.errors.url" role="alert" class="text-destructive flex items-center gap-1.5 text-sm">
+                <CircleAlert class="size-4 shrink-0" aria-hidden="true" />
+                {{ form.errors.url }}
+            </p>
+        </div>
+
+        <!-- Duplicate warning -->
+        <div v-if="duplicate" class="border-destructive/40 bg-destructive/10 mt-4 flex items-start gap-3 rounded-lg border p-4">
+            <CircleAlert class="text-destructive mt-0.5 size-5 shrink-0" aria-hidden="true" />
+            <div class="text-sm">
+                <p class="text-foreground font-medium">This video is already in the library.</p>
+                <Link :href="`/video/${duplicate.id}`" class="text-primary hover:underline"> Open “{{ duplicate.name }}” </Link>
+            </div>
+        </div>
+
+        <!-- Step 2: preview + edit (once fetched, no dup) -->
+        <div v-if="preview && !duplicate" class="mt-8 space-y-6">
+            <!-- Preview card -->
+            <div class="border-border bg-card flex gap-4 rounded-xl border p-4">
+                <div class="bg-muted relative aspect-video w-40 shrink-0 overflow-hidden rounded-lg">
+                    <img v-if="form.thumbnail" :src="form.thumbnail" alt="" class="h-full w-full object-cover" loading="lazy" />
+                    <span
+                        v-if="form.duration_seconds"
+                        class="bg-background/80 text-foreground absolute right-1 bottom-1 rounded px-1.5 py-0.5 text-xs font-medium tabular-nums"
+                    >
+                        {{ formatDuration(form.duration_seconds) }}
+                    </span>
+                </div>
+                <div class="min-w-0 flex-1 text-sm">
+                    <span class="text-muted-foreground text-xs tracking-wide uppercase">{{ preview.platform }}</span>
+                    <p class="text-foreground mt-0.5 line-clamp-2 font-medium">{{ form.name || 'Untitled' }}</p>
+                    <p v-if="recordedLabel" class="text-muted-foreground mt-1 tabular-nums">Recorded {{ recordedLabel }}</p>
+                </div>
+            </div>
+
+            <!-- Title + description -->
+            <div class="space-y-1.5">
+                <label for="video-name" class="text-foreground block text-sm font-medium">Title</label>
+                <Input id="video-name" v-model="form.name" type="text" class="text-base" maxlength="200" />
+            </div>
+
+            <div class="space-y-1.5">
+                <label for="video-description" class="text-foreground block text-sm font-medium">Description</label>
+                <textarea
+                    id="video-description"
+                    v-model="form.description"
+                    rows="4"
+                    class="border-input bg-background focus-visible:ring-ring w-full rounded-lg border px-3 py-2 text-base outline-none focus-visible:ring-2"
+                ></textarea>
+            </div>
+
+            <!-- Classification -->
+            <fieldset class="space-y-4">
+                <legend class="text-foreground text-base font-semibold">Classification</legend>
+                <p class="text-muted-foreground -mt-2 text-sm">All optional — you can refine these later.</p>
+                <div class="grid gap-4 sm:grid-cols-2">
+                    <TaxonomySelect
+                        id="tax-speakers"
+                        label="Speakers"
+                        :options="props.taxonomy.speakers"
+                        v-model="form.speaker_ids"
+                        multiple
+                        placeholder="Add speakers…"
+                    />
+                    <TaxonomySelect
+                        id="tax-series"
+                        label="Series"
+                        :options="props.taxonomy.series"
+                        v-model="form.series_id"
+                        placeholder="Choose a series…"
+                    />
+                    <TaxonomySelect
+                        id="tax-topics"
+                        label="Topics"
+                        :options="props.taxonomy.topics"
+                        v-model="form.topic_ids"
+                        multiple
+                        placeholder="Add topics…"
+                    />
+                    <TaxonomySelect
+                        id="tax-books"
+                        label="Bible books"
+                        :options="props.taxonomy.bible_books"
+                        v-model="form.bible_book_ids"
+                        multiple
+                        placeholder="Add Bible books…"
+                    />
+                    <TaxonomySelect
+                        id="tax-audiences"
+                        label="Audiences"
+                        :options="props.taxonomy.demographics"
+                        v-model="form.demographic_ids"
+                        multiple
+                        placeholder="Add audiences…"
+                    />
+                    <TaxonomySelect
+                        id="tax-ministries"
+                        label="Ministries"
+                        :options="props.taxonomy.ministries"
+                        v-model="form.ministry_ids"
+                        multiple
+                        placeholder="Add ministries…"
+                    />
+                </div>
+            </fieldset>
+
+            <!-- Actions -->
+            <div class="flex flex-wrap items-center gap-3 border-t pt-6">
+                <Button :disabled="!canSave || form.processing" @click="save('published')">
+                    {{ form.processing && form.status === 'published' ? 'Publishing…' : 'Publish' }}
+                </Button>
+                <Button variant="outline" :disabled="!canSave || form.processing" @click="save('draft')">
+                    {{ form.processing && form.status === 'draft' ? 'Saving…' : 'Save as draft' }}
+                </Button>
+                <span class="text-muted-foreground text-sm">Drafts stay hidden from the public site until published.</span>
+            </div>
+        </div>
+    </div>
+</template>

--- a/resources/js/pages/Studio/Library.vue
+++ b/resources/js/pages/Studio/Library.vue
@@ -9,9 +9,9 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSepara
 import { Input } from '@/ui/input';
 import { Skeleton } from '@/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table';
-import { Head, router } from '@inertiajs/vue3';
+import { Head, Link, router } from '@inertiajs/vue3';
 import { useDebounceFn } from '@vueuse/core';
-import { ExternalLink, Film, MoreHorizontal, Pencil, Plus, Search } from 'lucide-vue-next';
+import { ExternalLink, Film, LogOut, MoreHorizontal, Pencil, Plus, Search } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
 import { formatDuration } from '~/lib/duration';
 
@@ -146,6 +146,10 @@ function confirmDelete() {
     confirmingDelete.value = false;
 }
 
+function signOut() {
+    router.post('/studio/logout');
+}
+
 const resultLabel = computed(() => {
     const n = props.total;
     const noun = n === 1 ? 'video' : 'videos';
@@ -166,11 +170,18 @@ const resultLabel = computed(() => {
                 <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Studio — Library</h1>
                 <p class="text-muted-foreground mt-1 text-sm tabular-nums">{{ resultLabel }}</p>
             </div>
-            <!-- Add a video lands in Slice 3 -->
-            <Button disabled title="Coming in the next slice" class="cursor-not-allowed">
-                <Plus class="size-4" aria-hidden="true" />
-                Add a video
-            </Button>
+            <div class="flex items-center gap-2">
+                <Button variant="ghost" size="sm" @click="signOut">
+                    <LogOut class="size-4" aria-hidden="true" />
+                    Sign out
+                </Button>
+                <Button as-child>
+                    <Link href="/studio/add">
+                        <Plus class="size-4" aria-hidden="true" />
+                        Add a video
+                    </Link>
+                </Button>
+            </div>
         </div>
 
         <!-- Filter bar -->

--- a/resources/js/pages/Studio/Login.vue
+++ b/resources/js/pages/Studio/Login.vue
@@ -19,7 +19,7 @@ const props = defineProps<{
 // inertia-django 1.2 has no built-in error bag; the view shares
 // `errors: { detail }` on a bad login and useForm surfaces it on `form.errors`
 // (read below as `error`). The CSRF cookie is set server-side via
-// @ensure_csrf_cookie so axios echoes X-CSRFToken on this POST.
+// @ensure_csrf_cookie so the client echoes X-XSRF-TOKEN on this POST.
 const form = useForm({
     username: '',
     password: '',

--- a/tests/test_studio_add_video.py
+++ b/tests/test_studio_add_video.py
@@ -1,0 +1,265 @@
+"""Studio Add-a-video (Epic 3, Slice 3): the paste-a-URL intake.
+
+Covers the service layer (create a draft with the *correct* relations, dedup,
+id minting) and the views (the gated form page, the JSON metadata endpoint, and
+the create handler).
+"""
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+
+import app.studio.views as studio_views
+from app.auth import EDITORS_GROUP
+from app.studio import services
+from catalogue.metadata import MetadataError
+from catalogue.models.video import DRAFT, PUBLISHED, Video
+from tests.factories import SeriesFactory, SpeakerFactory, TopicFactory, VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+PASSWORD = "pw-correct-horse-1"  # gitleaks:allow
+
+
+def make_editor(username="editor"):
+    user = User.objects.create_user(username=username, password=PASSWORD)
+    group, _ = Group.objects.get_or_create(name=EDITORS_GROUP)
+    user.groups.add(group)
+    return user
+
+
+def login_editor(client, username="editor"):
+    make_editor(username)
+    client.login(username=username, password=PASSWORD)
+
+
+# --- service: create_video ------------------------------------------------
+
+
+def test_create_video_makes_draft_with_relations():
+    speaker = SpeakerFactory()
+    topic = TopicFactory()
+    series = SeriesFactory()
+
+    video = services.create_video(
+        url="https://www.youtube.com/watch?v=NEW1",
+        name="A fresh sermon",
+        description="Notes.",
+        duration_seconds=1730,
+        status=DRAFT,
+        speaker_ids=[speaker.id],
+        topic_ids=[topic.id],
+        series_id=series.pk,
+    )
+
+    assert video.status == DRAFT
+    assert video.id.startswith("S")
+    assert video.id_number == video.id
+    assert list(video.speaker.all()) == [speaker]
+    assert list(video.topic.all()) == [topic]
+    # Series membership lives on Series.videos (M2M) — NOT the decoy Video.series FK.
+    assert video.series_id is None
+    assert series.videos.filter(id=video.id).exists()
+
+
+def test_create_video_published_is_publicly_visible():
+    video = services.create_video(
+        url="https://www.youtube.com/watch?v=PUB1",
+        name="Published one",
+        status=PUBLISHED,
+    )
+    assert Video.objects.published().filter(id=video.id).exists()
+
+
+def test_create_video_duplicate_url_raises():
+    VideoFactory(url="https://www.youtube.com/watch?v=DUPE")
+    with pytest.raises(services.DuplicateVideoError) as exc:
+        services.create_video(url="https://www.youtube.com/watch?v=DUPE", name="Again")
+    assert exc.value.video is not None
+
+
+def test_minted_ids_are_unique():
+    a = services.create_video(url="https://vimeo.com/1", name="A")
+    b = services.create_video(url="https://vimeo.com/2", name="B")
+    assert a.id != b.id
+    assert a.id.startswith("S") and b.id.startswith("S")
+
+
+def test_unknown_status_falls_back_to_draft():
+    video = services.create_video(url="https://vimeo.com/9", name="X", status="nonsense")
+    assert video.status == DRAFT
+
+
+# --- service: find_duplicate + taxonomy_options ---------------------------
+
+
+def test_find_duplicate_returns_existing_or_none():
+    VideoFactory(id="42", name="Already here", url="https://vimeo.com/777")
+    assert services.find_duplicate("https://vimeo.com/777") == {"id": "42", "name": "Already here"}
+    assert services.find_duplicate("https://vimeo.com/absent") is None
+
+
+def test_taxonomy_options_shape():
+    SpeakerFactory(name="Zed Speaker")
+    TopicFactory(name="Grace")
+    options = services.taxonomy_options()
+    assert set(options) == {"speakers", "series", "topics", "bible_books", "demographics", "ministries"}
+    assert {"id", "name"} <= set(options["speakers"][0])
+
+
+# --- views: the Add page --------------------------------------------------
+
+
+def test_add_page_anonymous_redirected(client):
+    resp = client.get("/studio/add")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].startswith("/studio/login")
+
+
+def test_add_page_non_editor_forbidden(client):
+    User.objects.create_user(username="viewer", password=PASSWORD)
+    client.login(username="viewer", password=PASSWORD)
+    assert client.get("/studio/add").status_code == 403
+
+
+def test_add_page_renders_for_editor(client):
+    login_editor(client)
+    page = inertia_page(client.get("/studio/add"))
+    assert page["component"] == "Studio/AddVideo"
+    assert "taxonomy" in page["props"]
+
+
+# --- views: the metadata endpoint -----------------------------------------
+
+
+def test_fetch_metadata_requires_editor(client):
+    assert client.post("/studio/api/fetch-metadata").status_code == 302  # anon → login
+
+
+def test_fetch_metadata_returns_preview(client, monkeypatch):
+    login_editor(client)
+    fake = {
+        "platform": "youtube",
+        "platform_id": "abc",
+        "url": "https://www.youtube.com/watch?v=abc",
+        "name": "Preview me",
+        "description": "",
+        "thumbnail": "https://img/x.jpg",
+        "duration_seconds": 600,
+        "date_recorded": "2024-01-01",
+    }
+    monkeypatch.setattr(studio_views, "fetch_metadata", lambda url: fake)
+
+    resp = client.post(
+        "/studio/api/fetch-metadata",
+        data='{"url": "https://www.youtube.com/watch?v=abc"}',
+        content_type="application/json",
+    )
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["metadata"]["name"] == "Preview me"
+    assert body["duplicate"] is None
+
+
+def test_fetch_metadata_flags_duplicate(client, monkeypatch):
+    login_editor(client)
+    VideoFactory(id="99", name="Existing", url="https://www.youtube.com/watch?v=dup")
+    fake = {"platform": "youtube", "url": "https://www.youtube.com/watch?v=dup", "name": "x"}
+    monkeypatch.setattr(studio_views, "fetch_metadata", lambda url: fake)
+
+    body = client.post(
+        "/studio/api/fetch-metadata",
+        data='{"url": "https://www.youtube.com/watch?v=dup"}',
+        content_type="application/json",
+    ).json()
+    assert body["ok"] is True
+    assert body["duplicate"] == {"id": "99", "name": "Existing"}
+
+
+def test_fetch_metadata_reports_error(client, monkeypatch):
+    login_editor(client)
+
+    def boom(url):
+        raise MetadataError("That doesn't look like a YouTube or Vimeo link.")
+
+    monkeypatch.setattr(studio_views, "fetch_metadata", boom)
+    body = client.post(
+        "/studio/api/fetch-metadata",
+        data='{"url": "https://example.com"}',
+        content_type="application/json",
+    ).json()
+    assert body["ok"] is False
+    assert "YouTube or Vimeo" in body["error"]
+
+
+# --- views: the create handler --------------------------------------------
+
+
+def test_create_endpoint_requires_editor(client):
+    assert client.post("/studio/videos/create").status_code == 302  # anon → login
+
+
+def test_create_endpoint_creates_draft_and_redirects(client):
+    login_editor(client)
+    speaker = SpeakerFactory()
+    series = SeriesFactory()
+
+    resp = client.post(
+        "/studio/videos/create",
+        {
+            "url": "https://www.youtube.com/watch?v=CREATED",
+            "name": "Created via form",
+            "description": "Body.",
+            "status": DRAFT,
+            "speaker_ids": [speaker.id],
+            "series_id": series.pk,
+        },
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/studio"
+
+    video = Video.objects.get(url="https://www.youtube.com/watch?v=CREATED")
+    assert video.status == DRAFT
+    assert list(video.speaker.all()) == [speaker]
+    assert series.videos.filter(id=video.id).exists()
+
+
+def test_create_endpoint_accepts_json_body(client):
+    """Inertia posts a JSON body (not form-encoded), so the view must read it.
+    Regression guard for the request.POST-is-empty trap."""
+    login_editor(client)
+    speaker = SpeakerFactory()
+    resp = client.post(
+        "/studio/videos/create",
+        data=json.dumps(
+            {
+                "url": "https://www.youtube.com/watch?v=JSONBODY",
+                "name": "Posted as JSON",
+                "status": DRAFT,
+                "speaker_ids": [speaker.id],
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 302
+    video = Video.objects.get(url="https://www.youtube.com/watch?v=JSONBODY")
+    assert list(video.speaker.all()) == [speaker]
+
+
+def test_create_endpoint_rejects_duplicate(client):
+    login_editor(client)
+    VideoFactory(name="The original", url="https://vimeo.com/dupe-create")
+
+    resp = client.post(
+        "/studio/videos/create",
+        {"url": "https://vimeo.com/dupe-create", "name": "Trying again", "status": DRAFT},
+    )
+    # Re-renders the Add page with an inline error; no second row created.
+    page = inertia_page(resp)
+    assert page["component"] == "Studio/AddVideo"
+    assert "url" in page["props"]["errors"]
+    assert Video.objects.filter(url="https://vimeo.com/dupe-create").count() == 1

--- a/tests/test_studio_auth.py
+++ b/tests/test_studio_auth.py
@@ -68,8 +68,9 @@ def test_can_edit_content_admits_staff_and_editors_only():
 def test_login_get_renders_page_and_sets_csrf_cookie(client):
     response = client.get("/studio/login")
     assert response.status_code == 200
-    # ensure_csrf_cookie must set the cookie so Inertia's axios can echo it.
-    assert "csrftoken" in response.cookies
+    # ensure_csrf_cookie must set the (Inertia-aligned) XSRF cookie so the client
+    # can echo it as X-XSRF-TOKEN on the POST.
+    assert "XSRF-TOKEN" in response.cookies
 
 
 def test_login_bad_credentials_rerenders_with_error_and_no_session(client):
@@ -90,6 +91,22 @@ def test_login_good_credentials_authenticates_and_redirects_to_studio(client):
     response = client.post(
         "/studio/login",
         {"username": "ed4", "password": "pw-correct-horse-1"},
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/studio"
+    assert "_auth_user_id" in client.session
+
+
+def test_login_accepts_json_body(client):
+    """Inertia's useForm posts a JSON body; the login view must read it
+    (request.POST is empty for real browser submissions)."""
+    import json
+
+    make_editor(username="edjson")
+    response = client.post(
+        "/studio/login",
+        data=json.dumps({"username": "edjson", "password": "pw-correct-horse-1"}),
+        content_type="application/json",
     )
     assert response.status_code == 302
     assert response.headers["Location"] == "/studio"
@@ -122,6 +139,25 @@ def test_login_when_already_authenticated_redirects(client):
     response = client.get("/studio/login")
     assert response.status_code == 302
     assert response.headers["Location"] == "/studio"
+
+
+# --- logout ---------------------------------------------------------------
+
+
+def test_logout_ends_session_and_returns_to_login(client):
+    make_editor(username="ed8")
+    client.login(username="ed8", password="pw-correct-horse-1")
+    assert "_auth_user_id" in client.session
+
+    response = client.post("/studio/logout")
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/studio/login"
+    assert "_auth_user_id" not in client.session
+
+
+def test_logout_is_post_only(client):
+    # A GET must not log anyone out (CSRF-safe; a stray link can't sign you out).
+    assert client.get("/studio/logout").status_code == 405
 
 
 # --- create_editor command ------------------------------------------------

--- a/tests/test_studio_library.py
+++ b/tests/test_studio_library.py
@@ -96,6 +96,33 @@ def test_mutations_are_csrf_protected(db):
     assert video.status == DRAFT
 
 
+def test_mutation_accepts_inertia_xsrf_header(db):
+    """The real browser path: Inertia reads the XSRF-TOKEN cookie and sends it
+    as the X-XSRF-TOKEN header on a JSON body. Django's CSRF names are aligned to
+    those, so a CSRF-enforcing client succeeds with that header. Regression guard
+    for the 403-on-every-Inertia-POST trap (cookie/header name mismatch)."""
+    import json
+
+    from django.test import Client
+
+    csrf_client = Client(enforce_csrf_checks=True)
+    make_editor("ed_xsrf")
+    csrf_client.login(username="ed_xsrf", password=PASSWORD)
+    video = VideoFactory(status=DRAFT)
+    # ensure_csrf_cookie on the Library view primes the XSRF cookie.
+    csrf_client.get("/studio/")
+    token = csrf_client.cookies["XSRF-TOKEN"].value
+    response = csrf_client.post(
+        f"/studio/videos/{video.id}/status",
+        data=json.dumps({"status": PUBLISHED}),
+        content_type="application/json",
+        HTTP_X_XSRF_TOKEN=token,
+    )
+    assert response.status_code == 302
+    video.refresh_from_db()
+    assert video.status == PUBLISHED
+
+
 # --- the list shows all statuses -----------------------------------------
 
 
@@ -190,6 +217,24 @@ def test_bulk_status_changes_many(client):
     assert Video.objects.filter(status=PUBLISHED).count() == 2
     c.refresh_from_db()
     assert c.status == DRAFT
+
+
+def test_bulk_status_accepts_json_body(client):
+    """Inertia sends a JSON body, not form fields — the view must parse it.
+    Regression guard: request.POST is empty for real browser posts."""
+    import json
+
+    login_editor(client)
+    a = VideoFactory(status=DRAFT)
+    b = VideoFactory(status=DRAFT)
+
+    response = client.post(
+        "/studio/videos/bulk-status",
+        data=json.dumps({"status": PUBLISHED, "ids": [a.id, b.id]}),
+        content_type="application/json",
+    )
+    assert response.status_code == 302
+    assert Video.objects.filter(status=PUBLISHED, id__in=[a.id, b.id]).count() == 2
 
 
 def test_delete_removes_videos(client):

--- a/tests/test_studio_metadata.py
+++ b/tests/test_studio_metadata.py
@@ -1,0 +1,114 @@
+"""catalogue/metadata.py — the paste-a-URL metadata fetch behind the Studio's
+Add-a-video form (Epic 3, Slice 3).
+
+Network is faked: a YouTube videos.list payload and a Vimeo oEmbed payload are
+fed through a stub session so we test our normalisation, not the platforms.
+"""
+
+import pytest
+
+from catalogue.metadata import MetadataError, fetch_metadata
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+class FakeSession:
+    """Returns one canned response for every .get (enough for these single-call
+    fetches), recording the calls for assertion."""
+
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self._status = status_code
+        self.calls = []
+
+    def get(self, url, params=None, timeout=None):
+        self.calls.append((url, params))
+        return FakeResponse(self._payload, self._status)
+
+
+YT_PAYLOAD = {
+    "items": [
+        {
+            "snippet": {
+                "title": "Sermon on the Mount",
+                "description": "A talk about the Beatitudes.",
+                "publishedAt": "2024-03-02T10:00:00Z",
+                "thumbnails": {
+                    "high": {"url": "https://img/high.jpg"},
+                    "maxres": {"url": "https://img/maxres.jpg"},
+                },
+            },
+            "contentDetails": {"duration": "PT28M50S"},
+        }
+    ]
+}
+
+VIMEO_PAYLOAD = {
+    "video_id": 97249023,
+    "title": "Cloning Humans",
+    "description": "A documentary.",
+    "thumbnail_url": "https://i.vimeocdn.com/x.jpg",
+    "duration": 3600,
+    "upload_date": "2014-05-30 12:00:00",
+}
+
+
+def test_fetch_youtube_metadata(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")  # gitleaks:allow
+    session = FakeSession(YT_PAYLOAD)
+
+    meta = fetch_metadata("https://www.youtube.com/watch?v=abc123XYZ_-", session=session)
+
+    assert meta["platform"] == "youtube"
+    assert meta["platform_id"] == "abc123XYZ_-"
+    assert meta["url"] == "https://www.youtube.com/watch?v=abc123XYZ_-"
+    assert meta["name"] == "Sermon on the Mount"
+    assert meta["description"] == "A talk about the Beatitudes."
+    assert meta["duration_seconds"] == 28 * 60 + 50
+    assert meta["thumbnail"] == "https://img/maxres.jpg"  # highest resolution wins
+    assert meta["date_recorded"] == "2024-03-02"
+
+
+def test_fetch_youtube_not_found(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "test-key")  # gitleaks:allow
+    with pytest.raises(MetadataError):
+        fetch_metadata("https://youtu.be/missing12345", session=FakeSession({"items": []}))
+
+
+def test_fetch_vimeo_metadata():
+    session = FakeSession(VIMEO_PAYLOAD)
+
+    meta = fetch_metadata("https://vimeo.com/97249023", session=session)
+
+    assert meta["platform"] == "vimeo"
+    assert meta["platform_id"] == "97249023"
+    assert meta["url"] == "https://vimeo.com/97249023"
+    assert meta["name"] == "Cloning Humans"
+    assert meta["duration_seconds"] == 3600
+    assert meta["thumbnail"] == "https://i.vimeocdn.com/x.jpg"
+    assert meta["date_recorded"] == "2014-05-30"
+    # The oEmbed endpoint was called with the pasted URL.
+    assert session.calls and session.calls[0][1] == {"url": "https://vimeo.com/97249023"}
+
+
+def test_fetch_vimeo_not_found():
+    with pytest.raises(MetadataError):
+        fetch_metadata("https://vimeo.com/000", session=FakeSession({}, status_code=404))
+
+
+def test_unsupported_url_raises():
+    with pytest.raises(MetadataError):
+        fetch_metadata("https://example.com/not-a-video")
+
+
+def test_empty_url_raises():
+    with pytest.raises(MetadataError):
+        fetch_metadata("")


### PR DESCRIPTION
## What

Slice 3 of the Studio epic — the **headline**: a paste-a-URL intake so editors can add content directly once the legacy `sync_live_admin` feed retires and the catalogue freezes.

Paste a YouTube/Vimeo link → metadata is fetched (title, thumbnail, runtime, recorded date) → editor reviews/edits → classifies via searchable pickers → **Save as draft** or **Publish**.

## Highlights
- **`catalogue/metadata.py`** — normalised YouTube (`videos.list`) + Vimeo (oEmbed) fetch, reusing the existing `youtube_live.api_get` client + `parse_iso8601_duration`. Friendly errors for unsupported/private links.
- **`app/studio/services.create_video`** — mints a non-colliding `S`-prefixed id, links relations the importer's way (**`Series.videos` M2M, not the decoy FK**), dedups on the unique `Video.url`. Plus `taxonomy_options` + `find_duplicate`.
- **Views/URLs** — `/studio/add`, JSON `/studio/api/fetch-metadata`, `/studio/videos/create`.
- **`TaxonomySelect.vue`** — self-contained searchable single/multi picker (caps rendered results so the ~2,600 series list stays snappy; keyboard + a11y).
- **Studio logout** — `POST /studio/logout` + a **Sign out** button (there wasn't one), and the Library's "Add a video" button now links here.

## Cross-Studio bug fixed (caught in local browser testing)
Inertia posts a **JSON body** and uses the **`XSRF-TOKEN` cookie / `X-XSRF-TOKEN` header**, but Django was on `csrftoken`/`X-CSRFToken` and read `request.POST`. So **every** Studio Inertia POST (Slice 1 password login, Slice 2 Library mutations, this slice's create) was silently **403'd / empty in the browser** — only passing because the test client form-encodes. Aligned Django's CSRF names to Inertia's, added a JSON-body payload reader, and `@ensure_csrf_cookie` on the Library so a magic-linked session has a token. New regression tests cover both the JSON-body and the XSRF-header paths.

## Testing
- `uv run poe test` — 284 passed (new: `test_studio_metadata.py`, `test_studio_add_video.py`, + JSON/CSRF guards in auth/library).
- type-check, eslint, prettier, ruff, `build-only` all green.
- **Local Claude-in-browser integration test** (per cadence): paste a YouTube URL → preview populates → pick a speaker → Save as draft → lands in Library as Draft; duplicate detection, Sign out, and the CSRF fix all verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)