### PR TITLE
feat(studio): full tabbed video editor (Epic 3 Slice 4a)

### DIFF
--- a/app/cards.py
+++ b/app/cards.py
@@ -21,3 +21,43 @@ def video_card_props(videos):
     if hasattr(videos, "values"):
         return list(videos.values(*VIDEO_CARD_FIELDS))
     return [{field: getattr(video, field) for field in VIDEO_CARD_FIELDS} for video in videos]
+
+
+# Scalar fields the Studio editor edits directly on the Video row.
+VIDEO_EDIT_FIELDS = (
+    "id",
+    "name",
+    "description",
+    "url",
+    "thumbnail",
+    "duration_seconds",
+    "is_livestream",
+    "number_in_series",
+    "status",
+)
+
+
+def video_edit_props(video):
+    """Full editable view of one Video, as a plain dict for the Studio editor.
+
+    Includes the scalar fields plus every relation the editor manages: the five
+    M2M id-lists, the current series (via the ``Series.videos`` M2M — NOT the
+    decoy ``Video.series`` FK), the ``alternate_urls`` JSON, and the
+    ``related_resources`` rows. The caller should ``prefetch_related`` the M2Ms
+    and ``related_resources`` to keep this off the N+1 path.
+    """
+    from catalogue.models.series import Series
+
+    series_id = Series.objects.filter(videos=video).values_list("pk", flat=True).first()
+    return {
+        **{field: getattr(video, field) for field in VIDEO_EDIT_FIELDS},
+        "date_recorded": video.date_recorded.isoformat() if video.date_recorded else None,
+        "alternate_urls": video.alternate_urls or [],
+        "speaker_ids": [str(s.pk) for s in video.speaker.all()],
+        "topic_ids": [str(t.pk) for t in video.topic.all()],
+        "bible_book_ids": [str(b.pk) for b in video.bible_book.all()],
+        "demographic_ids": [str(d.pk) for d in video.demographic.all()],
+        "ministry_ids": [str(m.pk) for m in video.ministry.all()],
+        "series_id": str(series_id) if series_id is not None else None,
+        "related_resources": [{"kind": r.kind, "url": r.url} for r in video.related_resources.order_by("kind")],
+    }

