### PR TITLE
feat(enrichment): E3 — editor suggestions pre-fill (#201)

### DIFF
--- a/app/cards.py
+++ b/app/cards.py
@@ -60,4 +60,22 @@ def video_edit_props(video):
         "ministry_ids": [str(m.pk) for m in video.ministry.all()],
         "series_id": str(series_id) if series_id is not None else None,
         "related_resources": [{"kind": r.kind, "url": r.url} for r in video.related_resources.order_by("kind")],
+        "enrichment": enrichment_props(video),
+    }
+
+
+def enrichment_props(video):
+    """The stored AI suggestions for a video as a plain dict, or ``None`` when
+    there's no enrichment. Drives the editor's Suggestions panel (Epic #201, E3)
+    — display + per-field apply; never auto-applied to human fields."""
+    enrichment = getattr(video, "enrichment", None)
+    if enrichment is None:
+        return None
+    return {
+        "summary": enrichment.summary or "",
+        "topics": enrichment.topics or [],
+        "audience": enrichment.audience or "",
+        "bible_passages": enrichment.bible_passages or [],
+        "keywords": enrichment.keywords or [],
+        "generated_at": enrichment.generated_at.isoformat() if enrichment.generated_at else None,
     }

--- a/app/studio/services.py
+++ b/app/studio/services.py
@@ -243,7 +243,7 @@ def taxonomy_options():
         "speakers": _options(Speaker),
         "series": _options(Series),
         "topics": _options(Topic),
-        "bible_books": _options(Bible_Book),
+        "bible_books": _bible_book_options(),
         "demographics": _options(Demographic),
         "ministries": _options(Ministry),
     }
@@ -251,6 +251,13 @@ def taxonomy_options():
 
 def _options(model):
     return [{"id": str(pk), "name": name} for pk, name in model.objects.order_by("name").values_list("pk", "name")]
