### PR TITLE
test(frontend): cover embeds, csrf, player-dock (#283)

### DIFF
--- a/resources/js/composables/usePlayerDock.spec.ts
+++ b/resources/js/composables/usePlayerDock.spec.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { usePlayerDock } from '~/composables/usePlayerDock';
+
+const VIDEO = { id: 1, name: 'A talk', url: 'https://youtu.be/abc' };
+
+beforeEach(() => {
+    usePlayerDock().close();
+    localStorage.clear();
+});
+
+describe('usePlayerDock', () => {
+    it('loads a video into the dock (mini mode when no placeholder)', () => {
+        const dock = usePlayerDock();
+        const changed = dock.load(VIDEO);
+        expect(changed).toBe(true);
+        expect(dock.current.value?.id).toBe(1);
+        expect(dock.mode.value).toBe('mini');
+    });
+
+    it('is a no-op when loading the already-playing video', () => {
+        const dock = usePlayerDock();
+        dock.load(VIDEO);
+        expect(dock.load(VIDEO)).toBe(false); // same id → seamless, no reload
+    });
+
+    it('close() clears the dock to hidden', () => {
+        const dock = usePlayerDock();
+        dock.load(VIDEO);
+        dock.close();
+        expect(dock.current.value).toBeNull();
+        expect(dock.mode.value).toBe('hidden');
+    });
+
+    it('restore() rehydrates the last-played video from localStorage', () => {
+        localStorage.setItem('ctv:active-player', JSON.stringify({ id: 9, name: 'Saved', url: 'https://youtu.be/xyz', position: 42 }));
+        const dock = usePlayerDock();
+        dock.restore();
+        expect(dock.current.value?.id).toBe(9);
+        expect(dock.position.value).toBe(42);
+    });
+});

--- a/resources/js/lib/csrf.spec.ts
+++ b/resources/js/lib/csrf.spec.ts
@@ -1,0 +1,27 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getCsrfToken } from '~/lib/csrf';
+
+function setCookie(value: string) {
+    document.cookie = `XSRF-TOKEN=${value}`;
+}
+
+afterEach(() => {
+    // expire the cookie between tests
+    document.cookie = 'XSRF-TOKEN=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+});
+
+describe('getCsrfToken', () => {
+    it('reads the XSRF-TOKEN cookie', () => {
+        setCookie('tok-123');
+        expect(getCsrfToken()).toBe('tok-123');
+    });
+
+    it('URL-decodes the value', () => {
+        setCookie('a%2Bb');
+        expect(getCsrfToken()).toBe('a+b');
+    });
+
+    it('returns empty string when the cookie is absent', () => {
+        expect(getCsrfToken()).toBe('');
+    });
+});

--- a/resources/js/lib/embeds.spec.ts
+++ b/resources/js/lib/embeds.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { detectProvider, getEmbedUrl, getYoutubeId } from '~/lib/embeds';
+
+describe('getYoutubeId', () => {
+    it('extracts the id from common YouTube URL shapes', () => {
+        expect(getYoutubeId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+        expect(getYoutubeId('https://youtu.be/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+        expect(getYoutubeId('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
+    });
+
+    it('returns undefined for non-YouTube URLs', () => {
+        expect(getYoutubeId('https://vimeo.com/76979871')).toBeUndefined();
+        expect(getYoutubeId('https://example.com')).toBeUndefined();
+    });
+});
+
+describe('detectProvider', () => {
+    it('classifies YouTube, Vimeo, and neither', () => {
+        expect(detectProvider('https://youtu.be/abc')).toBe('youtube');
+        expect(detectProvider('https://vimeo.com/123')).toBe('vimeo');
+        expect(detectProvider('https://example.com/x')).toBeNull();
+    });
+});
+
+describe('getEmbedUrl', () => {
+    it('builds a privacy-domain YouTube embed, honouring start', () => {
+        const url = getEmbedUrl('https://www.youtube.com/watch?v=abc123', { start: 90 });
+        expect(url).toContain('youtube-nocookie.com/embed/abc123');
+        expect(url).toContain('start=90');
+    });
+
+    it('builds a Vimeo embed, carrying the privacy hash and start fragment', () => {
+        const url = getEmbedUrl('https://vimeo.com/76979871/abcdef', { start: 30 });
+        expect(url).toContain('player.vimeo.com/video/76979871');
+        expect(url).toContain('h=abcdef');
+        expect(url).toContain('#t=30s');
+    });
+
+    it('returns false for an unsupported URL', () => {
+        expect(getEmbedUrl('https://example.com/not-a-video')).toBe(false);
+    });
+});


### PR DESCRIPTION
Grows the Vitest net **9 → 22** onto the highest-value logic that would break silently: `getEmbedUrl`/`getYoutubeId`/`detectProvider` (all playback + editor preview + bulk-add detection), `getCsrfToken`, and `usePlayerDock` load/close/restore. Tests-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)