### PR TITLE
chore(techdebt): guard destructive importers (#286) + refresh stale docs (#289)

### DIFF
--- a/catalogue/management/commands/_destructive.py
+++ b/catalogue/management/commands/_destructive.py
@@ -1,0 +1,28 @@
+"""Guard for the legacy delete-all-then-reload CSV importers.
+
+These commands wipe a table before reloading from CSV — they exist only to seed
+a **local** dev database (SQLite). Epic 2 replaced ingestion on real databases
+with idempotent upserts (`catalogue/ingest/`, `sync_live_admin`). This guard
+stops anyone pointing the destructive importers at beta/prod (Postgres).
+
+Underscore-prefixed so Django's command discovery ignores it (not a command).
+"""
+
+import os
+
+from django.core.management.base import CommandError
+from django.db import connection
+
+
+def guard_destructive():
+    """Raise unless it's safe to wipe-and-reload: a SQLite (local) database, or
+    an explicit ``ALLOW_DESTRUCTIVE_IMPORT=1`` override for the rare deliberate case."""
+    engine = connection.settings_dict.get("ENGINE", "")
+    if "sqlite" in engine or os.getenv("ALLOW_DESTRUCTIVE_IMPORT") == "1":
+        return
+    raise CommandError(
+        f"Refusing to run a destructive (delete-all-then-reload) importer against a "
+        f"non-SQLite database ({engine or 'unknown'}). These are local-seed-only; on real "
+        f"databases use the Epic 2 upsert importers (ingest_legacy_dump / sync_live_admin). "
+        f"Set ALLOW_DESTRUCTIVE_IMPORT=1 if you genuinely intend to wipe this database."
+    )

--- a/catalogue/management/commands/import_bible_books.py
+++ b/catalogue/management/commands/import_bible_books.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
+from catalogue.management.commands._destructive import guard_destructive
 from catalogue.models.bible_book import BibleBook  # Updated to use the new class name
 
 
@@ -24,6 +25,7 @@ class Command(BaseCommand):
     def imp_bible(self, filepath, debug):
         if debug:
             self.stdout.write("The command ran and:")  # Debug Text using logger instead of print
+        guard_destructive()  # local-seed-only; refuse on non-SQLite
         BibleBook.objects.all().delete()  # Clears all existing data before reimporting
         # This is useful but potentially dangerous
         with Path(filepath).open(encoding="utf-8-sig") as file:  # Opens the file path using Path

--- a/catalogue/management/commands/import_demographics.py
+++ b/catalogue/management/commands/import_demographics.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
+from catalogue.management.commands._destructive import guard_destructive
 from catalogue.models.demograpic import Demographic
 
 csv.field_size_limit(sys.maxsize)
@@ -25,6 +26,7 @@ class Command(BaseCommand):
     def imp_demographics(self, filepath, debug):
         if debug:
             self.stdout.write("The command ran and:")  # Debug Text
+        guard_destructive()  # local-seed-only; refuse on non-SQLite
         Demographic.objects.all().delete()
         with Path(filepath).open(encoding="utf-8-sig") as file:
             reader = csv.DictReader(file)

--- a/catalogue/management/commands/import_ministries.py
+++ b/catalogue/management/commands/import_ministries.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
+from catalogue.management.commands._destructive import guard_destructive
 from catalogue.models.ministry import Ministry
 
 
@@ -22,6 +23,7 @@ class Command(BaseCommand):
     def imp_ministries(self, filepath, debug):
         if debug:
             self.stdout.write("The command ran and:")  # Debug Text
+        guard_destructive()  # local-seed-only; refuse on non-SQLite
         Ministry.objects.all().delete()
         with Path(filepath).open(encoding="utf-8-sig") as file:
             reader = csv.DictReader(file)

--- a/catalogue/management/commands/import_series.py
+++ b/catalogue/management/commands/import_series.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
+from catalogue.management.commands._destructive import guard_destructive
 from catalogue.models.series import Series
 
 
@@ -22,6 +23,7 @@ class Command(BaseCommand):
     def imp_series(self, filepath, debug):
         if debug:
             self.stdout.write("The command ran and:")  # Debug Text
+        guard_destructive()  # local-seed-only; refuse on non-SQLite
         Series.objects.all().delete()
         with Path(filepath).open(encoding="utf-8-sig") as file:
             reader = csv.DictReader(file)

--- a/catalogue/management/commands/import_speakers.py
+++ b/catalogue/management/commands/import_speakers.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
+from catalogue.management.commands._destructive import guard_destructive
 from catalogue.models.speaker import Speaker
 
 
@@ -22,6 +23,7 @@ class Command(BaseCommand):
     def imp_speakers(self, filepath, debug):
         if debug:
             self.stdout.write("The command ran and:")  # Debug Text
+        guard_destructive()  # local-seed-only; refuse on non-SQLite
         Speaker.objects.all().delete()
         with Path(filepath).open(encoding="utf-8-sig") as file:
             reader = csv.DictReader(file)

--- a/catalogue/management/commands/import_topics.py
+++ b/catalogue/management/commands/import_topics.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
+from catalogue.management.commands._destructive import guard_destructive
 from catalogue.models.topic import Topic
 
 
@@ -22,6 +23,7 @@ class Command(BaseCommand):
     def imp_topics(self, filepath, debug):
         if debug:
             self.stdout.write("The command ran and:")  # Debug Text
+        guard_destructive()  # local-seed-only; refuse on non-SQLite
         Topic.objects.all().delete()
         last_name = ""
         # id_num = 0

--- a/catalogue/management/commands/import_videos.py
+++ b/catalogue/management/commands/import_videos.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from django.core.management.base import BaseCommand
 
+from catalogue.management.commands._destructive import guard_destructive
 from catalogue.models.video import Video
 
 
@@ -61,6 +62,7 @@ class Command(BaseCommand):
         skipped_ids = []
         if debug:
             self.stdout.write("The command ran and:")  # Debug Text
+        guard_destructive()  # local-seed-only; refuse on non-SQLite
         Video.objects.all().delete()
         with Path(filepath).open(encoding="utf-8-sig") as file:
             reader = csv.DictReader(file)

--- a/docs/CREATOR_UI_RESEARCH.md
+++ b/docs/CREATOR_UI_RESEARCH.md
@@ -1,5 +1,10 @@
 # Creator / Editor UI — Design Research
 
+> **Status (2026-06-15): SHIPPED.** This research drove Epic 3 (the Studio),
+> now built and live on beta — Library, Add-a-video, full editor, Review queue +
+> soft-delete, and bulk add. Read as the design rationale, not pending work.
+> Directions B (contributors) and C (tenancy) remain deferred by design.
+
 *Drafted 2026-06-14 (Jamie + agent). Feeds the MVP2 implementation plan: "close
 the old site." Opinionated and concrete to our stack — not a survey.*
 

--- a/docs/MASTER_PLAN.md
+++ b/docs/MASTER_PLAN.md
@@ -5,6 +5,23 @@
 
 ## 0. Current status — update every session
 
+**As of 2026-06-15 — Epic 3 (the Studio) SHIPPED; interim tech-debt phase.**
+The "▶️ NEXT: Epic 3" lines further down are now superseded — Epic 3 is built
+and live on beta. Slices delivered: `Video.status` + draft-hiding on all public
+surfaces; auth (Editors group, custom `/studio/login`, logout, account menu in
+the header); the Studio Library (filter/search/bulk); Add-a-video (paste-a-URL
+intake); the full tabbed editor; the Review queue + **Laravel-style soft-delete**
+(recoverable, with an admin restore UI); and **bulk add** (paste-many + YouTube
+playlist import). A cross-cutting fix along the way: aligned Django's CSRF
+cookie/header names to Inertia's (every Studio POST was otherwise 403'd in the
+browser). Slice 6 (taxonomy merge) is an exploration doc only — `docs/STUDIO_TAXONOMY.md`.
+
+Now in an **interim tech-debt paydown** before new features — full register at
+GH #290 (Must/Should/Could/Won't). Remaining big rocks: **Epic 7
+(hardening + cutover)**, tracked as a live checklist at #287.
+
+---
+
 **As of 2026-06-13 (late) — Functionality Overhaul COMPLETE; Epic 5 (search) shipped.**
 Beta is feature-complete on the core product; remaining work is editorial auth
 (Epic 3) and the hardening/cutover runbook (Epic 7).