+
+
+def _bible_book_options():
+    """Bible books, named by their human display ("Genesis", not the stored
+    "GEN" code) so the picker — and the suggestions matcher — use real names."""
+    books = Bible_Book.objects.order_by("name")
+    return sorted(({"id": str(b.pk), "name": b.get_name_display()} for b in books), key=lambda o: o["name"])
 
 
 def create_video(
@@ -419,6 +426,7 @@ def get_video_for_edit(video_id):
     """The full editable view of one video (plain dict), or None if missing."""
     video = (
         Video.objects.filter(id=video_id)
+        .select_related("enrichment")
         .prefetch_related("speaker", "topic", "bible_book", "demographic", "ministry", "related_resources")
         .first()
     )

--- a/app/studio/urls.py
+++ b/app/studio/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     # Editor (Slice 4a).
     path("videos/<str:id>/edit", views.edit_video, name="studio_edit_video"),
     path("videos/<str:id>/update", views.update_video, name="studio_update_video"),
+    path("videos/<str:id>/suggest", views.suggest_video, name="studio_suggest_video"),
     # Library mutations (all @studio_required + POST + CSRF).
     path("videos/create", views.create_video, name="studio_create_video"),
     path("videos/bulk-status", views.bulk_status, name="studio_bulk_status"),

--- a/app/studio/views.py
+++ b/app/studio/views.py
@@ -20,7 +20,7 @@ from inertia import render, share
 
 from app.auth import can_edit_content
 from catalogue.metadata import MetadataError, fetch_metadata
-from catalogue.models.video import DRAFT, PUBLISHED
+from catalogue.models.video import DRAFT, PUBLISHED, Video
 
 from . import services
 from .auth import studio_required
@@ -433,3 +433,23 @@ def update_video(request, id):
         raise Http404
     messages.success(request, "Saved.")
     return redirect("/studio")
+
+
+@studio_required
+@require_POST
+def suggest_video(request, id):
+    """``POST /studio/videos/<id>/suggest`` — (re)generate AI suggestions for one
+    video and redirect back to the editor (Inertia reloads the props, so the
+    Suggestions panel refreshes). Best-effort: if the model is unreachable, flash
+    a friendly note rather than erroring."""
+    from catalogue.enrichment import store_enrichment
+
+    video = Video.all_objects.filter(id=id).first()
+    if video is None:
+        raise Http404
+    enrichment = store_enrichment(video)
+    if enrichment is None:
+        messages.warning(request, "Couldn't generate suggestions just now — please try again shortly.")
+    else:
+        messages.success(request, "Suggestions updated.")
+    return redirect("studio_edit_video", id=id)

--- a/resources/js/components/molecules/SuggestionsPanel.spec.ts
+++ b/resources/js/components/molecules/SuggestionsPanel.spec.ts
@@ -1,0 +1,87 @@
+import SuggestionsPanel from '@/molecules/SuggestionsPanel.vue';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+const taxonomy = {
+    topics: [{ id: 't1', name: 'Grace' }],
+    demographics: [{ id: 'd1', name: 'Adults' }],
+    bible_books: [{ id: 'b1', name: 'Romans' }],
+};
+
+const enrichment = {
+    summary: 'A sermon on grace.',
+    topics: ['Grace', 'Unknown topic'],
+    audience: 'Adults',
+    bible_passages: [{ book: 'Romans', label: 'Romans 8' }],
+    keywords: ['grace', 'adoption'],
+    generated_at: '2026-06-15T10:00:00Z',
+};
+
+function clickButton(wrapper: ReturnType<typeof mount>, text: string) {
+    const btn = wrapper.findAll('button').find((b) => b.text().includes(text));
+    if (!btn) throw new Error(`No button matching "${text}". Buttons: ${wrapper.findAll('button').map((b) => b.text())}`);
+    return btn.trigger('click');
+}
+
+describe('SuggestionsPanel', () => {
+    it('shows an empty state with a generate action when there is no enrichment', () => {
+        const wrapper = mount(SuggestionsPanel, { props: { enrichment: null, taxonomy } });
+        expect(wrapper.text()).toContain('No suggestions yet');
+        expect(wrapper.findAll('button').some((b) => b.text().includes('Generate suggestions'))).toBe(true);
+    });
+
+    it('renders the stored suggestions', () => {
+        const wrapper = mount(SuggestionsPanel, { props: { enrichment, taxonomy } });
+        expect(wrapper.text()).toContain('A sermon on grace.');
+        expect(wrapper.text()).toContain('Grace');
+        expect(wrapper.text()).toContain('Romans 8');
+        expect(wrapper.text()).toContain('adoption'); // a keyword
+    });
+
+    it('is not branded as AI', () => {
+        const wrapper = mount(SuggestionsPanel, { props: { enrichment, taxonomy } });
+        expect(wrapper.text()).not.toMatch(/\bAI\b/);
+        expect(wrapper.text()).not.toContain('✨');
+    });
+
+    it('emits the summary as a description', async () => {
+        const wrapper = mount(SuggestionsPanel, { props: { enrichment, taxonomy } });
+        await clickButton(wrapper, 'Use as description');
+        expect(wrapper.emitted('apply')?.[0]).toEqual([{ description: 'A sermon on grace.' }]);
+    });
+
+    it('applies only topics that match existing taxonomy', async () => {
+        const wrapper = mount(SuggestionsPanel, { props: { enrichment, taxonomy } });
+        await clickButton(wrapper, 'Add 1 topic');
+        expect(wrapper.emitted('apply')?.[0]).toEqual([{ topic_ids: ['t1'] }]);
+    });
+
+    it('shows an unmatched suggestion but excludes it from apply', () => {
+        const wrapper = mount(SuggestionsPanel, { props: { enrichment, taxonomy } });
+        expect(wrapper.text()).toContain('Unknown topic'); // displayed
+        // ...but the apply button only offers the one match.
+        expect(wrapper.findAll('button').some((b) => b.text().includes('Add 1 topic'))).toBe(true);
+    });
+
+    it('apply all bundles every matched field', async () => {
+        const wrapper = mount(SuggestionsPanel, { props: { enrichment, taxonomy } });
+        await clickButton(wrapper, 'Apply all');
+        expect(wrapper.emitted('apply')?.[0]).toEqual([
+            { description: 'A sermon on grace.', topic_ids: ['t1'], demographic_ids: ['d1'], bible_book_ids: ['b1'] },
+        ]);
+    });
+
+    it('emits regenerate', async () => {
+        const wrapper = mount(SuggestionsPanel, { props: { enrichment, taxonomy } });
+        await clickButton(wrapper, 'Regenerate');
+        expect(wrapper.emitted('regenerate')).toHaveLength(1);
+    });
+
+    it('disables the topic apply when nothing matches', () => {
+        const wrapper = mount(SuggestionsPanel, {
+            props: { enrichment: { ...enrichment, topics: ['Nope'] }, taxonomy },
+        });
+        const btn = wrapper.findAll('button').find((b) => b.text().includes('topic'));
+        expect(btn?.attributes('disabled')).toBeDefined();
+    });
+});

--- a/resources/js/components/molecules/SuggestionsPanel.vue
+++ b/resources/js/components/molecules/SuggestionsPanel.vue
@@ -1,0 +1,209 @@
+<script setup lang="ts">
+import { Button } from '@/ui/button';
+import { Lightbulb } from 'lucide-vue-next';
+import { computed } from 'vue';
+
+// A quiet editorial assist: shows stored suggestions for a video and lets the
+// editor copy them into the form. Deliberately NOT branded as "AI" — church
+// audiences may distrust visible AI, and these are unreviewed model output, so
+// the framing is "Suggested — review before applying". Keywords are shown for
+// transparency only (they already help search); they don't map to a form field.
+
+interface Option {
+    id: string;
+    name: string;
+}
+interface Passage {
+    book: string;
+    label?: string;
+}
+interface Enrichment {
+    summary: string;
+    topics: string[];
+    audience: string;
+    bible_passages: Passage[];
+    keywords: string[];
+    generated_at: string | null;
+}
+
+const props = defineProps<{
+    enrichment: Enrichment | null;
+    taxonomy: {
+        topics: Option[];
+        demographics: Option[];
+        bible_books: Option[];
+    };
+}>();
+
+const emit = defineEmits<{
+    (e: 'apply', payload: { description?: string; topic_ids?: string[]; demographic_ids?: string[]; bible_book_ids?: string[] }): void;
+    (e: 'regenerate'): void;
+}>();
+
+// Resolve free-text suggestion names against existing taxonomy (case-insensitive,
+// exact). We never create taxonomy from unreviewed suggestions — unmatched names
+// are shown muted and simply skipped on apply.
+function resolve(options: Option[], names: string[]) {
+    const byName = new Map(options.map((o) => [o.name.trim().toLowerCase(), o]));
+    const matched: Option[] = [];
+    const unmatched: string[] = [];
+    for (const raw of names) {
+        const hit = byName.get(raw.trim().toLowerCase());
+        if (hit) matched.push(hit);
+        else unmatched.push(raw);
+    }
+    return { matched, unmatched };
+}
+
+const topics = computed(() => resolve(props.taxonomy.topics, props.enrichment?.topics ?? []));
+const audience = computed(() => resolve(props.taxonomy.demographics, props.enrichment?.audience ? [props.enrichment.audience] : []));
+const passages = computed(() =>
+    resolve(
+        props.taxonomy.bible_books,
+        (props.enrichment?.bible_passages ?? []).map((p) => p.book),
+    ),
+);
+
+const ids = (matched: Option[]) => matched.map((o) => o.id);
+
+function applyAll() {
+    const payload: { description?: string; topic_ids?: string[]; demographic_ids?: string[]; bible_book_ids?: string[] } = {};
+    if (props.enrichment?.summary) payload.description = props.enrichment.summary;
+    if (topics.value.matched.length) payload.topic_ids = ids(topics.value.matched);
+    if (audience.value.matched.length) payload.demographic_ids = ids(audience.value.matched);
+    if (passages.value.matched.length) payload.bible_book_ids = ids(passages.value.matched);
+    emit('apply', payload);
+}
+
+const generatedLabel = computed(() => {
+    if (!props.enrichment?.generated_at) return '';
+    const d = new Date(props.enrichment.generated_at);
+    return Number.isNaN(d.getTime()) ? '' : d.toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' });
+});
+</script>
+
+<template>
+    <section class="bg-muted/40 rounded-xl border p-4" aria-labelledby="suggestions-heading">
+        <div class="flex items-start justify-between gap-3">
+            <div>
+                <h2 id="suggestions-heading" class="text-foreground flex items-center gap-1.5 text-sm font-semibold">
+                    <Lightbulb class="text-muted-foreground size-4" aria-hidden="true" />
+                    Suggestions
+                </h2>
+                <p class="text-muted-foreground mt-0.5 text-xs">
+                    Drawn from the title &amp; description — review before applying. Nothing is published automatically.
+                </p>
+            </div>
+            <Button variant="ghost" size="sm" class="shrink-0" @click="emit('regenerate')">Regenerate</Button>
+        </div>
+
+        <!-- No suggestions yet -->
+        <div v-if="!enrichment" class="mt-3 flex items-center justify-between gap-3">
+            <p class="text-muted-foreground text-sm">No suggestions yet for this video.</p>
+            <Button variant="outline" size="sm" @click="emit('regenerate')">Generate suggestions</Button>
+        </div>
+
+        <div v-else class="mt-3 space-y-4">
+            <!-- Summary -->
+            <div v-if="enrichment.summary" class="space-y-1.5">
+                <div class="flex items-center justify-between gap-2">
+                    <span class="text-foreground text-xs font-medium">Summary</span>
+                    <Button variant="outline" size="sm" @click="emit('apply', { description: enrichment.summary })">Use as description</Button>
+                </div>
+                <p class="text-muted-foreground text-sm">{{ enrichment.summary }}</p>
+            </div>
+
+            <!-- Topics -->
+            <div v-if="enrichment.topics.length" class="space-y-1.5">
+                <div class="flex items-center justify-between gap-2">
+                    <span class="text-foreground text-xs font-medium">Topics</span>
+                    <Button variant="outline" size="sm" :disabled="!topics.matched.length" @click="emit('apply', { topic_ids: ids(topics.matched) })">
+                        Add {{ topics.matched.length }} topic{{ topics.matched.length === 1 ? '' : 's' }}
+                    </Button>
+                </div>
+                <div class="flex flex-wrap gap-1.5">
+                    <span v-for="o in topics.matched" :key="`t-${o.id}`" class="bg-background rounded-full border px-2 py-0.5 text-xs">{{
+                        o.name
+                    }}</span>
+                    <span
+                        v-for="(name, i) in topics.unmatched"
+                        :key="`tu-${i}`"
+                        class="text-muted-foreground rounded-full border border-dashed px-2 py-0.5 text-xs"
+                        title="Not in your topics — won't be added"
+                        >{{ name }}</span
+                    >
+                </div>
+            </div>
+
+            <!-- Audience -->
+            <div v-if="enrichment.audience" class="space-y-1.5">
+                <div class="flex items-center justify-between gap-2">
+                    <span class="text-foreground text-xs font-medium">Audience</span>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        :disabled="!audience.matched.length"
+                        @click="emit('apply', { demographic_ids: ids(audience.matched) })"
+                    >
+                        Apply
+                    </Button>
+                </div>
+                <div class="flex flex-wrap gap-1.5">
+                    <span v-for="o in audience.matched" :key="`a-${o.id}`" class="bg-background rounded-full border px-2 py-0.5 text-xs">{{
+                        o.name
+                    }}</span>
+                    <span
+                        v-for="(name, i) in audience.unmatched"
+                        :key="`au-${i}`"
+                        class="text-muted-foreground rounded-full border border-dashed px-2 py-0.5 text-xs"
+                        title="No matching audience — won't be added"
+                        >{{ name }}</span
+                    >
+                </div>
+            </div>
+
+            <!-- Bible passages -->
+            <div v-if="enrichment.bible_passages.length" class="space-y-1.5">
+                <div class="flex items-center justify-between gap-2">
+                    <span class="text-foreground text-xs font-medium">Bible passages</span>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        :disabled="!passages.matched.length"
+                        @click="emit('apply', { bible_book_ids: ids(passages.matched) })"
+                    >
+                        Add {{ passages.matched.length }} book{{ passages.matched.length === 1 ? '' : 's' }}
+                    </Button>
+                </div>
+                <div class="flex flex-wrap gap-1.5">
+                    <span
+                        v-for="p in enrichment.bible_passages"
+                        :key="`p-${p.label ?? p.book}`"
+                        class="bg-background rounded-full border px-2 py-0.5 text-xs"
+                    >
+                        {{ p.label ?? p.book }}
+                    </span>
+                </div>
+            </div>
+
+            <!-- Keywords (display only) -->
+            <div v-if="enrichment.keywords.length" class="space-y-1.5">
+                <span class="text-foreground text-xs font-medium">Keywords</span>
+                <p class="text-muted-foreground text-xs">Already used to improve search — no action needed.</p>
+                <div class="flex flex-wrap gap-1.5">
+                    <span
+                        v-for="(k, i) in enrichment.keywords"
+                        :key="`k-${i}`"
+                        class="text-muted-foreground rounded-full border border-dashed px-2 py-0.5 text-xs"
+                        >{{ k }}</span
+                    >
+                </div>
+            </div>
+
+            <div class="flex items-center justify-between gap-3 border-t pt-3">
+                <span v-if="generatedLabel" class="text-muted-foreground text-xs">Generated {{ generatedLabel }}</span>
+                <Button size="sm" @click="applyAll">Apply all</Button>
+            </div>
+        </div>
+    </section>
+</template>

--- a/resources/js/pages/Studio/EditVideo.vue
+++ b/resources/js/pages/Studio/EditVideo.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import ClassificationFields from '@/molecules/ClassificationFields.vue';
+import SuggestionsPanel from '@/molecules/SuggestionsPanel.vue';
 import { Badge } from '@/ui/badge';
 import { Button } from '@/ui/button';
 import { Input } from '@/ui/input';
@@ -44,6 +45,14 @@ const props = defineProps<{
         ministry_ids: string[];
         series_id: string | null;
         related_resources: Resource[];
+        enrichment: {
+            summary: string;
+            topics: string[];
+            audience: string;
+            bible_passages: { book: string; label?: string }[];
+            keywords: string[];
+            generated_at: string | null;
+        } | null;
     };
     taxonomy: {
         speakers: Option[];
@@ -109,6 +118,24 @@ function togglePublish() {
         status: isPublished.value ? 'draft' : 'published',
         next: editPath.value,
     });
+}
+
+// --- suggestions (Epic #201, E3) ----------------------------------------
+// Copy stored suggestions into the form. M2M ids are merged (deduped), never
+// replaced, so applying never drops an editor's existing choices. The editor
+// still reviews and Saves — nothing is persisted by applying.
+const mergeIds = (current: string[], incoming: string[]) => Array.from(new Set([...current, ...incoming]));
+
+function applySuggestions(payload: { description?: string; topic_ids?: string[]; demographic_ids?: string[]; bible_book_ids?: string[] }) {
+    if (payload.description != null) form.description = payload.description;
+    if (payload.topic_ids) form.topic_ids = mergeIds(form.topic_ids, payload.topic_ids);
+    if (payload.demographic_ids) form.demographic_ids = mergeIds(form.demographic_ids, payload.demographic_ids);
+    if (payload.bible_book_ids) form.bible_book_ids = mergeIds(form.bible_book_ids, payload.bible_book_ids);
+}
+
+function regenerate() {
+    allowNav = true;
+    router.post(`/studio/videos/${props.video.id}/suggest`, {}, { preserveScroll: true });
 }
 
 // --- unsaved-changes guard ----------------------------------------------
