### PR TITLE
feat(cutover): 301 legacy clayton.tv watch URLs → /video/<id>

### DIFF
--- a/app/legacy_redirects.py
+++ b/app/legacy_redirects.py
@@ -1,0 +1,28 @@
+"""301 redirects from legacy clayton.tv URLs to the new routes — for cutover.
+
+When the legacy site is switched off and clayton.tv points here, old inbound
+links (bookmarks, search engines, the 100+ in-description links) must not break.
+The dying site's watch URLs all end in ``.../0i0/<programme_id>/``:
+
+    /new/0i0/<id>/
+    /find/explore/<category-path>/0i0/<id>/
+    /schedule/0i0/<id>
+
+Our ``Video.id`` *is* that legacy programme id (the importer keyed off it), so
+we 301 to ``/video/<id>`` when the programme is publicly available — and 404
+otherwise (never 301 to the wrong content, which would mislead search engines).
+"""
+
+from django.http import Http404
+from django.shortcuts import redirect
+from django.urls import reverse
+
+from catalogue.models.video import Video
+
+
+def legacy_video_redirect(request, pid):
+    """301 a legacy ``…/0i0/<pid>/`` watch URL to ``/video/<pid>``, or 404 if no
+    public video has that id (draft / trashed / unknown all 404)."""
+    if not Video.objects.published().filter(id=str(pid)).exists():
+        raise Http404
+    return redirect(reverse("video", args=[int(pid)]), permanent=True)

--- a/app/urls.py
+++ b/app/urls.py
@@ -16,8 +16,10 @@ Including another URLconf
 """
 
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
 from django.views.generic import RedirectView
+
+from app.legacy_redirects import legacy_video_redirect
 
 from .views import (
     audiences_index,
@@ -57,6 +59,12 @@ urlpatterns = [
     path("api/palette", palette, name="palette"),
     path("api/video/<int:id>/next", video_next, name="video_next"),
     path("video/<int:id>", video, name="video"),
+    # Legacy clayton.tv watch URLs (…/0i0/<id>/) → 301 to /video/<id>, for cutover.
+    re_path(
+        r"^(?:new|find|schedule)/.*?0i0/(?P<pid>\d+)/?$",
+        legacy_video_redirect,
+        name="legacy_video_redirect",
+    ),
     path("book/<str:id>", browse_bible_book, name="browse_bible_book"),
     path("channel/<str:id>", browse_channel, name="browse_channel"),
     path("audience/", audiences_index, name="audiences_index"),

--- a/tests/test_legacy_redirects.py
+++ b/tests/test_legacy_redirects.py
@@ -1,0 +1,53 @@
+"""Legacy clayton.tv URL → new-route 301 redirects (cutover safety).
+
+The dying site's watch URLs end in `.../0i0/<programme_id>/`; our Video.id is
+that id, so they 301 to /video/<id> when the programme is public, else 404.
+"""
+
+import pytest
+
+from catalogue.models.video import DRAFT
+from tests.factories import VideoFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    "legacy_path",
+    [
+        "/new/0i0/{id}/",
+        "/find/explore/475-1503/0i0/{id}/",
+        "/find/explore/475-1477-1488/0i0/{id}/",
+        "/schedule/0i0/{id}",  # no trailing slash
+        "/new/0i0/{id}",  # tolerate missing trailing slash
+    ],
+)
+def test_legacy_watch_urls_301_to_video(client, legacy_path):
+    video = VideoFactory()  # published + alive by default
+    resp = client.get(legacy_path.format(id=video.id))
+    assert resp.status_code == 301
+    assert resp.headers["Location"] == f"/video/{video.id}"
+
+
+def test_unknown_id_404s(client):
+    resp = client.get("/new/0i0/9999999/")
+    assert resp.status_code == 404
+
+
+def test_draft_is_not_redirected(client):
+    video = VideoFactory(status=DRAFT)
+    assert client.get(f"/new/0i0/{video.id}/").status_code == 404
+
+
+def test_trashed_is_not_redirected(client):
+    from app.studio import services
+
+    video = VideoFactory()
+    services.delete_videos([video.id])  # soft delete
+    assert client.get(f"/new/0i0/{video.id}/").status_code == 404
+
+
+def test_real_video_routes_are_not_shadowed(client):
+    # The redirect pattern must only catch the legacy shapes, not real routes.
+    video = VideoFactory()
+    assert client.get(f"/video/{video.id}").status_code == 200


### PR DESCRIPTION
Cutover safety (part of #287). When clayton.tv DNS points here, old inbound links (bookmarks, search engines, the 100+ in-description links) must keep working.

**Legacy scheme** (confirmed empirically from in-description links in the catalogue): watch URLs all end in `.../0i0/<programme_id>/` — `/new/0i0/<id>/`, `/find/explore/<cats>/0i0/<id>/`, `/schedule/0i0/<id>`. Our `Video.id` **is** that legacy programme id, so a single `re_path` 301s them to `/video/<id>` when the programme is public — and **404s** for draft/trashed/unknown (never 301 to wrong content, which would mislead search engines).

Tests (9): all three URL shapes + trailing-slash-optional → 301; unknown/draft/trashed → 404; real `/video` routes not shadowed. Server-side 301, so the integration tests are the verification. Full suite 353 green.

Refs #287.

🤖 Generated with [Claude Code](https://claude.com/claude-code)