### PR TITLE
test(ci): enforce coverage in poe test + ratchet gate 60→80% (#283)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,4 +82,4 @@ jobs:
         run: uv sync --locked
 
       - name: Run tests
-        run: uv run pytest --tb=short -p no:warnings -q --cov --cov-fail-under=60
+        run: uv run pytest --tb=short -p no:warnings -q --cov --cov-fail-under=80

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ baseline), [docs/SERVER_AUDIT.md](docs/SERVER_AUDIT.md),
 ```bash
 uv run poe          # list all tasks
 uv run poe dev      # Django + Vite dev servers (or use .claude/launch.json)
-uv run poe test     # pytest (coverage gate: 60%)
+uv run poe test     # pytest (coverage gate: 80%, enforced locally + in CI)
 uv run poe fix      # ruff lint --fix + format
 uv run poe manage <cmd>
 npm run build-only  # production asset build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,8 @@ help = "Lint and format all Python files"
 sequence = ["lint", "format"]
 
 [tool.poe.tasks.test]
-help = "Run the test suite"
-cmd = "pytest"
+help = "Run the test suite (with the coverage gate, matching CI)"
+cmd = "pytest --cov --cov-report=term-missing --cov-fail-under=80"
 
 [tool.poe.tasks.typesense]
 help = "Run a local Typesense container for search development"


### PR DESCRIPTION
First slice of the test-safety-net work (#283).

CI already enforced coverage (`--cov-fail-under=60`), but `poe test` was bare `pytest` — so the gate was invisible locally, and at **88% actual** a 60% floor protected almost nothing.

- `poe test` now runs `--cov --cov-report=term-missing --cov-fail-under=80` (local == CI).
- CI floor 60 → **80**.
- CLAUDE.md updated.

Tooling-only; `poe test` green at 88.15%. Frontend harness (the real gap) is the next PR.

Refs #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)