### PR TITLE
feat(studio): sortable Library columns

### DIFF
--- a/app/studio/services.py
+++ b/app/studio/services.py
@@ -14,7 +14,8 @@ import logging
 from datetime import date
 
 from django.core.paginator import Paginator
-from django.db.models import Q
+from django.db.models import F, Min, OuterRef, Q, Subquery
+from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 from app.cards import video_edit_props
@@ -36,6 +37,13 @@ STATUS_ALL = "all"
 STATUS_CHOICES = (STATUS_ALL, PUBLISHED, DRAFT)
 
 DEFAULT_PER_PAGE = 24
+
+# Sortable Library columns. The value is the sort key the frontend sends; each
+# maps to an ORDER BY expression in `_sorted` below. Speaker/series are M2M so
+# they sort via an annotation; "date" mirrors the displayed coalesce of
+# recorded→created. Thumbnail/actions aren't sortable.
+SORT_CHOICES = ("title", "speaker", "series", "date", "status", "runtime")
+SORT_DIRECTIONS = ("asc", "desc")
 
 
 def _series_name_by_video_id(video_ids):
@@ -99,14 +107,19 @@ def _search_ids(query):
     return ids, False
 
 
-def list_videos(*, search="", status=STATUS_ALL, page=1, per_page=DEFAULT_PER_PAGE):
-    """The Studio video list: filtered, searched, paginated — as plain dicts.
+def list_videos(*, search="", status=STATUS_ALL, page=1, per_page=DEFAULT_PER_PAGE, sort="", direction="desc"):
+    """The Studio video list: filtered, searched, sorted, paginated — as plain
+    dicts.
 
-    Returns a dict ready to spread into the Inertia props: ``videos`` (the row
-    dicts), ``total`` (matching count), and the pagination flags.
+    ``sort`` is one of ``SORT_CHOICES`` (else ignored); ``direction`` is asc/desc.
+    An explicit column sort takes precedence over search relevance. With no sort:
+    relevance order when searching, newest-first otherwise. Returns a dict ready
+    to spread into the Inertia props: ``videos``, ``total`` and pagination flags.
     """
     search = (search or "").strip()
     status = status if status in STATUS_CHOICES else STATUS_ALL
+    sort = sort if sort in SORT_CHOICES else ""
+    direction = direction if direction in SORT_DIRECTIONS else "desc"
 
     qs = Video.objects.all()
     if status != STATUS_ALL:
@@ -115,18 +128,45 @@ def list_videos(*, search="", status=STATUS_ALL, page=1, per_page=DEFAULT_PER_PA
     if search:
         ids, ordered = _search_ids(search)
         qs = qs.filter(id__in=ids)
-        if ordered:
-            # Preserve Typesense's relevance order across the (status-filtered) ids.
+        if ordered and not sort:
+            # No explicit column sort → preserve Typesense's relevance order
+            # across the (status-filtered) ids.
             position = {pk: i for i, pk in enumerate(ids)}
             objects = sorted(
                 qs.prefetch_related("speaker"),
                 key=lambda v: position.get(v.id, len(ids)),
             )
             return _paginate(objects, page, per_page)
-    # Newest first for the unsearched / ORM-fallback list — the daily "what's
-    # new to flip live" view reads best most-recent-first.
-    qs = qs.prefetch_related("speaker").order_by("-date_created", "-id")
+
+    qs = qs.prefetch_related("speaker")
+    # A column sort overrides the default; otherwise newest-created first — the
+    # daily "what's new to flip live" view reads best most-recent-first.
+    qs = _sorted(qs, sort, direction) if sort else qs.order_by("-date_created", "-id")
     return _paginate(qs, page, per_page)
+
+
+def _sorted(qs, sort, direction):
+    """Apply a column ORDER BY for the Library. M2M columns (speaker/series) sort
+    via an annotation; "date" mirrors the displayed recorded→created coalesce.
+    NULLs sort last in both directions; ``-id`` is a stable tiebreak."""
+    if sort == "speaker":
+        qs = qs.annotate(_sort=Min("speaker__name"))
+        field = F("_sort")
+    elif sort == "series":
+        # Series membership is the Series.videos M2M (related_name="+", so no
+        # reverse accessor) — reach it with a correlated subquery.
+        qs = qs.annotate(
+            _sort=Subquery(Series.objects.filter(videos=OuterRef("pk")).order_by("name").values("name")[:1])
+        )
+        field = F("_sort")
+    elif sort == "date":
+        qs = qs.annotate(_sort=Coalesce("date_recorded", "date_created"))
+        field = F("_sort")
+    else:
+        field = F({"title": "name", "status": "status", "runtime": "duration_seconds"}[sort])
+
+    ordering = field.desc(nulls_last=True) if direction == "desc" else field.asc(nulls_last=True)
+    return qs.order_by(ordering, "-id")
 
 
 def _paginate(objects, page, per_page):

--- a/app/studio/views.py
+++ b/app/studio/views.py
@@ -152,7 +152,7 @@ def logout_view(request):
 
 
 def _library_filters(request):
-    """The current ``(q, status, page)`` filters from a GET request."""
+    """The current ``(q, status, page, sort, direction)`` filters from a GET."""
     q = request.GET.get("q", "").strip()
     status = request.GET.get("status", services.STATUS_ALL)
     if status not in services.STATUS_CHOICES:
@@ -161,7 +161,13 @@ def _library_filters(request):
         page = int(request.GET.get("page", 1))
     except (TypeError, ValueError):
         page = 1
-    return q, status, page
+    sort = request.GET.get("sort", "")
+    if sort not in services.SORT_CHOICES:
+        sort = ""
+    direction = request.GET.get("dir", "desc")
+    if direction not in services.SORT_DIRECTIONS:
+        direction = "desc"
+    return q, status, page, sort, direction
 
 
 @studio_required
@@ -173,14 +179,16 @@ def library(request):
     ``ensure_csrf_cookie`` guarantees the XSRF cookie is present so the row/bulk
     mutations (Inertia POSTs) carry a valid CSRF token — including for a session
     that landed here straight from the magic link."""