--- a/tests/test_destructive_guard.py
+++ b/tests/test_destructive_guard.py
@@ -1,0 +1,27 @@
+"""The destructive-importer guard (#286): the delete-all-then-reload CSV
+importers must refuse to run against a non-SQLite (i.e. beta/prod) database."""
+
+import pytest
+from django.core.management.base import CommandError
+from django.db import connection
+
+from catalogue.management.commands._destructive import guard_destructive
+
+pytestmark = pytest.mark.django_db
+
+
+def test_guard_allows_sqlite():
+    # The test database is SQLite — the guard should pass silently.
+    guard_destructive()
+
+
+def test_guard_blocks_non_sqlite(monkeypatch):
+    monkeypatch.setitem(connection.settings_dict, "ENGINE", "django.db.backends.postgresql")
+    with pytest.raises(CommandError):
+        guard_destructive()
+
+
+def test_guard_env_override(monkeypatch):
+    monkeypatch.setitem(connection.settings_dict, "ENGINE", "django.db.backends.postgresql")
+    monkeypatch.setenv("ALLOW_DESTRUCTIVE_IMPORT", "1")
+    guard_destructive()  # explicit override → no raise


### PR DESCRIPTION
Two low-risk paydown items.

**#286 — guard the destructive CSV importers.** The delete-all-then-reload `import_*` commands now call `guard_destructive()` at each delete chokepoint, which **refuses to run against a non-SQLite database** (escape hatch: `ALLOW_DESTRUCTIVE_IMPORT=1`). They're local-seed-only; Epic 2's upsert importers (`ingest_legacy_dump`, `sync_live_admin`) own real databases. Closes #286.

**#289 — refresh stale planning docs.** Added a current-status banner to `MASTER_PLAN.md` and a 'SHIPPED' header to `CREATOR_UI_RESEARCH.md` so they stop describing Epic 3 (the Studio) as 'next' — it's built and live — and point at the register (#290) + cutover checklist (#287). (Leaving #289 open for the fuller line-by-line pass + DEPLOYMENT updates.)

Tests: 3 for the guard (allow SQLite / block Postgres / env override). Full suite 338 green at 88%.

Closes #286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)