### PR TITLE
feat(data): normalize_topics — clean names + merge duplicates (#288)

### DIFF
--- a/catalogue/management/commands/normalize_topics.py
+++ b/catalogue/management/commands/normalize_topics.py
@@ -1,0 +1,66 @@
+"""Clean existing Topic names and merge the duplicates that cleaning reveals.
+
+The ingest cleaners (`clean_topic_name`) already normalise *new* data, but rows
+imported before them keep depth-prefix / mojibake names (e.g. a triple
+minus-sign prefix on "The Grace of God"). Re-cleaning some names makes them identical
+to an already-clean topic — those are merged **deterministically** (no judgment):
+videos are re-pointed via the `Video.topic` M2M to the topic with the most
+videos, then the now-empty duplicate is deleted.
+
+Idempotent — a second run is a no-op. Safe to re-run after deploys until the
+Epic 2 importer rework owns this. Genuine typo dups that differ by *case*
+("Christian Life" vs "Christian LIfe") are NOT touched here — those need human
+judgment (the Slice 6 taxonomy-merge tool, docs/STUDIO_TAXONOMY.md).
+"""
+
+from collections import defaultdict
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Count
+
+from catalogue.ingest.normalize import clean_topic_name
+from catalogue.models.topic import Topic
+
+
+class Command(BaseCommand):
+    help = "Clean topic names (depth/mojibake prefixes) and merge the duplicates that reveals. Idempotent."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--dry-run", action="store_true", help="Report what would change without writing.")
+
+    def handle(self, *args, dry_run=False, **options):
+        groups = defaultdict(list)
+        for topic in Topic.objects.annotate(video_total=Count("video")):
+            key = clean_topic_name(topic.name)
+            if key:  # never collapse a name to empty
+                groups[key].append(topic)
+
+        renamed = merged = 0
+        for clean, topics in groups.items():
+            topics.sort(key=lambda t: t.video_total, reverse=True)
+            canonical, *losers = topics
+
+            if canonical.name != clean:
+                self.stdout.write(f"rename: {canonical.name!r} -> {clean!r}")
+                renamed += 1
+                if not dry_run:
+                    canonical.name = clean
+                    canonical.save()
+
+            for loser in losers:
+                self.stdout.write(f"merge:  {loser.name!r} ({loser.video_total} videos) -> {clean!r}")
+                merged += 1
+                if not dry_run:
+                    with transaction.atomic():
+                        videos = list(loser.video_set.all())
+                        for video in videos:
+                            video.topic.add(canonical)
+                        loser.delete()
+                        # M2M writes don't fire post_save — re-save each moved video
+                        # so its search doc reflects the canonical topic.
+                        for video in videos:
+                            video.save()
+
+        verb = "would " if dry_run else ""
+        self.stdout.write(self.style.SUCCESS(f"Done: {verb}rename {renamed}, {verb}merge {merged}."))

--- a/tests/test_normalize_topics.py
+++ b/tests/test_normalize_topics.py
@@ -1,0 +1,73 @@
+"""normalize_topics command (#288): clean topic names + deterministic merge."""
+
+import pytest
+from django.core.management import call_command
+
+from catalogue.models.topic import Topic
+from tests.factories import TopicFactory, VideoFactory
+
+pytestmark = pytest.mark.django_db
+
+# Real legacy prefix: U+2212 MINUS (UTF-8 E2 88 92) misdecoded as Latin-1
+# -> U+00E2 U+0088 U+0092, three deep.
+MOJIBAKE = "\u00e2\u0088\u0092" * 3 + " The Grace of God"
+
+
+def test_merges_mojibake_duplicate_into_clean_topic():
+    clean = TopicFactory(name="The Grace of God")
+    dirty = TopicFactory(name=MOJIBAKE)
+    v1 = VideoFactory()
+    v2 = VideoFactory()
+    v1.topic.add(clean)
+    v2.topic.add(dirty)
+
+    call_command("normalize_topics")
+
+    remaining = Topic.objects.filter(name="The Grace of God")
+    assert remaining.count() == 1
+    assert not Topic.objects.filter(name=MOJIBAKE).exists()
+    # the duplicate's video was re-pointed to the surviving topic
+    assert set(remaining.first().video_set.values_list("id", flat=True)) == {v1.id, v2.id}
+
+
+def test_renames_a_lone_dirty_topic_without_merging():
+    TopicFactory(name=MOJIBAKE)
+    call_command("normalize_topics")
+    assert Topic.objects.filter(name="The Grace of God").exists()
+    assert not Topic.objects.filter(name=MOJIBAKE).exists()
+
+
+def test_keeps_canonical_with_more_videos():
+    big = TopicFactory(name="The Grace of God")
+    small = TopicFactory(name=MOJIBAKE)
+    for _ in range(3):
+        VideoFactory().topic.add(big)
+    VideoFactory().topic.add(small)
+
+    call_command("normalize_topics")
+    survivor = Topic.objects.get(name="The Grace of God")
+    assert survivor.id == big.id  # kept the higher-video-count row
+    assert survivor.video_set.count() == 4
+
+
+def test_dry_run_changes_nothing():
+    TopicFactory(name=MOJIBAKE)
+    call_command("normalize_topics", "--dry-run")
+    assert Topic.objects.filter(name=MOJIBAKE).exists()
+
+
+def test_idempotent():
+    TopicFactory(name="The Grace of God")
+    TopicFactory(name=MOJIBAKE)
+    call_command("normalize_topics")
+    call_command("normalize_topics")  # second run is a no-op, must not error
+    assert Topic.objects.filter(name="The Grace of God").count() == 1
+
+
+def test_case_only_duplicates_are_left_alone():
+    # Differs by case, not whitespace/prefix → human judgment (Slice 6), not us.
+    TopicFactory(name="Christian Life")
+    TopicFactory(name="Christian LIfe")
+    call_command("normalize_topics")
+    assert Topic.objects.filter(name="Christian Life").exists()
+    assert Topic.objects.filter(name="Christian LIfe").exists()


### PR DESCRIPTION
Part of #288 (data-quality normalization).

The ingest cleaners already normalise *new* data; this idempotent command fixes **existing** rows: re-cleans Topic names (strips legacy depth/mojibake prefixes) and **merges the duplicates that reveals** — re-pointing videos via the `Video.topic` M2M to the topic with the most videos, deleting the empty dup, and re-saving moved videos so search stays correct. `--dry-run` supported.

**Deterministic only.** Case-differing typos ("Christian Life" vs "Christian LIfe") are left for the Slice 6 taxonomy-merge tool (human judgment). The ~1,070 messy series `year_start`/`year_end` values are ambiguous (e.g. `'16-'`) and the series page already guards display — **deferred** (noted on #288).

Verified on local seeded data: 139→138 topics, the mojibake `The Grace of God` merged into the clean one, re-run is a no-op. 6 tests; full suite 344 green.

**Deploy note:** this is a data command — after deploy it should be **run once on beta** (`manage.py normalize_topics`, a confirmed DB write) to clean the live rows. Idempotent + `--dry-run` available.

Refs #288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)