@@ -190,6 +217,15 @@ onBeforeUnmount(() => {
             ></iframe>
             <div v-else class="text-muted-foreground flex h-full items-center justify-center text-sm">No preview for this link</div>
         </div>
+
+        <!-- Suggestions (quiet editorial assist; never auto-applied) -->
+        <SuggestionsPanel
+            class="mt-6"
+            :enrichment="props.video.enrichment"
+            :taxonomy="props.taxonomy"
+            @apply="applySuggestions"
+            @regenerate="regenerate"
+        />
 
         <Tabs default-value="details" class="mt-6">
             <TabsList class="w-full sm:w-auto">

--- a/tests/test_studio_suggestions.py
+++ b/tests/test_studio_suggestions.py
@@ -1,0 +1,143 @@
+"""Studio editor — AI suggestions pre-fill (Epic #201, E3).
+
+The edit props carry the stored enrichment (or None), and a /suggest endpoint
+(re)generates it. store_enrichment is mocked — no test touches Ollama.
+"""
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+
+from app.auth import EDITORS_GROUP
+from app.studio import services
+from catalogue.enrichment import PROMPT_VERSION
+from catalogue.models.enrichment import VideoEnrichment
+from tests.factories import VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+PASSWORD = "pw-correct-horse-1"  # gitleaks:allow
+
+
+def make_editor(username="editor"):
+    user = User.objects.create_user(username=username, password=PASSWORD)
+    group, _ = Group.objects.get_or_create(name=EDITORS_GROUP)
+    user.groups.add(group)
+    return user
+
+
+def login_editor(client, username="editor"):
+    make_editor(username)
+    client.login(username=username, password=PASSWORD)
+
+
+def _enrich(video):
+    return VideoEnrichment.objects.create(
+        video=video,
+        summary="A sermon on grace.",
+        topics=["Grace"],
+        audience="Adults",
+        bible_passages=[{"book": "Romans", "label": "Romans 8"}],
+        keywords=["grace", "adoption"],
+        prompt_version=PROMPT_VERSION,
+    )
+
+
+# --- enrichment in the edit props ---------------------------------------- #
+
+
+def test_edit_props_enrichment_is_none_without_a_row():
+    video = VideoFactory()
+    props = services.get_video_for_edit(video.id)
+    assert props["enrichment"] is None
+
+
+def test_edit_props_include_stored_enrichment():
+    video = VideoFactory()
+    _enrich(video)
+
+    props = services.get_video_for_edit(video.id)
+
+    e = props["enrichment"]
+    assert e["summary"] == "A sermon on grace."
+    assert e["topics"] == ["Grace"]
+    assert e["audience"] == "Adults"
+    assert e["bible_passages"] == [{"book": "Romans", "label": "Romans 8"}]
+    assert e["keywords"] == ["grace", "adoption"]
+
+
+def test_edit_page_renders_enrichment_prop(client):
+    login_editor(client)
+    video = VideoFactory(name="Has suggestions")
+    _enrich(video)
+
+    page = inertia_page(client.get(f"/studio/videos/{video.id}/edit"))
+
+    assert page["props"]["video"]["enrichment"]["summary"] == "A sermon on grace."
+
+
+# --- the /suggest endpoint ----------------------------------------------- #
+
+
+def test_suggest_regenerates_and_redirects(client, monkeypatch):
+    login_editor(client)
+    video = VideoFactory()
+
+    called = []
+    # The view does `from catalogue.enrichment import store_enrichment` at call
+    # time, so patching it at the source intercepts the view's lookup.
+    monkeypatch.setattr("catalogue.enrichment.store_enrichment", lambda v, **k: called.append(v.pk) or _enrich(v))
+
+    resp = client.post(f"/studio/videos/{video.id}/suggest")
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"] == f"/studio/videos/{video.id}/edit"
+    assert called == [video.pk]
+
+
+def test_suggest_warns_when_model_returns_nothing(client, monkeypatch):
+    login_editor(client)
+    video = VideoFactory()
+    monkeypatch.setattr("catalogue.enrichment.store_enrichment", lambda v, **k: None)
+
+    resp = client.post(f"/studio/videos/{video.id}/suggest", follow=False)
+
+    assert resp.status_code == 302  # still redirects, just flashes a warning
+
+
+def test_suggest_404_for_missing(client):
+    login_editor(client)
+    assert client.post("/studio/videos/ghost/suggest").status_code == 404
+
+
+def test_suggest_requires_login(client):
+    video = VideoFactory()
+    assert client.post(f"/studio/videos/{video.id}/suggest").status_code == 302  # anon → login
+
+
+def test_suggest_forbidden_for_non_editor(client):
+    video = VideoFactory()
+    User.objects.create_user(username="viewer", password=PASSWORD)
+    client.login(username="viewer", password=PASSWORD)
+    assert client.post(f"/studio/videos/{video.id}/suggest").status_code == 403
+
+
+def test_suggest_rejects_get(client):
+    login_editor(client)
+    video = VideoFactory()
+    assert client.get(f"/studio/videos/{video.id}/suggest").status_code == 405
+
+
+# --- taxonomy uses Bible-book display names (so suggestions can match) ----- #
+
+
+def test_taxonomy_bible_books_use_display_names():
+    from tests.factories import BibleBookFactory
+
+    BibleBookFactory(name="GEN")  # stored as the code; displays as "Genesis"
+    books = services.taxonomy_options()["bible_books"]
+    names = [b["name"] for b in books]
+    assert "Genesis" in names  # the human name, not the raw "GEN" code
+    assert "GEN" not in names


### PR DESCRIPTION
## E3 — Editor pre-fill (the human assist)

Third slice of the AI enrichment epic (#201). A quiet editorial assist in the Studio editor: a **Suggestions** panel showing a video's stored enrichment, with one-click apply into the form.

### UX (per Jamie's guidance)
- **Not branded as "AI"** — no ✨, heading is just "Suggestions" with "Drawn from the title & description — review before applying. Nothing is published automatically." Church audiences may distrust visible AI; these are unreviewed model output.
- **Per-field Apply + Apply all**: summary→description, topics→topic picker, audience→demographic, passages→Bible books. M2M ids are **merged, never replaced**, so applying never drops an editor's existing choices. Nothing persists until the editor **Saves**.
- **Honest matching**: free-text suggestions matched case-insensitively against existing taxonomy; unmatched names show muted and are skipped — we never create taxonomy from unreviewed output. Keywords are read-only (they already feed search).
- **Regenerate** re-runs enrichment for the one video (best-effort; flashes a friendly note if the model is unreachable).

### Backend
- `video_edit_props` carries `enrichment` (new `enrichment_props`); `get_video_for_edit` `select_related`s it.
- `POST /studio/videos/<id>/suggest` — (re)generate, redirect back (auth-gated, 404/405 guarded).
- **Bonus fix**: `taxonomy_options` bible_books now use display names ("Genesis", not the stored "GEN" code) — so the matcher works *and* the editor's existing book picker stops showing raw codes.

### Tests
Backend: enrichment in props (present/absent), suggest endpoint (regenerate, empty→warn, 404, auth gate, GET→405), bible-book display names. Vitest: render, name-matching, per-field + apply-all emits, no-AI-branding assertion, disabled-when-no-match. **415 passed / 89% coverage; 9 Vitest.**

### Manual verification (Claude-in-browser, local)
Opened the editor for a video with a stored enrichment: panel renders with real data (matched topic solid, unmatched muted, audience/book matched, keywords read-only). **Apply all** populated the description with the summary and merged "Adoption by God"/"Genesis"/"Kids" into the form alongside existing values; **Save persisted** — confirmed in the DB.

Part of #201. Next: E4 (flag-gated public surfacing) is deferred until you want public AI metadata.