--- a/app/studio/services.py
+++ b/app/studio/services.py
@@ -11,15 +11,18 @@ published alike — so these queries use ``Video.objects`` unfiltered, NOT
 """
 
 import logging
+from datetime import date
 
 from django.core.paginator import Paginator
 from django.db.models import Q
 from django.utils import timezone
 
+from app.cards import video_edit_props
 from catalogue import search as search_index
 from catalogue.models.bible_book import Bible_Book
 from catalogue.models.demograpic import Demographic
 from catalogue.models.ministry import Ministry
+from catalogue.models.related_resource import RelatedResource
 from catalogue.models.series import Series
 from catalogue.models.speaker import Speaker
 from catalogue.models.topic import Topic
@@ -274,7 +277,7 @@ def create_video(
         status=status,
     )
 
-    _link_relations(
+    _apply_relations(
         video,
         speaker_ids=speaker_ids,
         topic_ids=topic_ids,
@@ -304,20 +307,131 @@ def _mint_video_id():
         n += 1
 
 
-def _link_relations(video, *, speaker_ids, topic_ids, bible_book_ids, demographic_ids, ministry_ids, series_id):
-    """Wire the M2M classifications. Unknown ids are silently dropped (the form
-    only ever submits ids it was given). Series goes through ``Series.videos``."""
-    if speaker_ids:
-        video.speaker.set(Speaker.objects.filter(pk__in=list(speaker_ids)))
-    if topic_ids:
-        video.topic.set(Topic.objects.filter(pk__in=list(topic_ids)))
-    if bible_book_ids:
-        video.bible_book.set(Bible_Book.objects.filter(pk__in=list(bible_book_ids)))
-    if demographic_ids:
-        video.demographic.set(Demographic.objects.filter(pk__in=list(demographic_ids)))
-    if ministry_ids:
-        video.ministry.set(Ministry.objects.filter(pk__in=list(ministry_ids)))
+def _apply_relations(video, *, speaker_ids, topic_ids, bible_book_ids, demographic_ids, ministry_ids, series_id):
+    """Set the M2M classifications to exactly the given ids — ``.set()`` so the
+    editor can *remove* relations, not only add (create passes the same shape, so
+    empty lists clear correctly). Unknown ids are silently dropped. Series goes
+    through the ``Series.videos`` M2M (re-pointed: dropped from any other series,
+    added to the chosen one), never the decoy ``Video.series`` FK."""
+    video.speaker.set(Speaker.objects.filter(pk__in=list(speaker_ids or [])))
+    video.topic.set(Topic.objects.filter(pk__in=list(topic_ids or [])))
+    video.bible_book.set(Bible_Book.objects.filter(pk__in=list(bible_book_ids or [])))
+    video.demographic.set(Demographic.objects.filter(pk__in=list(demographic_ids or [])))
+    video.ministry.set(Ministry.objects.filter(pk__in=list(ministry_ids or [])))
+
+    for series in Series.objects.filter(videos=video):
+        if str(series.pk) != str(series_id):
+            series.videos.remove(video)
     if series_id:
-        series = Series.objects.filter(pk=series_id).first()
-        if series is not None:
-            series.videos.add(video)
+        target = Series.objects.filter(pk=series_id).first()
+        if target is not None:
+            target.videos.add(video)
+
+
+# --------------------------------------------------------------------------- #
+# Edit a video (Slice 4a)
+# --------------------------------------------------------------------------- #
+
+
+def get_video_for_edit(video_id):
+    """The full editable view of one video (plain dict), or None if missing."""
+    video = (
+        Video.objects.filter(id=video_id)
+        .prefetch_related("speaker", "topic", "bible_book", "demographic", "ministry", "related_resources")
+        .first()
+    )
+    return video_edit_props(video) if video is not None else None
+
+
+def update_video(
+    video_id,
+    *,
+    name,
+    description="",
+    url,
+    thumbnail=None,
+    duration_seconds=None,
+    date_recorded=None,
+    is_livestream=False,
+    number_in_series=None,
+    speaker_ids=(),
+    topic_ids=(),
+    bible_book_ids=(),
+    demographic_ids=(),
+    ministry_ids=(),
+    series_id=None,
+    alternate_urls=None,
+    related_resources=None,
+):
+    """Update an existing video's scalar fields, classification, alternate URLs
+    and related resources. Returns True, or False if the id doesn't exist.
+
+    Publication status is NOT touched here — that goes through ``set_video_status``
+    (the editor's Publish/Unpublish buttons), keeping Save status-neutral. Raises
+    ``DuplicateVideoError`` if ``url`` is changed to one another video already uses
+    (``Video.url`` is unique)."""
+    video = Video.objects.filter(id=video_id).first()
+    if video is None:
+        return False
+
+    url = (url or "").strip()
+    clash = Video.objects.filter(url=url).exclude(id=video_id).first()
+    if clash is not None:
+        raise DuplicateVideoError(clash)
+
+    video.name = (name or "").strip()[:200] or video.name
+    video.description = description or ""
+    video.url = url
+    video.thumbnail = thumbnail
+    video.duration_seconds = duration_seconds
+    video.date_recorded = _parse_date(date_recorded)
+    video.is_livestream = bool(is_livestream)
+    video.number_in_series = number_in_series
+    video.alternate_urls = alternate_urls or []
+
+    _apply_relations(
+        video,
+        speaker_ids=speaker_ids,
+        topic_ids=topic_ids,
+        bible_book_ids=bible_book_ids,
+        demographic_ids=demographic_ids,
+        ministry_ids=ministry_ids,
+        series_id=series_id,
+    )
+    _sync_resources(video, related_resources or [])
+    # Single save after relations are set so the search signal re-indexes a doc
+    # that reflects the new scalars + facets.
+    video.save()
+    return True
+
+
+def _parse_date(value):
+    """An ISO ``YYYY-MM-DD`` string (or date) → a date, else None."""
+    if not value:
+        return None
+    if hasattr(value, "isoformat") and not isinstance(value, str):
+        return value
+    try:
+        return date.fromisoformat(str(value)[:10])
+    except ValueError:
+        return None
+
+
+_RESOURCE_KINDS = {kind for kind, _ in RelatedResource.KINDS}
+
+
+def _sync_resources(video, resources):
+    """Make ``video.related_resources`` match the given ``[{kind, url}]`` list:
+    drop rows no longer present, create the new ones. Skips invalid/blank rows."""
+    wanted = {
+        (r.get("kind"), (r.get("url") or "").strip())
+        for r in resources
+        if r.get("kind") in _RESOURCE_KINDS and (r.get("url") or "").strip()
+    }
+    existing = {(r.kind, r.url): r for r in video.related_resources.all()}
+    for key, row in existing.items():
+        if key not in wanted:
+            row.delete()
+    for kind, url in wanted:
+        if (kind, url) not in existing:
+            RelatedResource.objects.create(video=video, kind=kind, url=url)

--- a/app/studio/urls.py
+++ b/app/studio/urls.py
@@ -14,6 +14,9 @@ urlpatterns = [
     path("dev-login", views.dev_login, name="studio_dev_login"),
     # JSON metadata preview for the Add form (not Inertia).
     path("api/fetch-metadata", views.fetch_metadata_api, name="studio_fetch_metadata"),
+    # Editor (Slice 4a).
+    path("videos/<str:id>/edit", views.edit_video, name="studio_edit_video"),
+    path("videos/<str:id>/update", views.update_video, name="studio_update_video"),
     # Library mutations (all @studio_required + POST + CSRF).
     path("videos/create", views.create_video, name="studio_create_video"),
     path("videos/bulk-status", views.bulk_status, name="studio_bulk_status"),

--- a/app/studio/views.py
+++ b/app/studio/views.py
@@ -324,3 +324,55 @@ def create_video(request):
     verb = "Published" if video.status == PUBLISHED else "Saved as draft"
     messages.success(request, f"{verb}: “{video.name}”.")
     return redirect("/studio")
+
+
+# --------------------------------------------------------------------------- #
+# Edit a video (Slice 4a)
+# --------------------------------------------------------------------------- #
+
+
+@studio_required
+@ensure_csrf_cookie
+def edit_video(request, id):
+    """``/studio/videos/<id>/edit`` — the full tabbed editor for one video."""
+    video = services.get_video_for_edit(id)
+    if video is None:
+        raise Http404
+    return render(request, "Studio/EditVideo", {"video": video, "taxonomy": services.taxonomy_options()})
+
+
+@studio_required
+@require_POST
+def update_video(request, id):
+    """``POST /studio/videos/<id>/update`` — save edits (status-neutral; publish
+    is a separate action). On a URL clash, re-render the editor with an inline
+    error (the form's typed state survives via Inertia)."""
+    post = _Payload(request)
+    try:
+        ok = services.update_video(
+            id,
+            name=post.get("name", ""),
+            description=post.get("description", ""),
+            url=post.get("url", ""),
+            thumbnail=post.get("thumbnail") or None,
+            duration_seconds=_int_or_none(post.get("duration_seconds")),
+            date_recorded=post.get("date_recorded") or None,
+            is_livestream=bool(post.get("is_livestream")),
+            number_in_series=_int_or_none(post.get("number_in_series")),
+            speaker_ids=post.getlist("speaker_ids"),
+            topic_ids=post.getlist("topic_ids"),
+            bible_book_ids=post.getlist("bible_book_ids"),
+            demographic_ids=post.getlist("demographic_ids"),
+            ministry_ids=post.getlist("ministry_ids"),
+            series_id=post.get("series_id") or None,
+            alternate_urls=post.get("alternate_urls") or [],
+            related_resources=post.get("related_resources") or [],
+        )
+    except services.DuplicateVideoError as exc:
+        share(request, errors={"url": f"“{exc.video.name}” already uses that link."})
+        props = {"video": services.get_video_for_edit(id), "taxonomy": services.taxonomy_options()}
+        return render(request, "Studio/EditVideo", props)
+    if not ok:
+        raise Http404
+    messages.success(request, "Saved.")
+    return redirect("/studio")

--- a/resources/js/components/molecules/ClassificationFields.vue
+++ b/resources/js/components/molecules/ClassificationFields.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import TaxonomySelect from '@/molecules/TaxonomySelect.vue';
+
+/**
+ * The shared classification grid: speakers · series · topics · Bible books ·
+ * audiences · ministries, each a searchable {@link TaxonomySelect}. Used by both
+ * the Add-a-video form and the editor so the two stay in lockstep. Series is
+ * single-select (one series per video); the rest are multi.
+ */
+
+interface Option {
+    id: string;
+    name: string;
+}
+
+defineProps<{
+    taxonomy: {
+        speakers: Option[];
+        series: Option[];
+        topics: Option[];
+        bible_books: Option[];
+        demographics: Option[];
+        ministries: Option[];
+    };
+}>();
+
+const speakerIds = defineModel<string[]>('speakerIds', { default: () => [] });
+const topicIds = defineModel<string[]>('topicIds', { default: () => [] });
+const bibleBookIds = defineModel<string[]>('bibleBookIds', { default: () => [] });
+const demographicIds = defineModel<string[]>('demographicIds', { default: () => [] });
+const ministryIds = defineModel<string[]>('ministryIds', { default: () => [] });
+const seriesId = defineModel<string | null>('seriesId', { default: null });
+</script>
+
+<template>
+    <div class="grid gap-4 sm:grid-cols-2">
+        <TaxonomySelect id="tax-speakers" label="Speakers" :options="taxonomy.speakers" v-model="speakerIds" multiple placeholder="Add speakers…" />
+        <TaxonomySelect id="tax-series" label="Series" :options="taxonomy.series" v-model="seriesId" placeholder="Choose a series…" />
+        <TaxonomySelect id="tax-topics" label="Topics" :options="taxonomy.topics" v-model="topicIds" multiple placeholder="Add topics…" />
+        <TaxonomySelect
+            id="tax-books"
+            label="Bible books"
+            :options="taxonomy.bible_books"
+            v-model="bibleBookIds"
+            multiple
+            placeholder="Add Bible books…"
+        />
+        <TaxonomySelect
+            id="tax-audiences"
+            label="Audiences"
+            :options="taxonomy.demographics"
+            v-model="demographicIds"
+            multiple
+            placeholder="Add audiences…"
+        />
+        <TaxonomySelect
+            id="tax-ministries"
+            label="Ministries"
+            :options="taxonomy.ministries"
+            v-model="ministryIds"
+            multiple
+            placeholder="Add ministries…"
+        />
+    </div>
+</template>

--- a/resources/js/components/ui/tabs/Tabs.vue
+++ b/resources/js/components/ui/tabs/Tabs.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import type { TabsRootEmits, TabsRootProps } from 'reka-ui';
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+import { reactiveOmit } from '@vueuse/core';
+import { TabsRoot, useForwardPropsEmits } from 'reka-ui';
+
+const props = defineProps<TabsRootProps & { class?: HTMLAttributes['class'] }>();
+const emits = defineEmits<TabsRootEmits>();
+
+const delegatedProps = reactiveOmit(props, 'class');
+const forwarded = useForwardPropsEmits(delegatedProps, emits);
+</script>
+
+<template>
+    <TabsRoot data-slot="tabs" v-bind="forwarded" :class="cn('flex flex-col gap-4', props.class)">
+        <slot />
+    </TabsRoot>
+</template>

--- a/resources/js/components/ui/tabs/TabsContent.vue
+++ b/resources/js/components/ui/tabs/TabsContent.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { TabsContentProps } from 'reka-ui';
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+import { reactiveOmit } from '@vueuse/core';
+import { TabsContent, useForwardProps } from 'reka-ui';
+
+const props = defineProps<TabsContentProps & { class?: HTMLAttributes['class'] }>();
+
+const delegatedProps = reactiveOmit(props, 'class');
+const forwarded = useForwardProps(delegatedProps);
+</script>
+
+<template>
+    <TabsContent
+        data-slot="tabs-content"
+        v-bind="forwarded"
+        :class="cn('flex-1 outline-none', props.class)"
+    >
+        <slot />
+    </TabsContent>
+</template>

--- a/resources/js/components/ui/tabs/TabsList.vue
+++ b/resources/js/components/ui/tabs/TabsList.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { TabsListProps } from 'reka-ui';
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+import { reactiveOmit } from '@vueuse/core';
+import { TabsList, useForwardProps } from 'reka-ui';
+
+const props = defineProps<TabsListProps & { class?: HTMLAttributes['class'] }>();
+
+const delegatedProps = reactiveOmit(props, 'class');
+const forwarded = useForwardProps(delegatedProps);
+</script>
+
+<template>
+    <TabsList
+        data-slot="tabs-list"
+        v-bind="forwarded"
+        :class="
+            cn(
+                'bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-0.5',
+                props.class,
+            )
+        "
+    >
+        <slot />
+    </TabsList>
+</template>

--- a/resources/js/components/ui/tabs/TabsTrigger.vue
+++ b/resources/js/components/ui/tabs/TabsTrigger.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { TabsTriggerProps } from 'reka-ui';
+import type { HTMLAttributes } from 'vue';
+import { cn } from '@/lib/utils';
+import { reactiveOmit } from '@vueuse/core';
+import { TabsTrigger, useForwardProps } from 'reka-ui';
+
+const props = defineProps<TabsTriggerProps & { class?: HTMLAttributes['class'] }>();
+
+const delegatedProps = reactiveOmit(props, 'class');
+const forwarded = useForwardProps(delegatedProps);
+</script>
+
+<template>
+    <TabsTrigger
+        data-slot="tabs-trigger"
+        v-bind="forwarded"
+        :class="
+            cn(
+                'data-[state=active]:bg-background data-[state=active]:text-foreground focus-visible:ring-ring text-muted-foreground inline-flex h-8 flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1 text-sm font-medium whitespace-nowrap transition-colors outline-none focus-visible:ring-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:size-4 [&_svg]:shrink-0',
+                props.class,
+            )
+        "
+    >
+        <slot />
+    </TabsTrigger>
+</template>

--- a/resources/js/components/ui/tabs/index.ts
+++ b/resources/js/components/ui/tabs/index.ts
@@ -1,0 +1,4 @@
+export { default as Tabs } from './Tabs.vue'
+export { default as TabsContent } from './TabsContent.vue'
+export { default as TabsList } from './TabsList.vue'
+export { default as TabsTrigger } from './TabsTrigger.vue'

--- a/resources/js/pages/Studio/AddVideo.vue
+++ b/resources/js/pages/Studio/AddVideo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import TaxonomySelect from '@/molecules/TaxonomySelect.vue';
+import ClassificationFields from '@/molecules/ClassificationFields.vue';
 import { Button } from '@/ui/button';
 import { Input } from '@/ui/input';
 import { Head, Link, useForm } from '@inertiajs/vue3';
@@ -218,55 +218,15 @@ const recordedLabel = computed(() => (preview.value?.date_recorded ? preview.val
             <fieldset class="space-y-4">
                 <legend class="text-foreground text-base font-semibold">Classification</legend>
                 <p class="text-muted-foreground -mt-2 text-sm">All optional — you can refine these later.</p>
-                <div class="grid gap-4 sm:grid-cols-2">
-                    <TaxonomySelect
-                        id="tax-speakers"
-                        label="Speakers"
-                        :options="props.taxonomy.speakers"
-                        v-model="form.speaker_ids"
-                        multiple
-                        placeholder="Add speakers…"
-                    />
-                    <TaxonomySelect
-                        id="tax-series"
-                        label="Series"
-                        :options="props.taxonomy.series"
-                        v-model="form.series_id"
-                        placeholder="Choose a series…"
-                    />
-                    <TaxonomySelect
-                        id="tax-topics"
-                        label="Topics"
-                        :options="props.taxonomy.topics"
-                        v-model="form.topic_ids"
-                        multiple
-                        placeholder="Add topics…"
-                    />
-                    <TaxonomySelect
-                        id="tax-books"
-                        label="Bible books"
-                        :options="props.taxonomy.bible_books"
-                        v-model="form.bible_book_ids"
-                        multiple
-                        placeholder="Add Bible books…"
-                    />
-                    <TaxonomySelect
-                        id="tax-audiences"
-                        label="Audiences"
-                        :options="props.taxonomy.demographics"
-                        v-model="form.demographic_ids"
-                        multiple
-                        placeholder="Add audiences…"
-                    />
-                    <TaxonomySelect
-                        id="tax-ministries"
-                        label="Ministries"
-                        :options="props.taxonomy.ministries"
-                        v-model="form.ministry_ids"
-                        multiple
-                        placeholder="Add ministries…"
-                    />
-                </div>
+                <ClassificationFields
+                    :taxonomy="props.taxonomy"
+                    v-model:speaker-ids="form.speaker_ids"
+                    v-model:topic-ids="form.topic_ids"
+                    v-model:bible-book-ids="form.bible_book_ids"
+                    v-model:demographic-ids="form.demographic_ids"
+                    v-model:ministry-ids="form.ministry_ids"
+                    v-model:series-id="form.series_id"
+                />
             </fieldset>
 
             <!-- Actions -->

--- a/resources/js/pages/Studio/EditVideo.vue
+++ b/resources/js/pages/Studio/EditVideo.vue
@@ -1,0 +1,301 @@
+<script setup lang="ts">
+import ClassificationFields from '@/molecules/ClassificationFields.vue';
+import { Badge } from '@/ui/badge';
+import { Button } from '@/ui/button';
+import { Input } from '@/ui/input';
+import { Switch } from '@/ui/switch';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs';
+import { Head, Link, router, useForm } from '@inertiajs/vue3';
+import { ArrowLeft, ExternalLink, Plus, Trash2 } from 'lucide-vue-next';
+import { computed, onBeforeUnmount, onMounted } from 'vue';
+import { formatDuration } from '~/lib/duration';
+import { getEmbedUrl } from '~/lib/embeds';
+
+interface Option {
+    id: string;
+    name: string;
+}
+interface AlternateUrl {
+    url: string;
+    platform: string;
+}
+interface Resource {
+    kind: string;
+    url: string;
+}
+
+const props = defineProps<{
+    video: {
+        id: string;
+        name: string;
+        description: string;
+        url: string;
+        thumbnail: string | null;
+        duration_seconds: number | null;
+        date_recorded: string | null;
+        is_livestream: boolean;
+        number_in_series: number | null;
+        status: 'draft' | 'published';
+        alternate_urls: AlternateUrl[];
+        speaker_ids: string[];
+        topic_ids: string[];
+        bible_book_ids: string[];
+        demographic_ids: string[];
+        ministry_ids: string[];
+        series_id: string | null;
+        related_resources: Resource[];
+    };
+    taxonomy: {
+        speakers: Option[];
+        series: Option[];
+        topics: Option[];
+        bible_books: Option[];
+        demographics: Option[];
+        ministries: Option[];
+    };
+}>();
+
+const v = props.video;
+const form = useForm({
+    name: v.name,
+    description: v.description ?? '',
+    url: v.url,
+    thumbnail: v.thumbnail ?? '',
+    duration_seconds: v.duration_seconds,
+    date_recorded: v.date_recorded ?? '',
+    is_livestream: v.is_livestream,
+    number_in_series: v.number_in_series,
+    speaker_ids: [...v.speaker_ids],
+    topic_ids: [...v.topic_ids],
+    bible_book_ids: [...v.bible_book_ids],
+    demographic_ids: [...v.demographic_ids],
+    ministry_ids: [...v.ministry_ids],
+    series_id: v.series_id,
+    alternate_urls: v.alternate_urls.map((a) => ({ ...a })),
+    related_resources: v.related_resources.map((r) => ({ ...r })),
+});
+
+const isPublished = computed(() => props.video.status === 'published');
+const embedUrl = computed(() => getEmbedUrl(form.url) || '');
+const editPath = computed(() => `/studio/videos/${props.video.id}/edit`);
+
+// --- alternate URLs + resources (inline row editors) ---------------------
+function addAlternate() {
+    form.alternate_urls.push({ url: '', platform: 'other' });
+}
+function removeAlternate(i: number) {
+    form.alternate_urls.splice(i, 1);
+}
+function addResource() {
+    form.related_resources.push({ kind: 'transcript', url: '' });
+}
+function removeResource(i: number) {
+    form.related_resources.splice(i, 1);
+}
+
+// --- save + publish ------------------------------------------------------
+// Status changes go through the existing set-status endpoint; Save is
+// status-neutral. `allowNav` lets our own visits bypass the dirty guard.
+let allowNav = false;
+
+function save() {
+    allowNav = true;
+    form.post(`/studio/videos/${props.video.id}/update`, { preserveScroll: true });
+}
+
+function togglePublish() {
+    allowNav = true;
+    router.post(`/studio/videos/${props.video.id}/status`, {
+        status: isPublished.value ? 'draft' : 'published',
+        next: editPath.value,
+    });
+}
+
+// --- unsaved-changes guard ----------------------------------------------
+const onBeforeUnload = (e: BeforeUnloadEvent) => {
+    if (form.isDirty) {
+        e.preventDefault();
+        e.returnValue = '';
+    }
+};
+
+let stopGuard: (() => void) | undefined;
+
+onMounted(() => {
+    window.addEventListener('beforeunload', onBeforeUnload);
+    // Cancel in-app navigations away from a dirty form (but not our own
+    // save/publish visits, which set allowNav first).
+    stopGuard = router.on('before', () => {
+        if (allowNav) {
+            allowNav = false;
+            return;
+        }
+        if (form.isDirty && !window.confirm('You have unsaved changes. Leave without saving?')) {
+            return false;
+        }
+    });
+});
+
+onBeforeUnmount(() => {
+    window.removeEventListener('beforeunload', onBeforeUnload);
+    stopGuard?.();
+});
+</script>
+
+<template>
+    <Head :title="`Studio — Editing ${form.name}`" />
+
+    <div class="mx-auto max-w-4xl px-4 py-8 lg:px-8">
+        <Link
+            href="/studio"
+            class="text-muted-foreground hover:text-foreground focus-visible:ring-ring -ml-1 inline-flex items-center gap-1.5 rounded text-sm transition-colors outline-none focus-visible:ring-2"
+        >
+            <ArrowLeft class="size-4" aria-hidden="true" />
+            Back to Library
+        </Link>
+
+        <!-- Header + actions -->
+        <div class="mt-3 flex flex-wrap items-start justify-between gap-4">
+            <div class="min-w-0">
+                <div class="flex items-center gap-3">
+                    <h1 class="font-display text-foreground truncate text-2xl font-bold sm:text-3xl">Edit video</h1>
+                    <Badge :variant="isPublished ? 'default' : 'secondary'">{{ isPublished ? 'Published' : 'Draft' }}</Badge>
+                </div>
+                <a
+                    :href="props.video.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-muted-foreground hover:text-foreground mt-1 inline-flex items-center gap-1 text-sm"
+                >
+                    Open source <ExternalLink class="size-3.5" aria-hidden="true" />
+                </a>
+            </div>
+            <div class="flex items-center gap-2">
+                <Button variant="outline" @click="togglePublish">{{ isPublished ? 'Unpublish' : 'Publish' }}</Button>
+                <Button :disabled="form.processing || !form.isDirty" @click="save">
+                    {{ form.processing ? 'Saving…' : 'Save' }}
+                </Button>
+            </div>
+        </div>
+
+        <!-- Live preview -->
+        <div class="bg-muted relative mt-6 aspect-video w-full overflow-hidden rounded-xl">
+            <iframe
+                v-if="embedUrl"
+                :src="embedUrl"
+                class="h-full w-full"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen
+                :title="form.name"
+            ></iframe>
+            <div v-else class="text-muted-foreground flex h-full items-center justify-center text-sm">No preview for this link</div>
+        </div>
+
+        <Tabs default-value="details" class="mt-6">
+            <TabsList class="w-full sm:w-auto">
+                <TabsTrigger value="details">Details</TabsTrigger>
+                <TabsTrigger value="classification">Classification</TabsTrigger>
+                <TabsTrigger value="sources">Sources</TabsTrigger>
+                <TabsTrigger value="resources">Resources</TabsTrigger>
+            </TabsList>
+
+            <!-- Details -->
+            <TabsContent value="details" class="space-y-5">
+                <div class="space-y-1.5">
+                    <label for="edit-name" class="text-foreground block text-sm font-medium">Title</label>
+                    <Input id="edit-name" v-model="form.name" type="text" class="text-base" maxlength="200" />
+                </div>
+                <div class="space-y-1.5">
+                    <label for="edit-description" class="text-foreground block text-sm font-medium">Description</label>
+                    <textarea
+                        id="edit-description"
+                        v-model="form.description"
+                        rows="5"
+                        class="border-input bg-background focus-visible:ring-ring w-full rounded-lg border px-3 py-2 text-base outline-none focus-visible:ring-2"
+                    ></textarea>
+                </div>
+                <div class="grid gap-5 sm:grid-cols-2">
+                    <div class="space-y-1.5">
+                        <label for="edit-date" class="text-foreground block text-sm font-medium">Date recorded</label>
+                        <Input id="edit-date" v-model="form.date_recorded" type="date" class="text-base" />
+                    </div>
+                    <div class="space-y-1.5">
+                        <label class="text-foreground block text-sm font-medium">Runtime</label>
+                        <p class="text-muted-foreground py-2 text-base tabular-nums">
+                            {{ form.duration_seconds ? formatDuration(form.duration_seconds) : '—' }}
+                        </p>
+                    </div>
+                </div>
+                <div class="space-y-1.5">
+                    <label for="edit-thumbnail" class="text-foreground block text-sm font-medium">Thumbnail URL</label>
+                    <Input id="edit-thumbnail" v-model="form.thumbnail" type="url" class="text-base" />
+                    <img v-if="form.thumbnail" :src="form.thumbnail" alt="" class="mt-2 aspect-video w-40 rounded-lg object-cover" />
+                </div>
+                <label class="flex items-center gap-3">
+                    <Switch v-model="form.is_livestream" />
+                    <span class="text-foreground text-sm font-medium">This is a livestream recording</span>
+                </label>
+            </TabsContent>
+
+            <!-- Classification -->
+            <TabsContent value="classification">
+                <ClassificationFields
+                    :taxonomy="props.taxonomy"
+                    v-model:speaker-ids="form.speaker_ids"
+                    v-model:topic-ids="form.topic_ids"
+                    v-model:bible-book-ids="form.bible_book_ids"
+                    v-model:demographic-ids="form.demographic_ids"
+                    v-model:ministry-ids="form.ministry_ids"
+                    v-model:series-id="form.series_id"
+                />
+            </TabsContent>
+
+            <!-- Sources -->
+            <TabsContent value="sources" class="space-y-5">
+                <div class="space-y-1.5">
+                    <label for="edit-url" class="text-foreground block text-sm font-medium">Primary link</label>
+                    <Input id="edit-url" v-model="form.url" type="url" class="text-base" />
+                    <p v-if="form.errors.url" role="alert" class="text-destructive text-sm">{{ form.errors.url }}</p>
+                </div>
+                <div class="space-y-2">
+                    <p class="text-foreground text-sm font-medium">Other places this is hosted</p>
+                    <div v-for="(alt, i) in form.alternate_urls" :key="i" class="flex items-center gap-2">
+                        <Input v-model="alt.url" type="url" placeholder="https://…" class="flex-1 text-base" />
+                        <select v-model="alt.platform" class="border-input bg-background h-9 rounded-md border px-2 text-sm" aria-label="Platform">
+                            <option value="youtube">YouTube</option>
+                            <option value="vimeo">Vimeo</option>
+                            <option value="other">Other</option>
+                        </select>
+                        <Button variant="ghost" size="icon" :aria-label="`Remove alternate link ${i + 1}`" @click="removeAlternate(i)">
+                            <Trash2 class="size-4" aria-hidden="true" />
+                        </Button>
+                    </div>
+                    <Button variant="outline" size="sm" @click="addAlternate">
+                        <Plus class="size-4" aria-hidden="true" />
+                        Add a link
+                    </Button>
+                </div>
+            </TabsContent>
+
+            <!-- Resources -->
+            <TabsContent value="resources" class="space-y-2">
+                <p class="text-muted-foreground text-sm">Transcript, audio or study-material links that live on other sites.</p>
+                <div v-for="(res, i) in form.related_resources" :key="i" class="flex items-center gap-2">
+                    <select v-model="res.kind" class="border-input bg-background h-9 rounded-md border px-2 text-sm" aria-label="Resource type">
+                        <option value="transcript">Transcript</option>
+                        <option value="audio">Audio</option>
+                        <option value="other">Other</option>
+                    </select>
+                    <Input v-model="res.url" type="url" placeholder="https://…" class="flex-1 text-base" />
+                    <Button variant="ghost" size="icon" :aria-label="`Remove resource ${i + 1}`" @click="removeResource(i)">
+                        <Trash2 class="size-4" aria-hidden="true" />
+                    </Button>
+                </div>
+                <Button variant="outline" size="sm" @click="addResource">
+                    <Plus class="size-4" aria-hidden="true" />
+                    Add a resource
+                </Button>
+            </TabsContent>
+        </Tabs>
+    </div>
+</template>

--- a/resources/js/pages/Studio/Library.vue
+++ b/resources/js/pages/Studio/Library.vue
@@ -298,9 +298,11 @@ const resultLabel = computed(() => {
                                             Open on site
                                         </a>
                                     </DropdownMenuItem>
-                                    <DropdownMenuItem disabled>
-                                        <Pencil class="size-4" aria-hidden="true" />
-                                        Edit (coming soon)
+                                    <DropdownMenuItem as-child>
+                                        <Link :href="`/studio/videos/${video.id}/edit`">
+                                            <Pencil class="size-4" aria-hidden="true" />
+                                            Edit
+                                        </Link>
                                     </DropdownMenuItem>
                                 </DropdownMenuContent>
                             </DropdownMenu>

--- a/tests/test_studio_editor.py
+++ b/tests/test_studio_editor.py
@@ -1,0 +1,252 @@
+"""Studio editor (Epic 3, Slice 4a): the full tabbed EditVideo screen.
+
+Covers the prefilled edit props (incl. the Series.videos M2M and related
+resources), and the update service/endpoint — scalars, add AND remove of M2Ms,
+series re-pointing, alternate_urls + related_resources sync, URL-clash guard,
+and status-neutrality (Save never changes publication state).
+"""
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+
+from app.auth import EDITORS_GROUP
+from app.studio import services
+from catalogue.models.related_resource import RelatedResource
+from catalogue.models.video import DRAFT, PUBLISHED, Video
+from tests.factories import (
+    BibleBookFactory,
+    DemographicFactory,
+    MinistryFactory,
+    SeriesFactory,
+    SpeakerFactory,
+    TopicFactory,
+    VideoFactory,
+)
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+PASSWORD = "pw-correct-horse-1"  # gitleaks:allow
+
+
+def make_editor(username="editor"):
+    user = User.objects.create_user(username=username, password=PASSWORD)
+    group, _ = Group.objects.get_or_create(name=EDITORS_GROUP)
+    user.groups.add(group)
+    return user
+
+
+def login_editor(client, username="editor"):
+    make_editor(username)
+    client.login(username=username, password=PASSWORD)
+
+
+# --- get_video_for_edit / the edit page ----------------------------------
+
+
+def test_edit_props_include_relations_and_series_via_m2m():
+    speaker = SpeakerFactory()
+    topic = TopicFactory()
+    series = SeriesFactory()
+    video = VideoFactory(status=DRAFT)
+    video.speaker.add(speaker)
+    video.topic.add(topic)
+    series.videos.add(video)  # membership lives on Series.videos, not Video.series
+    RelatedResource.objects.create(video=video, kind="transcript", url="https://x.test/t")
+
+    props = services.get_video_for_edit(video.id)
+
+    assert props["id"] == video.id
+    assert props["speaker_ids"] == [str(speaker.id)]
+    assert props["topic_ids"] == [str(topic.id)]
+    assert props["series_id"] == str(series.pk)
+    assert props["related_resources"] == [{"kind": "transcript", "url": "https://x.test/t"}]
+
+
+def test_get_video_for_edit_missing_returns_none():
+    assert services.get_video_for_edit("nope") is None
+
+
+def test_edit_page_anonymous_redirected(client):
+    video = VideoFactory()
+    resp = client.get(f"/studio/videos/{video.id}/edit")
+    assert resp.status_code == 302
+    assert resp.headers["Location"].startswith("/studio/login")
+
+
+def test_edit_page_non_editor_forbidden(client):
+    video = VideoFactory()
+    User.objects.create_user(username="viewer", password=PASSWORD)
+    client.login(username="viewer", password=PASSWORD)
+    assert client.get(f"/studio/videos/{video.id}/edit").status_code == 403
+
+
+def test_edit_page_renders_for_editor(client):
+    login_editor(client)
+    video = VideoFactory(name="Editable")
+    page = inertia_page(client.get(f"/studio/videos/{video.id}/edit"))
+    assert page["component"] == "Studio/EditVideo"
+    assert page["props"]["video"]["name"] == "Editable"
+    assert "taxonomy" in page["props"]
+
+
+def test_edit_page_404_for_missing(client):
+    login_editor(client)
+    assert client.get("/studio/videos/ghost/edit").status_code == 404
+
+
+# --- update service -------------------------------------------------------
+
+
+def test_update_changes_scalar_fields():
+    video = VideoFactory(name="Old", description="old")
+    ok = services.update_video(
+        video.id,
+        name="New title",
+        description="New body",
+        url=video.url,
+        duration_seconds=123,
+    )
+    assert ok is True
+    video.refresh_from_db()
+    assert video.name == "New title"
+    assert video.description == "New body"
+    assert video.duration_seconds == 123
+
+
+def test_update_adds_and_removes_m2m():
+    keep = SpeakerFactory()
+    drop = SpeakerFactory()
+    add = TopicFactory()
+    video = VideoFactory()
+    video.speaker.add(keep, drop)
+
+    services.update_video(
+        video.id,
+        name=video.name,
+        url=video.url,
+        speaker_ids=[str(keep.id)],  # drops `drop`
+        topic_ids=[str(add.id)],  # adds a topic
+    )
+    assert set(video.speaker.values_list("id", flat=True)) == {keep.id}
+    assert set(video.topic.values_list("id", flat=True)) == {add.id}
+
+
+def test_update_repoints_series_via_m2m():
+    old = SeriesFactory()
+    new = SeriesFactory()
+    video = VideoFactory()
+    old.videos.add(video)
+
+    services.update_video(video.id, name=video.name, url=video.url, series_id=new.pk)
+
+    assert not old.videos.filter(id=video.id).exists()
+    assert new.videos.filter(id=video.id).exists()
+    assert video.series_id is None  # decoy FK never used
+
+
+def test_update_clearing_series_removes_membership():
+    series = SeriesFactory()
+    video = VideoFactory()
+    series.videos.add(video)
+    services.update_video(video.id, name=video.name, url=video.url, series_id=None)
+    assert not series.videos.filter(id=video.id).exists()
+
+
+def test_update_syncs_related_resources():
+    video = VideoFactory()
+    RelatedResource.objects.create(video=video, kind="audio", url="https://x.test/old")
+    services.update_video(
+        video.id,
+        name=video.name,
+        url=video.url,
+        related_resources=[{"kind": "transcript", "url": "https://x.test/new"}],
+    )
+    rows = {(r.kind, r.url) for r in video.related_resources.all()}
+    assert rows == {("transcript", "https://x.test/new")}
+
+
+def test_update_replaces_alternate_urls():
+    video = VideoFactory()
+    alts = [{"url": "https://vimeo.com/1", "platform": "vimeo"}]
+    services.update_video(video.id, name=video.name, url=video.url, alternate_urls=alts)
+    video.refresh_from_db()
+    assert video.alternate_urls == alts
+
+
+def test_update_is_status_neutral():
+    video = VideoFactory(status=PUBLISHED)
+    services.update_video(video.id, name="changed", url=video.url)
+    video.refresh_from_db()
+    assert video.status == PUBLISHED  # Save never flips publication state
+
+
+def test_update_missing_returns_false():
+    assert services.update_video("ghost", name="x", url="https://x.test/y") is False
+
+
+def test_update_url_clash_raises():
+    other = VideoFactory(url="https://youtu.be/taken")
+    video = VideoFactory()
+    with pytest.raises(services.DuplicateVideoError):
+        services.update_video(video.id, name=video.name, url="https://youtu.be/taken")
+    # nothing changed
+    assert Video.objects.get(id=other.id).url == "https://youtu.be/taken"
+
+
+# --- update endpoint ------------------------------------------------------
+
+
+def test_update_endpoint_requires_editor(client):
+    video = VideoFactory()
+    assert client.post(f"/studio/videos/{video.id}/update").status_code == 302  # anon → login
+
+
+def test_update_endpoint_saves_via_json_body(client):
+    login_editor(client)
+    speaker = SpeakerFactory()
+    book = BibleBookFactory(name="EXO")
+    demo = DemographicFactory()
+    ministry = MinistryFactory()
+    video = VideoFactory(name="Before")
+
+    resp = client.post(
+        f"/studio/videos/{video.id}/update",
+        data=json.dumps(
+            {
+                "name": "After",
+                "url": video.url,
+                "description": "Edited.",
+                "speaker_ids": [str(speaker.id)],
+                "bible_book_ids": [str(book.id)],
+                "demographic_ids": [str(demo.id)],
+                "ministry_ids": [str(ministry.id)],
+                "related_resources": [{"kind": "other", "url": "https://x.test/r"}],
+            }
+        ),
+        content_type="application/json",
+    )
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == "/studio"
+    video.refresh_from_db()
+    assert video.name == "After"
+    assert set(video.speaker.values_list("id", flat=True)) == {speaker.id}
+    assert video.related_resources.count() == 1
+
+
+def test_update_endpoint_url_clash_rerenders_with_error(client):
+    login_editor(client)
+    VideoFactory(name="Owner", url="https://youtu.be/owned")
+    video = VideoFactory()
+    resp = client.post(
+        f"/studio/videos/{video.id}/update",
+        data=json.dumps({"name": video.name, "url": "https://youtu.be/owned"}),
+        content_type="application/json",
+    )
+    page = inertia_page(resp)
+    assert page["component"] == "Studio/EditVideo"
+    assert "url" in page["props"]["errors"]


### PR DESCRIPTION
## What
Slice 4a of the Studio epic — the **full video editor**, the daily workhorse once the legacy feed freezes. Edit any catalogue video from `/studio/videos/<id>/edit`:

- **Tabs**: Details (title, description, recorded date, livestream toggle, thumbnail + preview, runtime) · Classification (the shared searchable selects) · Sources (primary URL + alternate URLs) · Resources (transcript/audio/other links).
- **Live embed preview** via `getEmbedUrl()` (plain iframe — not the persistent dock).
- **Save** (status-neutral) + **Publish/Unpublish** (reuses the existing set-status endpoint), with an **unsaved-changes guard** (`form.isDirty` + router `before` hook + `beforeunload`).

## Backend
- `app/cards.py::video_edit_props` — full editable dict incl. M2M id-lists, **series via the `Series.videos` M2M** (not the decoy FK), `alternate_urls`, `related_resources`.
- `services.get_video_for_edit` + `update_video`; `_link_relations` → **`_apply_relations`** (always `.set()` so deselecting *removes*; series re-pointed); `_sync_resources` for `RelatedResource` rows. URL-clash reuses `DuplicateVideoError`.
- `/studio/videos/<id>/edit` (GET) + `/update` (POST), JSON-body aware via `_Payload`.

## Frontend
- Vendored `ui/tabs` (reka-ui). Extracted **`ClassificationFields`** shared by Add + Edit (DRY). New `EditVideo.vue`. Library row ⋯ → **Edit** now links here.

## Testing
- `tests/test_studio_editor.py` (18): prefilled props incl. series M2M; scalar edits; **add AND remove** M2M; series re-point + clear; alternate_urls + resources sync; status-neutrality; URL clash; auth gate; JSON body; 404. Full suite 302 passed.
- type-check, eslint, prettier, ruff, build — all green.
- **Local browser** (Claude): opened video 97 in the editor → live preview + 4 tabs render → Save disabled until dirty → edited title → Save persisted (status stayed `published`) → tab switch shows the shared classification fields. (Local change reverted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)