### PR TITLE
feat(studio): bulk add — paste-many + YouTube playlist import (Epic 3 Slice 5)

### DIFF
--- a/app/studio/services.py
+++ b/app/studio/services.py
@@ -18,6 +18,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from app.cards import video_edit_props
+from catalogue import metadata
 from catalogue import search as search_index
 from catalogue.models.bible_book import Bible_Book
 from catalogue.models.demograpic import Demographic
@@ -228,7 +229,9 @@ def find_duplicate(url):
     classification. ``Video.url`` is unique, so this is the authoritative match;
     ``create_video`` re-checks at save time to close the race.
     """
-    existing = Video.objects.filter(url=(url or "").strip()).only("id", "name").first()
+    # all_objects: a soft-deleted row still holds the unique URL, so a create
+    # would collide with it — surface that as a duplicate too.
+    existing = Video.all_objects.filter(url=(url or "").strip()).only("id", "name").first()
     return {"id": existing.id, "name": existing.name} if existing else None
 
 
@@ -275,7 +278,9 @@ def create_video(
     exists. New content defaults to ``draft``; the post_save signal indexes it.
     """
     url = (url or "").strip()
-    existing = Video.objects.filter(url=url).first()
+    # all_objects so a trashed row's URL (which still holds the unique constraint)
+    # is treated as a duplicate rather than causing an IntegrityError.
+    existing = Video.all_objects.filter(url=url).first()
     if existing is not None:
         raise DuplicateVideoError(existing)
 
