### PR TITLE
feat(admin): soft-delete visibility + restore/trash actions (#284)

### DIFF
--- a/catalogue/admin.py
+++ b/catalogue/admin.py
@@ -30,15 +30,43 @@ class RelatedResourceInline(admin.TabularInline):
 
 
 # Video Admin Configuration
+class TrashFilter(admin.SimpleListFilter):
+    """Filter the changelist by soft-delete state. Default (no selection) shows
+    BOTH live and trashed, so trashed rows are never silently hidden in admin."""
+
+    title = "trash status"
+    parameter_name = "trash"
+
+    def lookups(self, request, model_admin):
+        return (("live", "Live"), ("trashed", "Trashed"))
+
+    def queryset(self, request, queryset):
+        if self.value() == "live":
+            return queryset.filter(deleted_at__isnull=True)
+        if self.value() == "trashed":
+            return queryset.filter(deleted_at__isnull=False)
+        return queryset
+
+
 @admin.register(Video)
 class VideoAdmin(admin.ModelAdmin):
     """Admin configuration for Video model"""
 
-    list_display = ("name", "id_number", "channel", "series", "date_created", "is_livestream", "display_topic")
-    list_filter = ("is_livestream", "date_created", "channel", "series", "labels")
+    list_display = (
+        "name",
+        "id_number",
+        "channel",
+        "series",
+        "date_created",
+        "is_livestream",
+        "deleted_at",
+        "display_topic",
+    )
+    list_filter = (TrashFilter, "is_livestream", "date_created", "channel", "series", "labels")
     search_fields = ("name", "id_number", "description")
     ordering = ("-date_created",)
     date_hierarchy = "date_created"
+    actions = ("restore_selected", "trash_selected")
 
     inlines = (RelatedResourceInline,)
 
@@ -46,7 +74,7 @@ class VideoAdmin(admin.ModelAdmin):
     filter_horizontal = ("bible_book", "demographic", "ministry", "speaker", "topic")
 
     # Read-only fields
-    readonly_fields = ("date_modified",)
+    readonly_fields = ("date_modified", "deleted_at")
 
     # Custom fieldsets for better organization
     fieldsets = (
@@ -58,10 +86,32 @@ class VideoAdmin(admin.ModelAdmin):
         ),
         (
             "Dates & Status",
-            {"fields": ("is_livestream", "date_recorded", "date_created", "date_modified"), "classes": ("collapse",)},
+            {
+                "fields": ("is_livestream", "date_recorded", "date_created", "date_modified", "deleted_at"),
+                "classes": ("collapse",),
+            },
         ),
         ("Admin", {"fields": ("labels",), "classes": ("collapse",)}),
     )
+
+    def get_queryset(self, request):
+        # Use all_objects so soft-deleted (trashed) videos are visible/recoverable
+        # in admin — the default manager would hide them entirely.
+        return Video.all_objects.all()
+
+    @admin.action(description="Restore selected videos (clear trash)")
+    def restore_selected(self, request, queryset):
+        from app.studio import services
+
+        count = services.restore_videos([v.id for v in queryset])
+        self.message_user(request, f"Restored {count} video{'' if count == 1 else 's'}.")
+
+    @admin.action(description="Move selected videos to trash (soft delete)")
+    def trash_selected(self, request, queryset):
+        from app.studio import services
+
+        count = services.delete_videos([v.id for v in queryset.filter(deleted_at__isnull=True)])
+        self.message_user(request, f"Moved {count} video{'' if count == 1 else 's'} to trash.")
 
 
 # Series Admin Configuration

--- a/tests/test_admin_soft_delete.py
+++ b/tests/test_admin_soft_delete.py
@@ -1,0 +1,72 @@
+"""VideoAdmin soft-delete visibility + restore/trash actions (#284).
+
+Trashed videos must stay visible and recoverable in the Django admin — the
+default manager hides them, so VideoAdmin uses ``all_objects`` and provides
+restore/trash actions.
+"""
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
+
+from app.studio import services
+from catalogue.admin import VideoAdmin
+from catalogue.models.video import Video
+from tests.factories import VideoFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _request():
+    request = RequestFactory().post("/admin/catalogue/video/")
+    request.session = {}
+    request._messages = FallbackStorage(request)
+    return request
+
+
+def test_admin_queryset_includes_trashed():
+    video = VideoFactory()
+    services.delete_videos([video.id])  # soft delete
+    assert not Video.objects.filter(id=video.id).exists()  # hidden from default manager
+
+    admin = VideoAdmin(Video, AdminSite())
+    assert admin.get_queryset(_request()).filter(id=video.id).exists()  # visible in admin
+
+
+def test_admin_restore_action_recovers_a_trashed_video():
+    video = VideoFactory()
+    services.delete_videos([video.id])
+
+    admin = VideoAdmin(Video, AdminSite())
+    admin.restore_selected(_request(), Video.all_objects.filter(id=video.id))
+
+    assert Video.objects.filter(id=video.id).exists()  # back in the default manager
+
+
+def test_admin_trash_action_soft_deletes():
+    video = VideoFactory()
+    admin = VideoAdmin(Video, AdminSite())
+    admin.trash_selected(_request(), Video.all_objects.filter(id=video.id))
+
+    assert not Video.objects.filter(id=video.id).exists()
+    assert Video.all_objects.get(id=video.id).deleted_at is not None
+
+
+def test_admin_changelist_renders_with_trash_filter(client, django_user_model):
+    """The real admin ChangeList (custom filter + all_objects queryset) must
+    render without error, and the Trashed filter must surface trashed rows."""
+    django_user_model.objects.create_superuser("boss", "boss@example.com", "pw-xyz-1")  # gitleaks:allow
+    client.login(username="boss", password="pw-xyz-1")  # gitleaks:allow
+    VideoFactory(name="Live talk")
+    gone = VideoFactory(name="Trashed talk")
+    services.delete_videos([gone.id])
+
+    all_rows = client.get("/admin/catalogue/video/")
+    assert all_rows.status_code == 200
+    assert b"Live talk" in all_rows.content and b"Trashed talk" in all_rows.content  # both shown by default
+
+    trashed_only = client.get("/admin/catalogue/video/?trash=trashed")
+    assert trashed_only.status_code == 200
+    assert b"Trashed talk" in trashed_only.content
+    assert b"Live talk" not in trashed_only.content


### PR DESCRIPTION
Closes the recovery hole from Slice 4b: soft-deleted videos were invisible to admins (recovery was shell-only).

- `VideoAdmin.get_queryset` → `all_objects` (trashed rows visible).
- **Trash-status filter** (default shows live + trashed; `?trash=trashed` narrows), `deleted_at` in the list + detail.
- **Restore** / **Move-to-trash** bulk actions, reusing `services.restore_videos` / `delete_videos` so search re-indexing stays single-sourced.

Tests (4): queryset includes trashed, restore + trash actions, and the **real admin ChangeList renders 200** with the filter. Django-admin backend (break-glass), so the integration test is the verification rather than a superuser browser run.

Closes #284.

🤖 Generated with [Claude Code](https://claude.com/claude-code)