### PR TITLE
feat(studio): account menu in header (replace ad-hoc sign-out)

### DIFF
--- a/app/http/middleware/handle_inertia_requests.py
+++ b/app/http/middleware/handle_inertia_requests.py
@@ -3,18 +3,22 @@ import os
 from django.contrib.messages import get_messages
 from inertia import share
 
+from app.auth import can_edit_content
 from catalogue.youtube_live import is_live_now
 
 
 def _auth_user(user):
     """Real signed-in user for Inertia, or None when anonymous. No placeholder —
-    the frontend treats a null user as logged-out (real auth lands in Epic 3)."""
+    the frontend treats a null user as logged-out."""
     if not user.is_authenticated:
         return None
     return {
         "id": user.id,
         "name": user.get_full_name() or user.get_username(),
         "email": user.email,
+        # Gates the account menu's "Studio" link to editors/staff (mirrors the
+        # studio_required server gate, so the link only shows when it'd work).
+        "can_edit": can_edit_content(user),
     }
 
 

--- a/resources/js/components/layouts/AppHeader.vue
+++ b/resources/js/components/layouts/AppHeader.vue
@@ -1,13 +1,14 @@
 <script setup lang="ts">
 import LogoMark from '@/atoms/LogoMark.vue';
+import AccountMenu from '@/molecules/AccountMenu.vue';
 import ShortcutsHelp from '@/molecules/ShortcutsHelp.vue';
 import TextSizeControl from '@/molecules/TextSizeControl.vue';
 import ThemeToggle from '@/molecules/ThemeToggle.vue';
 import CommandPalette from '@/organisms/CommandPalette.vue';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/ui/dropdown-menu';
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/ui/sheet';
-import { Link, usePage } from '@inertiajs/vue3';
-import { ChevronDown, Menu, Search } from 'lucide-vue-next';
+import { Link, router, usePage } from '@inertiajs/vue3';
+import { ChevronDown, LayoutGrid, LogOut, Menu, Search } from 'lucide-vue-next';
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { usePalette } from '~/composables/usePalette';
 import { EVENTS, track } from '~/lib/analytics';
@@ -32,6 +33,15 @@ const isCurrent = (href: string) => (href === '/' ? page.url === '/' : page.url.
 const isBrowseSection = () => BROWSE_PREFIXES.some((p) => page.url.startsWith(p));
 // Global "a service is on air" flag (shared from the Inertia middleware)
 const liveNow = computed(() => page.props.live_now === true);
+
+// The signed-in user (real-or-null), shared by the Inertia middleware. Drives
+// the account menu; null for anonymous visitors.
+const user = computed(() => (page.props.auth as { user: { name: string; email: string; can_edit?: boolean } | null } | undefined)?.user ?? null);
+
+const signOut = () => {
+    mobileNavOpen.value = false;
+    router.post('/studio/logout');
+};
 
 const { paletteOpen, helpOpen } = usePalette();
 
@@ -148,6 +158,11 @@ const navLink = (active: boolean) =>
                 <kbd class="border-border bg-muted ml-auto rounded border px-1.5 py-0.5 font-sans text-xs">{{ isMac ? '⌘K' : 'Ctrl K' }}</kbd>
             </button>
 
+            <!-- Signed-in account menu (Studio + Sign out) — desktop; mobile uses
+                 the slide-over below. ml-auto only kicks in on small screens,
+                 where the search bar is hidden, so the avatar still sits right. -->
+            <AccountMenu v-if="user" :user="user" class="ml-auto hidden lg:inline-flex" />
+
             <Sheet v-model:open="mobileNavOpen">
                 <SheetTrigger
                     class="focus-visible:ring-ring text-muted-foreground hover:text-foreground ml-auto inline-flex min-h-11 min-w-11 items-center justify-center rounded-md outline-none focus-visible:ring-2 sm:ml-0 lg:hidden"
@@ -231,6 +246,29 @@ const navLink = (active: boolean) =>
                     <div class="flex items-center justify-between px-4 pt-3">
                         <span class="text-muted-foreground text-sm">Text size</span>
                         <TextSizeControl />
+                    </div>
+
+                    <!-- Account (signed-in only) — the mobile counterpart of the
+                         desktop avatar menu -->
+                    <div v-if="user" class="border-border mt-4 border-t px-2 pt-4">
+                        <p class="text-foreground truncate px-2 text-sm font-medium">{{ user.name }}</p>
+                        <p v-if="user.email" class="text-muted-foreground truncate px-2 text-xs">{{ user.email }}</p>
+                        <Link
+                            v-if="user.can_edit"
+                            href="/studio"
+                            @click="mobileNavOpen = false"
+                            class="focus-visible:ring-ring text-muted-foreground hover:bg-accent hover:text-foreground mt-2 flex items-center gap-2 rounded-md px-2 py-3 text-base font-medium outline-none focus-visible:ring-2"
+                        >
+                            <LayoutGrid class="size-4" aria-hidden="true" />
+                            Studio
+                        </Link>
+                        <button
+                            @click="signOut"
+                            class="focus-visible:ring-ring text-muted-foreground hover:bg-accent hover:text-foreground flex w-full items-center gap-2 rounded-md px-2 py-3 text-base font-medium outline-none focus-visible:ring-2"
+                        >
+                            <LogOut class="size-4" aria-hidden="true" />
+                            Sign out
+                        </button>
                     </div>
                 </SheetContent>
             </Sheet>

--- a/resources/js/components/molecules/AccountMenu.vue
+++ b/resources/js/components/molecules/AccountMenu.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/ui/dropdown-menu';
+import { Link, router } from '@inertiajs/vue3';
+import { LayoutGrid, LogOut } from 'lucide-vue-next';
+import { computed } from 'vue';
+
+/**
+ * The signed-in user's account menu — an avatar (initials) at the far right of
+ * the header that opens a dropdown with their identity, a link into the Studio
+ * (editors only), and Sign out. The standard app-shell place for these, so
+ * "Sign out" lives here rather than bolted onto a page header. Only rendered
+ * when there's a user (see AppHeader); the slot is where a future public "Sign
+ * in" entry point would go.
+ */
+
+const props = defineProps<{
+    user: { name: string; email: string; can_edit?: boolean };
+}>();
+
+// Up to two initials from the display name, for the avatar.
+const initials = computed(() => {
+    const parts = props.user.name.trim().split(/\s+/).filter(Boolean);
+    if (!parts.length) return '?';
+    const first = parts[0][0];
+    const last = parts.length > 1 ? parts[parts.length - 1][0] : '';
+    return (first + last).toUpperCase();
+});
+
+function signOut() {
+    router.post('/studio/logout');
+}
+</script>
+
+<template>
+    <DropdownMenu>
+        <DropdownMenuTrigger
+            class="focus-visible:ring-ring bg-secondary text-secondary-foreground hover:bg-accent hover:text-accent-foreground inline-flex size-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold transition-colors outline-none focus-visible:ring-2"
+            aria-label="Account menu"
+        >
+            {{ initials }}
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" class="w-56">
+            <DropdownMenuLabel class="flex flex-col gap-0.5">
+                <span class="text-foreground truncate text-sm font-medium">{{ user.name }}</span>
+                <span v-if="user.email" class="text-muted-foreground truncate text-xs font-normal">{{ user.email }}</span>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem v-if="user.can_edit" as-child>
+                <Link href="/studio" class="flex cursor-pointer items-center gap-2">
+                    <LayoutGrid class="size-4" aria-hidden="true" />
+                    Studio
+                </Link>
+            </DropdownMenuItem>
+            <DropdownMenuItem class="cursor-pointer" @select="signOut">
+                <LogOut class="size-4" aria-hidden="true" />
+                Sign out
+            </DropdownMenuItem>
+        </DropdownMenuContent>
+    </DropdownMenu>
+</template>

--- a/resources/js/pages/Studio/Library.vue
+++ b/resources/js/pages/Studio/Library.vue
@@ -11,7 +11,7 @@ import { Skeleton } from '@/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table';
 import { Head, Link, router } from '@inertiajs/vue3';
 import { useDebounceFn } from '@vueuse/core';
-import { ExternalLink, Film, LogOut, MoreHorizontal, Pencil, Plus, Search } from 'lucide-vue-next';
+import { ExternalLink, Film, MoreHorizontal, Pencil, Plus, Search } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
 import { formatDuration } from '~/lib/duration';
 
@@ -146,10 +146,6 @@ function confirmDelete() {
     confirmingDelete.value = false;
 }
 
-function signOut() {
-    router.post('/studio/logout');
-}
-
 const resultLabel = computed(() => {
     const n = props.total;
     const noun = n === 1 ? 'video' : 'videos';
@@ -170,18 +166,12 @@ const resultLabel = computed(() => {
                 <h1 class="font-display text-foreground text-2xl font-bold sm:text-3xl">Studio — Library</h1>
                 <p class="text-muted-foreground mt-1 text-sm tabular-nums">{{ resultLabel }}</p>
             </div>
-            <div class="flex items-center gap-2">
-                <Button variant="ghost" size="sm" @click="signOut">
-                    <LogOut class="size-4" aria-hidden="true" />
-                    Sign out
-                </Button>
-                <Button as-child>
-                    <Link href="/studio/add">
-                        <Plus class="size-4" aria-hidden="true" />
-                        Add a video
-                    </Link>
-                </Button>
-            </div>
+            <Button as-child>
+                <Link href="/studio/add">
+                    <Plus class="size-4" aria-hidden="true" />
+                    Add a video
+                </Link>
+            </Button>
         </div>
 
         <!-- Filter bar -->


### PR DESCRIPTION
## What
Replaces the mismatched **Sign out** button bolted onto the Library header with the standard app-shell pattern: an **avatar → account dropdown** at the far right of the global header.

Follows the shadcn/dashboard convention (reuses our `DropdownMenu`, so it inherits the design tokens and feels cohesive). The avatar bumps the search bar slightly left, exactly as discussed. Sign out is now reachable from **anywhere** in the app, not just the Library — and the slot is the natural home for a future public "Sign in".

## Changes
- **`handle_inertia_requests`** — share `auth.user.can_edit` so the menu's **Studio** link only shows for editors/staff (mirrors `studio_required`).
- **`AccountMenu.vue`** — avatar (initials) → dropdown: name + email, Studio (editors only), Sign out. Only rendered when signed in.
- **`AppHeader`** — avatar top-right on desktop; an account section in the mobile slide-over.
- **`Library.vue`** — removed the ad-hoc Sign out button (now just the "Add a video" CTA).

## Testing
- 284 tests pass; type-check, eslint, prettier, ruff, build all green.
- **Local browser** (Claude): avatar shows for a signed-in editor on the public header; dropdown shows name/email + Studio + Sign out; search bar shifts left; anonymous visitors see no avatar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)