### PR TITLE
feat(studio): editor manages number_in_series

### DIFF
--- a/resources/js/pages/Studio/EditVideo.vue
+++ b/resources/js/pages/Studio/EditVideo.vue
@@ -225,6 +225,18 @@ onBeforeUnmount(() => {
                             {{ form.duration_seconds ? formatDuration(form.duration_seconds) : '—' }}
                         </p>
                     </div>
+                    <div class="space-y-1.5">
+                        <label for="edit-number" class="text-foreground block text-sm font-medium">Number in series</label>
+                        <Input
+                            id="edit-number"
+                            :model-value="form.number_in_series ?? undefined"
+                            @update:model-value="(val) => (form.number_in_series = val === '' || val == null ? null : Number(val))"
+                            type="number"
+                            min="1"
+                            class="text-base"
+                        />
+                        <p class="text-muted-foreground text-xs">Episode position, for ordering within a series.</p>
+                    </div>
                 </div>
                 <div class="space-y-1.5">
                     <label for="edit-thumbnail" class="text-foreground block text-sm font-medium">Thumbnail URL</label>

--- a/tests/test_studio_editor.py
+++ b/tests/test_studio_editor.py
@@ -118,6 +118,13 @@ def test_update_changes_scalar_fields():
     assert video.duration_seconds == 123
 
 
+def test_update_sets_number_in_series():
+    video = VideoFactory(number_in_series=None)
+    services.update_video(video.id, name=video.name, url=video.url, number_in_series=7)
+    video.refresh_from_db()
+    assert video.number_in_series == 7
+
+
 def test_update_adds_and_removes_m2m():
     keep = SpeakerFactory()
     drop = SpeakerFactory()


### PR DESCRIPTION
Adds the one editor-relevant field the editor was omitting — **Number in series** (episode position; 8,524 videos use it). Backend already accepted it (Slice 4a); this adds the input (with null↔empty coercion for the typed Input) + a persistence test. Verified in-browser: set to 5 → saved.

`channel`/`labels` deliberately **not** surfaced — both are 0-row unused legacy fields (`labels` has no name) and are better removal candidates than editor UI (noted on #290).

🤖 Generated with [Claude Code](https://claude.com/claude-code)