-    q, status, page = _library_filters(request)
-    result = services.list_videos(search=q, status=status, page=page)
+    q, status, page, sort, direction = _library_filters(request)
+    result = services.list_videos(search=q, status=status, page=page, sort=sort, direction=direction)
     return render(
         request,
         "Studio/Library",
         {
             "q": q,
             "status": status,
+            "sort": sort,
+            "dir": direction,
             "draft_count": services.draft_count(),
             **result,
         },

--- a/resources/js/pages/Studio/Library.vue
+++ b/resources/js/pages/Studio/Library.vue
@@ -11,7 +11,7 @@ import { Skeleton } from '@/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table';
 import { Head, Link, router } from '@inertiajs/vue3';
 import { useDebounceFn } from '@vueuse/core';
-import { ExternalLink, Film, MoreHorizontal, Pencil, Plus, Search } from 'lucide-vue-next';
+import { ArrowDown, ArrowUp, ChevronsUpDown, ExternalLink, Film, MoreHorizontal, Pencil, Plus, Search } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
 import { formatDuration } from '~/lib/duration';
 
@@ -31,6 +31,8 @@ const props = defineProps<{
     videos: VideoRow[];
     q: string;
     status: 'all' | 'draft' | 'published';
+    sort: string;
+    dir: 'asc' | 'desc';
     total: number;
     page: number;
     num_pages: number;
@@ -38,6 +40,9 @@ const props = defineProps<{
     has_next_page: boolean;
     draft_count: number;
 }>();
+
+// Columns the Library can sort by (key must match services.SORT_CHOICES).
+type SortKey = 'title' | 'speaker' | 'series' | 'date' | 'status' | 'runtime';
 
 // --- filters: search (debounced) + status -------------------------------
 const search = ref(props.q);
@@ -49,7 +54,7 @@ const loading = ref(false);
 function reload(params: Record<string, string>) {
     loading.value = true;
     router.get('/studio/', params, {
-        only: ['videos', 'q', 'status', 'total', 'page', 'num_pages', 'has_prev_page', 'has_next_page'],
+        only: ['videos', 'q', 'status', 'sort', 'dir', 'total', 'page', 'num_pages', 'has_prev_page', 'has_next_page'],
         preserveState: true,
         preserveScroll: true,
         replace: true,
@@ -59,14 +64,28 @@ function reload(params: Record<string, string>) {
 
 // The query string for a given (search, status) pair — the single place we
 // decide which params survive a reload (omit defaults to keep URLs clean).
-const buildParams = (status: 'all' | 'draft' | 'published') => {
+const buildParams = (status: 'all' | 'draft' | 'published', sort: string = props.sort, dir: 'asc' | 'desc' = props.dir) => {
     const params: Record<string, string> = {};
     if (search.value.trim()) params.q = search.value.trim();
     if (status !== 'all') params.status = status;
+    if (sort) {
+        params.sort = sort;
+        params.dir = dir;
+    }
     return params;
 };
 
 const runSearch = useDebounceFn(() => reload(buildParams(props.status)), 300);
+
+// Click a column header: toggle direction if it's the active column, else sort
+// by it ascending. Sorting is server-side (the list is paginated), so this is a
+// reload, not a client-side resort.
+function sortBy(col: SortKey) {
+    const dir: 'asc' | 'desc' = props.sort === col && props.dir === 'asc' ? 'desc' : 'asc';
+    reload(buildParams(props.status, col, dir));
+}
+
+const ariaSort = (col: SortKey) => (props.sort === col ? (props.dir === 'asc' ? 'ascending' : 'descending') : 'none');
 
 watch(search, () => runSearch());
 
@@ -231,12 +250,116 @@ const resultLabel = computed(() => {
                             <Checkbox :model-value="headerState" @update:model-value="toggleAll" aria-label="Select all videos on this page" />
                         </TableHead>
                         <TableHead class="w-20">Thumbnail</TableHead>
-                        <TableHead>Title</TableHead>
-                        <TableHead class="hidden md:table-cell">Speaker</TableHead>
-                        <TableHead class="hidden lg:table-cell">Series</TableHead>
-                        <TableHead class="hidden sm:table-cell">Date</TableHead>
-                        <TableHead>Status</TableHead>
-                        <TableHead class="hidden sm:table-cell">Runtime</TableHead>
+                        <TableHead :aria-sort="ariaSort('title')">
+                            <button
+                                type="button"
+                                class="group/sort hover:text-foreground focus-visible:ring-ring -mx-1 inline-flex cursor-pointer items-center gap-1 rounded px-1 transition-colors outline-none focus-visible:ring-2"
+                                @click="sortBy('title')"
+                            >
+                                Title
+                                <component
+                                    :is="props.sort === 'title' ? (props.dir === 'asc' ? ArrowUp : ArrowDown) : ChevronsUpDown"
+                                    class="size-3.5 shrink-0"
+                                    :class="
+                                        props.sort === 'title' ? 'text-foreground' : 'text-muted-foreground/40 group-hover/sort:text-muted-foreground'
+                                    "
+                                    aria-hidden="true"
+                                />
+                            </button>
+                        </TableHead>
+                        <TableHead class="hidden md:table-cell" :aria-sort="ariaSort('speaker')">
+                            <button
+                                type="button"
+                                class="group/sort hover:text-foreground focus-visible:ring-ring -mx-1 inline-flex cursor-pointer items-center gap-1 rounded px-1 transition-colors outline-none focus-visible:ring-2"
+                                @click="sortBy('speaker')"
+                            >
+                                Speaker
+                                <component
+                                    :is="props.sort === 'speaker' ? (props.dir === 'asc' ? ArrowUp : ArrowDown) : ChevronsUpDown"
+                                    class="size-3.5 shrink-0"
+                                    :class="
+                                        props.sort === 'speaker'
+                                            ? 'text-foreground'
+                                            : 'text-muted-foreground/40 group-hover/sort:text-muted-foreground'
+                                    "
+                                    aria-hidden="true"
+                                />
+                            </button>
+                        </TableHead>
+                        <TableHead class="hidden lg:table-cell" :aria-sort="ariaSort('series')">
+                            <button
+                                type="button"
+                                class="group/sort hover:text-foreground focus-visible:ring-ring -mx-1 inline-flex cursor-pointer items-center gap-1 rounded px-1 transition-colors outline-none focus-visible:ring-2"
+                                @click="sortBy('series')"
+                            >
+                                Series
+                                <component
+                                    :is="props.sort === 'series' ? (props.dir === 'asc' ? ArrowUp : ArrowDown) : ChevronsUpDown"
+                                    class="size-3.5 shrink-0"
+                                    :class="
+                                        props.sort === 'series'
+                                            ? 'text-foreground'
+                                            : 'text-muted-foreground/40 group-hover/sort:text-muted-foreground'
+                                    "
+                                    aria-hidden="true"
+                                />
+                            </button>
+                        </TableHead>
+                        <TableHead class="hidden sm:table-cell" :aria-sort="ariaSort('date')">
+                            <button
+                                type="button"
+                                class="group/sort hover:text-foreground focus-visible:ring-ring -mx-1 inline-flex cursor-pointer items-center gap-1 rounded px-1 transition-colors outline-none focus-visible:ring-2"
+                                @click="sortBy('date')"
+                            >
+                                Date
+                                <component
+                                    :is="props.sort === 'date' ? (props.dir === 'asc' ? ArrowUp : ArrowDown) : ChevronsUpDown"
+                                    class="size-3.5 shrink-0"
+                                    :class="
+                                        props.sort === 'date' ? 'text-foreground' : 'text-muted-foreground/40 group-hover/sort:text-muted-foreground'
+                                    "
+                                    aria-hidden="true"
+                                />
+                            </button>
+                        </TableHead>
+                        <TableHead :aria-sort="ariaSort('status')">
+                            <button
+                                type="button"
+                                class="group/sort hover:text-foreground focus-visible:ring-ring -mx-1 inline-flex cursor-pointer items-center gap-1 rounded px-1 transition-colors outline-none focus-visible:ring-2"
+                                @click="sortBy('status')"
+                            >
+                                Status
+                                <component
+                                    :is="props.sort === 'status' ? (props.dir === 'asc' ? ArrowUp : ArrowDown) : ChevronsUpDown"
+                                    class="size-3.5 shrink-0"
+                                    :class="
+                                        props.sort === 'status'
+                                            ? 'text-foreground'
+                                            : 'text-muted-foreground/40 group-hover/sort:text-muted-foreground'
+                                    "
+                                    aria-hidden="true"
+                                />
+                            </button>
+                        </TableHead>
+                        <TableHead class="hidden sm:table-cell" :aria-sort="ariaSort('runtime')">
+                            <button
+                                type="button"
+                                class="group/sort hover:text-foreground focus-visible:ring-ring -mx-1 inline-flex cursor-pointer items-center gap-1 rounded px-1 transition-colors outline-none focus-visible:ring-2"
+                                @click="sortBy('runtime')"
+                            >
+                                Runtime
+                                <component
+                                    :is="props.sort === 'runtime' ? (props.dir === 'asc' ? ArrowUp : ArrowDown) : ChevronsUpDown"
+                                    class="size-3.5 shrink-0"
+                                    :class="
+                                        props.sort === 'runtime'
+                                            ? 'text-foreground'
+                                            : 'text-muted-foreground/40 group-hover/sort:text-muted-foreground'
+                                    "
+                                    aria-hidden="true"
+                                />
+                            </button>
+                        </TableHead>
                         <TableHead class="w-10"><span class="sr-only">Actions</span></TableHead>
                     </TableRow>
                 </TableHeader>
@@ -255,7 +378,11 @@ const resultLabel = computed(() => {
                     </TableRow>
                 </TableBody>
 
-                <TableBody v-else-if="videos.length">
+                <TableBody
+                    v-else-if="videos.length"
+                    :key="`${props.sort}-${props.dir}-${props.page}`"
+                    class="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200"
+                >
                     <TableRow v-for="video in videos" :key="video.id" :data-state="selected.has(video.id) ? 'selected' : undefined">
                         <TableCell>
                             <Checkbox

--- a/tests/test_studio_library_sort.py
+++ b/tests/test_studio_library_sort.py
@@ -1,0 +1,137 @@
+"""Studio Library column sorting (sortable datatable).
+
+Server-side sort (the list is paginated, so sorting must happen in the DB before
+the page slice). Covers the plain columns, the coalesced date, the two M2M
+columns (speaker via Min, series via subquery), direction toggling, NULL
+placement, invalid-input fallback, and that sort survives the status filter.
+"""
+
+import datetime
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+
+from app.auth import EDITORS_GROUP
+from app.studio import services
+from catalogue.models.video import DRAFT, PUBLISHED
+from tests.factories import SeriesFactory, SpeakerFactory, VideoFactory
+from tests.utils import inertia_page
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+PASSWORD = "pw-correct-horse-1"  # gitleaks:allow
+
+
+def _names(result):
+    return [r["name"] for r in result["videos"]]
+
+
+def _login_editor(client):
+    user = User.objects.create_user(username="editor", password=PASSWORD)
+    group, _ = Group.objects.get_or_create(name=EDITORS_GROUP)
+    user.groups.add(group)
+    client.login(username="editor", password=PASSWORD)
+
+
+# --- plain columns -------------------------------------------------------- #
+
+
+def test_sort_by_title_ascending_and_descending():
+    VideoFactory(name="Banana")
+    VideoFactory(name="Apple")
+    VideoFactory(name="Cherry")
+
+    assert _names(services.list_videos(sort="title", direction="asc")) == ["Apple", "Banana", "Cherry"]
+    assert _names(services.list_videos(sort="title", direction="desc")) == ["Cherry", "Banana", "Apple"]
+
+
+def test_sort_by_runtime_puts_nulls_last_both_directions():
+    VideoFactory(name="Short", duration_seconds=60)
+    VideoFactory(name="Long", duration_seconds=3600)
+    VideoFactory(name="Unknown", duration_seconds=None)
+
+    asc = _names(services.list_videos(sort="runtime", direction="asc"))
+    assert asc == ["Short", "Long", "Unknown"]  # null last even ascending
+    desc = _names(services.list_videos(sort="runtime", direction="desc"))
+    assert desc == ["Long", "Short", "Unknown"]  # null still last
+
+
+def test_sort_by_status():
+    VideoFactory(name="Pub", status=PUBLISHED)
+    VideoFactory(name="Draft", status=DRAFT)
+    # draft < published alphabetically
+    assert _names(services.list_videos(sort="status", direction="asc")) == ["Draft", "Pub"]
+
+
+def test_sort_by_date_uses_recorded_then_created_coalesce():
+    # "Newer" has no recorded date → falls back to its (later) created date, which
+    # must still sort it after "Older" whose recorded date is earlier.
+    VideoFactory(name="Older", date_recorded=datetime.date(2020, 1, 1), date_created=datetime.date(2026, 1, 1))
+    VideoFactory(name="Newer", date_recorded=None, date_created=datetime.date(2024, 1, 1))
+
+    assert _names(services.list_videos(sort="date", direction="asc")) == ["Older", "Newer"]
+
+
+# --- M2M columns ---------------------------------------------------------- #
+
+
+def test_sort_by_speaker_via_m2m():
+    v1 = VideoFactory(name="Zebra talk")
+    v1.speaker.add(SpeakerFactory(name="Adams, Anne"))
+    v2 = VideoFactory(name="Apple talk")
+    v2.speaker.add(SpeakerFactory(name="Zimmer, Zoe"))
+
+    # Sorted by SPEAKER, not title.
+    assert _names(services.list_videos(sort="speaker", direction="asc")) == ["Zebra talk", "Apple talk"]
+
+
+def test_sort_by_series_via_m2m_subquery():
+    v1 = VideoFactory(name="In Genesis")
+    SeriesFactory(name="Aardvark Studies").videos.add(v1)
+    v2 = VideoFactory(name="In Exodus")
+    SeriesFactory(name="Zoology Studies").videos.add(v2)
+
+    assert _names(services.list_videos(sort="series", direction="asc")) == ["In Genesis", "In Exodus"]
+
+
+# --- robustness ----------------------------------------------------------- #
+
+
+def test_invalid_sort_falls_back_to_newest_first():
+    older = VideoFactory(name="Older", date_created=datetime.date(2026, 1, 1))
+    newer = VideoFactory(name="Newer", date_created=datetime.date(2026, 6, 1))
+
+    result = services.list_videos(sort="bogus_column", direction="sideways")
+    # Default order is newest-created first, and the bad direction is ignored.
+    assert _names(result) == ["Newer", "Older"]
+    assert older.name and newer.name  # (sanity)
+
+
+def test_sort_respects_status_filter():
+    VideoFactory(name="Apple", status=DRAFT)
+    VideoFactory(name="Banana", status=PUBLISHED)
+    VideoFactory(name="Cherry", status=DRAFT)
+
+    result = services.list_videos(status=DRAFT, sort="title", direction="asc")
+    assert _names(result) == ["Apple", "Cherry"]  # Banana (published) excluded
+
+
+# --- view wiring ---------------------------------------------------------- #
+
+
+def test_library_view_echoes_sort_and_dir(client):
+    _login_editor(client)
+    VideoFactory(name="A")
+    props = inertia_page(client.get("/studio/", {"sort": "title", "dir": "asc"}))["props"]
+    assert props["sort"] == "title"
+    assert props["dir"] == "asc"
+
+
+def test_library_view_defaults_sort_empty(client):
+    _login_editor(client)
+    VideoFactory(name="A")
+    props = inertia_page(client.get("/studio/"))["props"]
+    assert props["sort"] == ""
+    assert props["dir"] == "desc"


### PR DESCRIPTION
## Sortable Studio Library

Click any column header (Title · Speaker · Series · Date · Status · Runtime) to sort; click again to flip direction. An asc/desc/idle chevron + `aria-sort` show the state, and the sort is preserved across search, the status filter, and pagination.

### Why server-side
The Library paginates server-side (24/page), so a client-side resort would only reorder the visible 24 — sorting has to order the **full filtered set** before the page slice. It rides the existing partial-reload + skeleton path, so it stays snappy and the URL stays shareable (`?sort=series&dir=asc`).

### No DB-index work needed
At ~10k rows Postgres sorts any of these columns in single-digit ms; indexes only matter at much larger scale or hot query volume, and the catalogue is ~10k and effectively frozen. So this is a "thread a sort param through" change, not an indexing one.

- `services.list_videos(sort, direction)` + `_sorted`: plain fields sort directly; the two **M2M** columns via annotation — speaker = `Min(speaker__name)`, series via a correlated `Subquery` (since `Series.videos` is `related_name="+"`); **date** via `Coalesce(date_recorded, date_created)` to match the displayed value. NULLs sort last in both directions; `-id` tiebreak. A column sort overrides search relevance; invalid input falls back to the newest-first default.
- View threads `sort`/`dir` through and echoes them as props.
- `Library.vue`: sortable header buttons (reduced-motion-safe colour transitions + a gentle fade-in on freshly-sorted rows, per the design-engineering principles), direction toggle, sort survives row/bulk mutations.

### Tests
Per-column ordering, NULL placement, date coalesce, both M2M paths, direction toggle, invalid-input fallback, status-filter interplay, view echo. **425 passed, 89% coverage.**

### Verified in-browser (local)
Title asc↔desc, Series (M2M subquery) — active arrow + `?sort=…&dir=…` URL + fade-in all working.

Note on Inertia v3 deferred/optional props: not used here — for the table's *primary* content the proven partial-reload+skeleton already gives the instant feel, and deferred props need inertia-django server support we've held off on (per CLAUDE.md). Good candidate for heavier secondary data later.