@@ -311,6 +316,62 @@ def create_video(
     return video
 
 
+# Cap a single bulk submission so one request stays fast and quota stays sane.
+BULK_MAX = 100
+
+
+def expand_playlist(playlist_url):
+    """A YouTube playlist URL → its video watch-URLs (raises MetadataError on a
+    bad/empty/private playlist). Thin pass-through to the metadata helper."""
+    return metadata.youtube_playlist_video_urls(playlist_url, max_items=BULK_MAX)
+
+
+def bulk_create_from_urls(urls):
+    """Create draft videos for many URLs at once. De-dupes the input, caps at
+    ``BULK_MAX``, fetches metadata in a batch, then creates a draft per fresh
+    URL. Returns a per-URL report plus tallies so the page can show what landed,
+    what was already in the library, and what couldn't be read."""
+    unique = []
+    for raw in urls:
+        url = (raw or "").strip()
+        if url and url not in unique:
+            unique.append(url)
+    unique = unique[:BULK_MAX]
+
+    fetched = metadata.fetch_metadata_many(unique)
+    results = []
+    for url in unique:
+        outcome = fetched.get(url) or {"ok": False, "error": "Could not read that link."}
+        if not outcome.get("ok"):
+            results.append({"url": url, "status": "error", "error": outcome.get("error", "Could not read.")})
+            continue
+        meta = outcome["metadata"]
+        try:
+            video = create_video(
+                url=meta["url"],
+                name=meta["name"],
+                description=meta.get("description", ""),
+                thumbnail=meta.get("thumbnail"),
+                duration_seconds=meta.get("duration_seconds"),
+                date_recorded=meta.get("date_recorded"),
+                status=DRAFT,
+            )
+        except DuplicateVideoError as exc:
+            results.append({"url": url, "status": "duplicate", "name": exc.video.name, "id": exc.video.id})
+            continue
+        results.append({"url": url, "status": "created", "name": video.name, "id": video.id})
+
+    tally = {"created": 0, "duplicate": 0, "error": 0}
+    for r in results:
+        tally[r["status"]] += 1
+    return {
+        "results": results,
+        "created": tally["created"],
+        "duplicates": tally["duplicate"],
+        "errors": tally["error"],
+    }
+
+
 def _mint_video_id():
     """A unique, non-colliding primary key for a Studio-created video.
 
@@ -318,10 +379,12 @@ def _mint_video_id():
     (``S0000001``) so they never clash with a legacy id — even one the dying
     live-admin feed imports later — and fit the 10-char ``id`` column.
     """
-    n = Video.objects.filter(id__startswith="S").count() + 1
+    # all_objects: trashed S-rows still occupy their primary key, so they must
+    # count toward uniqueness or we'd mint a colliding id.
+    n = Video.all_objects.filter(id__startswith="S").count() + 1
     while True:
         candidate = f"S{n:07d}"
-        if not Video.objects.filter(Q(id=candidate) | Q(id_number=candidate)).exists():
+        if not Video.all_objects.filter(Q(id=candidate) | Q(id_number=candidate)).exists():
             return candidate
         n += 1
 
@@ -394,7 +457,7 @@ def update_video(
         return False
 
     url = (url or "").strip()
-    clash = Video.objects.filter(url=url).exclude(id=video_id).first()
+    clash = Video.all_objects.filter(url=url).exclude(id=video_id).first()
     if clash is not None:
         raise DuplicateVideoError(clash)
 

--- a/app/studio/urls.py
+++ b/app/studio/urls.py
@@ -9,12 +9,14 @@ urlpatterns = [
     path("", views.library, name="studio_library"),
     path("review", views.review, name="studio_review"),
     path("add", views.add_video, name="studio_add_video"),
+    path("bulk", views.bulk_add, name="studio_bulk_add"),
     path("login", views.login_view, name="studio_login"),
     path("logout", views.logout_view, name="studio_logout"),
     # Beta-only secret magic link (key-gated; 404 without the secret). See settings.
     path("dev-login", views.dev_login, name="studio_dev_login"),
     # JSON metadata preview for the Add form (not Inertia).
     path("api/fetch-metadata", views.fetch_metadata_api, name="studio_fetch_metadata"),
+    path("api/bulk-create", views.bulk_create_api, name="studio_bulk_create"),
     # Editor (Slice 4a).
     path("videos/<str:id>/edit", views.edit_video, name="studio_edit_video"),
     path("videos/<str:id>/update", views.update_video, name="studio_update_video"),

--- a/app/studio/views.py
+++ b/app/studio/views.py
@@ -341,6 +341,49 @@ def create_video(request):
 
 
 # --------------------------------------------------------------------------- #
+# Bulk add (Slice 5): paste-many URLs + YouTube playlist import
+# --------------------------------------------------------------------------- #
+
+
+@studio_required
+@ensure_csrf_cookie
+def bulk_add(request):
+    """``/studio/bulk`` — paste many links (or a YouTube playlist) → drafts."""
+    return render(request, "Studio/BulkAdd", {})
+
+
+@studio_required
+@require_POST
+def bulk_create_api(request):
+    """``POST /studio/api/bulk-create`` → create drafts for many URLs at once.
+
+    Body is either ``{urls: [...] | "newline string"}`` or ``{playlist_url}``
+    (expanded server-side). Returns a JSON per-URL report (created / duplicate /
+    error) the page renders inline."""
+    try:
+        body = json.loads(request.body or "{}")
+    except (ValueError, TypeError):
+        body = {}
+
+    playlist = (body.get("playlist_url") or "").strip()
+    if playlist:
+        try:
+            urls = services.expand_playlist(playlist)
+        except MetadataError as exc:
+            return JsonResponse({"ok": False, "error": str(exc)}, status=200)
+    else:
+        urls = body.get("urls") or []
+        if isinstance(urls, str):
+            urls = urls.splitlines()
+
+    urls = [u for u in urls if (u or "").strip()]
+    if not urls:
+        return JsonResponse({"ok": False, "error": "Paste at least one video link."}, status=200)
+
+    return JsonResponse({"ok": True, **services.bulk_create_from_urls(urls)})
+
+
+# --------------------------------------------------------------------------- #
 # Edit a video (Slice 4a)
 # --------------------------------------------------------------------------- #
 

--- a/catalogue/metadata.py
+++ b/catalogue/metadata.py
@@ -15,6 +15,8 @@ Network failures / unknown URLs raise ``MetadataError`` with a human-readable
 message; the view turns that into a friendly inline error.
 """
 
+import re
+
 import requests
 
 from catalogue import durations, youtube_live
@@ -60,9 +62,13 @@ def _fetch_youtube(url, session):
     items = data.get("items") or []
     if not items:
         raise MetadataError("No YouTube video found at that link (it may be private or deleted).")
+    return _youtube_doc(yid, items[0])
 
-    snippet = items[0].get("snippet", {})
-    details = items[0].get("contentDetails", {})
+
+def _youtube_doc(yid, item):
+    """Normalise one ``videos.list`` item into our metadata dict."""
+    snippet = item.get("snippet", {})
+    details = item.get("contentDetails", {})
     published = snippet.get("publishedAt") or ""
     return {
         "platform": "youtube",
@@ -106,3 +112,94 @@ def _fetch_vimeo(url, session):
         "duration_seconds": int(duration) if duration else None,
         "date_recorded": upload_date[:10] or None,
     }
+
+
+# --------------------------------------------------------------------------- #
+# Bulk intake (Slice 5): many URLs at once + YouTube playlist expansion
+# --------------------------------------------------------------------------- #
+
+YT_BATCH = 50
+_PLAYLIST_ID = re.compile(r"[?&]list=([^&]+)")
+
+
+def fetch_metadata_many(urls, session=None):
+    """Metadata for many URLs at once. YouTube ids are **batched**
+    (``videos.list``, 50/call — keeps a paste-many or playlist import to a
+    handful of API calls); Vimeo is per-URL oEmbed. One bad URL never sinks the
+    batch: returns ``{url: {"ok": True, "metadata": {...}}}`` or
+    ``{url: {"ok": False, "error": "..."}}`` per input URL."""
+    session = session or requests.Session()
+    results = {}
+    youtube = {}  # yid -> [original urls]
+
+    for raw in urls:
+        url = (raw or "").strip()
+        if not url:
+            continue
+        yid = durations.youtube_id(url)
+        if yid:
+            youtube.setdefault(yid, []).append(url)
+        elif "vimeo.com" in url:
+            try:
+                results[url] = {"ok": True, "metadata": _fetch_vimeo(url, session)}
+            except MetadataError as exc:
+                results[url] = {"ok": False, "error": str(exc)}
+        else:
+            results[url] = {"ok": False, "error": "Not a YouTube or Vimeo link."}
+
+    ids = list(youtube)
+    for start in range(0, len(ids), YT_BATCH):
+        _resolve_youtube_batch(ids[start : start + YT_BATCH], youtube, session, results)
+    return results
+
+
+def _resolve_youtube_batch(batch, youtube, session, results):
+    """Look up one batch of YouTube ids and record a result for every URL that
+    mapped to them (into ``results``, keyed by original URL)."""
+    try:
+        data = youtube_live.api_get(session, "videos", part="snippet,contentDetails", id=",".join(batch))
+        found = {item["id"]: item for item in data.get("items", [])}
+    except (youtube_live.YoutubeApiError, KeyError):
+        found = None
+    for yid in batch:
+        if found is None:
+            outcome = {"ok": False, "error": "Couldn't reach YouTube just now."}
+        elif yid not in found:
+            outcome = {"ok": False, "error": "Video not found (private or deleted)."}
+        else:
+            outcome = {"ok": True, "metadata": _youtube_doc(yid, found[yid])}
+        for url in youtube[yid]:
+            results[url] = outcome
+
+
+def youtube_playlist_video_urls(playlist_url, session=None, max_items=200):
+    """Expand a YouTube playlist URL to its video watch-URLs (``playlistItems``,
+    paginated 50/page, capped at ``max_items``). Raises ``MetadataError`` for a
+    non-playlist link or an empty/private playlist."""
+    match = _PLAYLIST_ID.search(playlist_url or "")
+    if not match:
+        raise MetadataError("That doesn't look like a YouTube playlist link.")
+    playlist_id = match.group(1)
+    session = session or requests.Session()
+
+    urls = []
+    page_token = None
+    while len(urls) < max_items:
+        params = {"part": "contentDetails", "maxResults": YT_BATCH, "playlistId": playlist_id}
+        if page_token:
+            params["pageToken"] = page_token
+        try:
+            data = youtube_live.api_get(session, "playlistItems", **params)
+        except (youtube_live.YoutubeApiError, KeyError) as exc:
+            raise MetadataError("Couldn't load that playlist (it may be private).") from exc
+        for item in data.get("items", []):
+            vid = item.get("contentDetails", {}).get("videoId")
+            if vid:
+                urls.append(f"https://www.youtube.com/watch?v={vid}")
+        page_token = data.get("nextPageToken")
+        if not page_token:
+            break
+
+    if not urls:
+        raise MetadataError("That playlist has no videos (or is private).")
+    return urls[:max_items]

--- a/resources/js/pages/Studio/AddVideo.vue
+++ b/resources/js/pages/Studio/AddVideo.vue
@@ -137,7 +137,10 @@ const recordedLabel = computed(() => (preview.value?.date_recorded ? preview.val
         </Link>
 
         <h1 class="font-display text-foreground mt-3 text-2xl font-bold sm:text-3xl">Add a video</h1>
-        <p class="text-muted-foreground mt-1 text-sm">Paste a YouTube or Vimeo link and we'll fetch the details. Review, classify, then save.</p>
+        <p class="text-muted-foreground mt-1 text-sm">
+            Paste a YouTube or Vimeo link and we'll fetch the details. Review, classify, then save. Got several?
+            <Link href="/studio/bulk" class="text-primary hover:underline">Add a batch or a playlist</Link>.
+        </p>
 
         <!-- Step 1: the URL -->
         <div class="mt-8 space-y-1.5">

--- a/resources/js/pages/Studio/BulkAdd.vue
+++ b/resources/js/pages/Studio/BulkAdd.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { Button } from '@/ui/button';
+import { Input } from '@/ui/input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/ui/tabs';
+import { Head, Link } from '@inertiajs/vue3';
+import { ArrowLeft, CheckCircle2, CircleAlert, Copy, LoaderCircle } from 'lucide-vue-next';
+import { computed, ref } from 'vue';
+import { getCsrfToken } from '~/lib/csrf';
+
+interface Result {
+    url: string;
+    status: 'created' | 'duplicate' | 'error';
+    name?: string;
+    error?: string;
+    id?: string;
+}
+interface Summary {
+    results: Result[];
+    created: number;
+    duplicates: number;
+    errors: number;
+}
+
+const mode = ref<'links' | 'playlist'>('links');
+const linksText = ref('');
+const playlistUrl = ref('');
+
+const submitting = ref(false);
+const topError = ref('');
+const summary = ref<Summary | null>(null);
+
+const lineCount = computed(() => linksText.value.split('\n').filter((l) => l.trim()).length);
+const canSubmit = computed(() => (mode.value === 'links' ? lineCount.value > 0 : !!playlistUrl.value.trim()));
+
+async function submit() {
+    if (!canSubmit.value || submitting.value) return;
+    submitting.value = true;
+    topError.value = '';
+    summary.value = null;
+    const payload = mode.value === 'links' ? { urls: linksText.value } : { playlist_url: playlistUrl.value.trim() };
+    try {
+        const res = await fetch('/studio/api/bulk-create', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-XSRF-TOKEN': getCsrfToken() },
+            body: JSON.stringify(payload),
+        });
+        const data = await res.json();
+        if (!data.ok) {
+            topError.value = data.error || 'Something went wrong.';
+            return;
+        }
+        summary.value = data;
+    } catch {
+        topError.value = 'Something went wrong reaching the server. Try again.';
+    } finally {
+        submitting.value = false;
+    }
+}
+
+function reset() {
+    summary.value = null;
+    linksText.value = '';
+    playlistUrl.value = '';
+}
+
+const STATUS_META: Record<Result['status'], { class: string; label: string }> = {
+    created: { class: 'text-primary', label: 'Draft created' },
+    duplicate: { class: 'text-muted-foreground', label: 'Already in library' },
+    error: { class: 'text-destructive', label: 'Skipped' },
+};
+</script>
+
+<template>
+    <Head title="Studio — Add several" />
+
+    <div class="mx-auto max-w-3xl px-4 py-8 lg:px-8">
+        <Link
+            href="/studio"
+            class="text-muted-foreground hover:text-foreground focus-visible:ring-ring -ml-1 inline-flex items-center gap-1.5 rounded text-sm transition-colors outline-none focus-visible:ring-2"
+        >
+            <ArrowLeft class="size-4" aria-hidden="true" />
+            Back to Library
+        </Link>
+
+        <h1 class="font-display text-foreground mt-3 text-2xl font-bold sm:text-3xl">Add several at once</h1>
+        <p class="text-muted-foreground mt-1 text-sm">
+            Paste a batch of links or a whole YouTube playlist. Each becomes a draft for review — up to 100 at a time.
+        </p>
+
+        <!-- Input (hidden once we have results) -->
+        <div v-if="!summary" class="mt-8">
+            <Tabs v-model="mode">
+                <TabsList class="w-full sm:w-auto">
+                    <TabsTrigger value="links">Paste links</TabsTrigger>
+                    <TabsTrigger value="playlist">YouTube playlist</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="links" class="space-y-2">
+                    <label for="bulk-links" class="text-foreground block text-sm font-medium">One link per line</label>
+                    <textarea
+                        id="bulk-links"
+                        v-model="linksText"
+                        rows="8"
+                        placeholder="https://www.youtube.com/watch?v=…&#10;https://vimeo.com/…"
+                        class="border-input bg-background focus-visible:ring-ring w-full rounded-lg border px-3 py-2 font-mono text-sm outline-none focus-visible:ring-2"
+                    ></textarea>
+                    <p class="text-muted-foreground text-xs tabular-nums">{{ lineCount }} {{ lineCount === 1 ? 'link' : 'links' }}</p>
+                </TabsContent>
+
+                <TabsContent value="playlist" class="space-y-2">
+                    <label for="bulk-playlist" class="text-foreground block text-sm font-medium">YouTube playlist link</label>
+                    <Input
+                        id="bulk-playlist"
+                        v-model="playlistUrl"
+                        type="url"
+                        inputmode="url"
+                        placeholder="https://www.youtube.com/playlist?list=…"
+                        class="text-base"
+                    />
+                    <p class="text-muted-foreground text-xs">We'll pull in every video on the playlist (newest first), up to 100.</p>
+                </TabsContent>
+            </Tabs>
+
+            <p v-if="topError" role="alert" class="text-destructive mt-3 flex items-center gap-1.5 text-sm">
+                <CircleAlert class="size-4 shrink-0" aria-hidden="true" />
+                {{ topError }}
+            </p>
+
+            <div class="mt-6 flex items-center gap-3 border-t pt-6">
+                <Button :disabled="!canSubmit || submitting" @click="submit">
+                    <LoaderCircle v-if="submitting" class="size-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
+                    {{ submitting ? 'Fetching…' : 'Fetch & create drafts' }}
+                </Button>
+                <span class="text-muted-foreground text-sm">Drafts wait in Review until you publish them.</span>
+            </div>
+        </div>
+
+        <!-- Results -->
+        <div v-else class="mt-8 space-y-6">
+            <div class="border-border bg-card flex flex-wrap items-center gap-x-6 gap-y-1 rounded-xl border p-4 text-sm">
+                <span class="text-foreground font-medium">
+                    <CheckCircle2 class="text-primary mr-1 inline size-4" aria-hidden="true" />
+                    {{ summary.created }} created
+                </span>
+                <span class="text-muted-foreground">{{ summary.duplicates }} already in library</span>
+                <span class="text-muted-foreground">{{ summary.errors }} skipped</span>
+            </div>
+
+            <ul class="divide-border divide-y rounded-xl border">
+                <li v-for="(r, i) in summary.results" :key="i" class="flex items-start gap-3 px-4 py-3 text-sm">
+                    <Copy class="text-muted-foreground mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                    <div class="min-w-0 flex-1">
+                        <p class="text-foreground truncate">{{ r.name || r.url }}</p>
+                        <p class="text-muted-foreground truncate text-xs">{{ r.url }}</p>
+                        <p v-if="r.error" class="text-destructive text-xs">{{ r.error }}</p>
+                    </div>
+                    <span :class="['shrink-0 text-xs font-medium', STATUS_META[r.status].class]">{{ STATUS_META[r.status].label }}</span>
+                </li>
+            </ul>
+
+            <div class="flex flex-wrap items-center gap-3 border-t pt-6">
+                <Button as-child>
+                    <Link href="/studio/review">Go to Review</Link>
+                </Button>
+                <Button variant="outline" @click="reset">Add more</Button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/tests/test_studio_bulk_add.py
+++ b/tests/test_studio_bulk_add.py
@@ -1,0 +1,253 @@
+"""Studio bulk add (Epic 3, Slice 5): paste-many URLs + YouTube playlist import.
+
+The metadata batch + playlist expansion are unit-tested against a stub session;
+the service and endpoint are tested with the fetch layer patched so one bad URL
+never sinks the batch and dedup/tallies are correct.
+"""
+
+import json
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+
+import catalogue.metadata as metadata
+from app.auth import EDITORS_GROUP
+from app.studio import services
+from catalogue.metadata import MetadataError, fetch_metadata_many, youtube_playlist_video_urls
+from catalogue.models.video import DRAFT, Video
+from tests.factories import VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+PASSWORD = "pw-correct-horse-1"  # gitleaks:allow
+
+
+def make_editor(username="editor"):
+    user = User.objects.create_user(username=username, password=PASSWORD)
+    group, _ = Group.objects.get_or_create(name=EDITORS_GROUP)
+    user.groups.add(group)
+    return user
+
+
+def login_editor(client, username="editor"):
+    make_editor(username)
+    client.login(username=username, password=PASSWORD)
+
+
+class FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+class DispatchSession:
+    """Returns canned payloads keyed by which endpoint is hit."""
+
+    def __init__(self, *, videos=None, oembed=None, playlist=None):
+        self._videos = videos or {"items": []}
+        self._oembed = oembed
+        self._playlist = playlist or {"items": []}
+
+    def get(self, url, params=None, timeout=None):
+        if "oembed" in url:
+            return FakeResponse(self._oembed or {}, 200 if self._oembed else 404)
+        if "playlistItems" in url:
+            return FakeResponse(self._playlist)
+        return FakeResponse(self._videos)  # videos.list
+
+
+# --- metadata batch -------------------------------------------------------
+
+
+def test_fetch_metadata_many_batches_youtube_and_handles_mixed(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "k")  # gitleaks:allow
+    videos_payload = {
+        "items": [
+            {
+                "id": "aaaaaaaaaaa",
+                "snippet": {"title": "First", "thumbnails": {}},
+                "contentDetails": {"duration": "PT5M"},
+            },
+            {
+                "id": "bbbbbbbbbbb",
+                "snippet": {"title": "Second", "thumbnails": {}},
+                "contentDetails": {"duration": "PT6M"},
+            },
+        ]
+    }
+    session = DispatchSession(videos=videos_payload)
+    out = fetch_metadata_many(
+        [
+            "https://www.youtube.com/watch?v=aaaaaaaaaaa",
+            "https://www.youtube.com/watch?v=bbbbbbbbbbb",
+            "https://example.com/nope",
+        ],
+        session=session,
+    )
+    assert out["https://www.youtube.com/watch?v=aaaaaaaaaaa"]["metadata"]["name"] == "First"
+    assert out["https://www.youtube.com/watch?v=bbbbbbbbbbb"]["ok"] is True
+    assert out["https://example.com/nope"]["ok"] is False
+
+
+def test_fetch_metadata_many_reports_missing_youtube(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "k")  # gitleaks:allow
+    session = DispatchSession(videos={"items": []})  # id not returned → gone
+    out = fetch_metadata_many(["https://youtu.be/zzzzzzzzzzz"], session=session)
+    assert out["https://youtu.be/zzzzzzzzzzz"]["ok"] is False
+
+
+# --- playlist expansion ---------------------------------------------------
+
+
+def test_youtube_playlist_video_urls(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "k")  # gitleaks:allow
+    payload = {
+        "items": [
+            {"contentDetails": {"videoId": "vid1"}},
+            {"contentDetails": {"videoId": "vid2"}},
+        ]
+    }
+    session = DispatchSession(playlist=payload)
+    urls = youtube_playlist_video_urls("https://www.youtube.com/playlist?list=PL123", session=session)
+    assert urls == ["https://www.youtube.com/watch?v=vid1", "https://www.youtube.com/watch?v=vid2"]
+
+
+def test_youtube_playlist_rejects_non_playlist():
+    with pytest.raises(MetadataError):
+        youtube_playlist_video_urls("https://www.youtube.com/watch?v=abc")
+
+
+# --- bulk_create_from_urls ------------------------------------------------
+
+
+def _patch_fetch(monkeypatch, mapping):
+    monkeypatch.setattr(metadata, "fetch_metadata_many", lambda urls, session=None: mapping)
+
+
+def _meta(url, name="A talk"):
+    metadata_dict = {
+        "url": url,
+        "name": name,
+        "description": "",
+        "thumbnail": None,
+        "duration_seconds": 60,
+        "date_recorded": None,
+    }
+    return {"ok": True, "metadata": metadata_dict}
+
+
+def test_bulk_create_creates_drafts_and_tallies(monkeypatch):
+    existing = VideoFactory(name="Already", url="https://youtu.be/dup")
+    mapping = {
+        "https://youtu.be/new1": _meta("https://youtu.be/new1", "New one"),
+        "https://youtu.be/dup": _meta("https://youtu.be/dup", "Dup"),
+        "https://bad/x": {"ok": False, "error": "Not a video link."},
+    }
+    _patch_fetch(monkeypatch, mapping)
+
+    summary = services.bulk_create_from_urls(list(mapping))
+    assert summary["created"] == 1
+    assert summary["duplicates"] == 1
+    assert summary["errors"] == 1
+    new = Video.objects.get(url="https://youtu.be/new1")
+    assert new.status == DRAFT
+    # The duplicate row was not re-created.
+    assert Video.all_objects.filter(url="https://youtu.be/dup").count() == 1
+    assert existing.id != new.id
+
+
+def test_bulk_create_dedupes_input(monkeypatch):
+    mapping = {"https://youtu.be/same": _meta("https://youtu.be/same")}
+    _patch_fetch(monkeypatch, mapping)
+    summary = services.bulk_create_from_urls(["https://youtu.be/same", "https://youtu.be/same", "  "])
+    assert summary["created"] == 1
+    assert len(summary["results"]) == 1
+
+
+# --- endpoints ------------------------------------------------------------
+
+
+def test_bulk_page_requires_editor(client):
+    assert client.get("/studio/bulk").status_code == 302  # anon → login
+
+
+def test_bulk_page_renders_for_editor(client):
+    login_editor(client)
+    page = inertia_page(client.get("/studio/bulk"))
+    assert page["component"] == "Studio/BulkAdd"
+
+
+def test_bulk_create_endpoint_requires_editor(client):
+    assert client.post("/studio/api/bulk-create").status_code == 302
+
+
+def test_bulk_create_endpoint_creates_drafts(client, monkeypatch):
+    login_editor(client)
+    _patch_fetch(monkeypatch, {"https://youtu.be/e1": _meta("https://youtu.be/e1", "Endpoint one")})
+    resp = client.post(
+        "/studio/api/bulk-create",
+        data=json.dumps({"urls": ["https://youtu.be/e1"]}),
+        content_type="application/json",
+    )
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["created"] == 1
+    assert Video.objects.filter(url="https://youtu.be/e1").exists()
+
+
+def test_bulk_create_endpoint_accepts_newline_string(client, monkeypatch):
+    login_editor(client)
+    _patch_fetch(monkeypatch, {"https://youtu.be/line1": _meta("https://youtu.be/line1")})
+    resp = client.post(
+        "/studio/api/bulk-create",
+        data=json.dumps({"urls": "https://youtu.be/line1\n\n"}),
+        content_type="application/json",
+    )
+    assert resp.json()["created"] == 1
+
+
+def test_bulk_create_endpoint_empty_is_friendly_error(client):
+    login_editor(client)
+    body = client.post(
+        "/studio/api/bulk-create",
+        data=json.dumps({"urls": []}),
+        content_type="application/json",
+    ).json()
+    assert body["ok"] is False
+    assert "at least one" in body["error"]
+
+
+def test_bulk_create_endpoint_expands_playlist(client, monkeypatch):
+    login_editor(client)
+    monkeypatch.setattr(services, "expand_playlist", lambda url: ["https://youtu.be/p1"])
+    _patch_fetch(monkeypatch, {"https://youtu.be/p1": _meta("https://youtu.be/p1", "From playlist")})
+    body = client.post(
+        "/studio/api/bulk-create",
+        data=json.dumps({"playlist_url": "https://www.youtube.com/playlist?list=PLx"}),
+        content_type="application/json",
+    ).json()
+    assert body["ok"] is True
+    assert body["created"] == 1
+
+
+def test_bulk_create_endpoint_playlist_error_is_friendly(client, monkeypatch):
+    login_editor(client)
+
+    def boom(url):
+        raise MetadataError("That playlist has no videos (or is private).")
+
+    monkeypatch.setattr(services, "expand_playlist", boom)
+    body = client.post(
+        "/studio/api/bulk-create",
+        data=json.dumps({"playlist_url": "https://www.youtube.com/playlist?list=PLbad"}),
+        content_type="application/json",
+    ).json()
+    assert body["ok"] is False
+    assert "playlist" in body["error"].lower()

--- a/tests/test_studio_review.py
+++ b/tests/test_studio_review.py
@@ -65,6 +65,22 @@ def test_soft_deleted_video_drops_out_of_series_relation():
     assert not series.videos.filter(id=video.id).exists()
 
 
+def test_create_against_trashed_url_is_duplicate_not_crash():
+    """A trashed row still holds the unique URL, so a create must report a
+    duplicate (via all_objects) rather than hit an IntegrityError."""
+    gone = VideoFactory(url="https://youtu.be/trashed-url")
+    services.delete_videos([gone.id])
+    with pytest.raises(services.DuplicateVideoError):
+        services.create_video(url="https://youtu.be/trashed-url", name="Retry")
+
+
+def test_minted_id_skips_trashed_rows():
+    a = services.create_video(url="https://youtu.be/mint-a", name="A")
+    services.delete_videos([a.id])  # a is now trashed but still owns S0000001
+    b = services.create_video(url="https://youtu.be/mint-b", name="B")
+    assert b.id != a.id  # the minter counted the trashed row
+
+
 def test_restore_brings_video_back():
     video = VideoFactory()
     services.delete_videos([video.id])


### PR DESCRIPTION
## What
Slice 5 — **add a whole batch at once**. Paste many YouTube/Vimeo links (one per line) **or** a YouTube **playlist** URL → each becomes a draft in the Review queue. The manual bridge to automation before the legacy feed dies.

## Backend
- `catalogue/metadata.py`: **`fetch_metadata_many`** — YouTube ids **batched** (`videos.list`, 50/call) so a paste-many or playlist import is a handful of API calls; Vimeo per-URL oEmbed; one bad URL never sinks the batch (per-URL ok/error). **`youtube_playlist_video_urls`** — paginated `playlistItems`, capped.
- `services`: **`bulk_create_from_urls`** (de-dupes input, caps at 100, per-URL report: created / duplicate / error) + `expand_playlist`.
- `views`/`urls`: `/studio/bulk` + JSON `/studio/api/bulk-create` (accepts `urls[]`, a newline string, or `playlist_url`).

## Frontend
- `Studio/BulkAdd.vue`: tabbed (Paste links / YouTube playlist) → inline **per-URL results** + tallies + **Go to Review**. Linked from the Add page.

## Soft-delete follow-up (from 4b)
`create_video` / `update_video` / `find_duplicate` / the id minter now check **`all_objects`**, so a trashed row's still-unique URL or primary key is reported as a friendly duplicate rather than causing an `IntegrityError`.

## Testing
- `tests/test_studio_bulk_add.py` (14): batch + playlist parsing, tallies, input de-dupe, endpoint (urls / newline string / playlist / empty / playlist-error); + soft-delete dedup regressions in `test_studio_review.py`. **Full suite 331 passed.**
- type-check, eslint, prettier, ruff (lint + format), build — all green.
- **Local browser** (Claude): pasted 2 links → 2 drafts created → both appear in Review; re-submitting reported **1 already in library + 1 skipped** (bad link). Test drafts cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)