### PR TITLE
feat(studio): Library row-click select + title→edit link (#305)

### DIFF
--- a/resources/js/pages/Studio/Library.vue
+++ b/resources/js/pages/Studio/Library.vue
@@ -383,8 +383,14 @@ const resultLabel = computed(() => {
                     :key="`${props.sort}-${props.dir}-${props.page}`"
                     class="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200"
                 >
-                    <TableRow v-for="video in videos" :key="video.id" :data-state="selected.has(video.id) ? 'selected' : undefined">
-                        <TableCell>
+                    <TableRow
+                        v-for="video in videos"
+                        :key="video.id"
+                        :data-state="selected.has(video.id) ? 'selected' : undefined"
+                        class="cursor-pointer"
+                        @click="toggleRow(video.id, !selected.has(video.id))"
+                    >
+                        <TableCell @click.stop>
                             <Checkbox
                                 :model-value="selected.has(video.id)"
                                 @update:model-value="(v: boolean | 'indeterminate') => toggleRow(video.id, v)"
@@ -397,7 +403,13 @@ const resultLabel = computed(() => {
                             </div>
                         </TableCell>
                         <TableCell class="max-w-xs">
-                            <span class="text-foreground line-clamp-2 font-medium whitespace-normal">{{ video.name }}</span>
+                            <Link
+                                :href="`/studio/videos/${video.id}/edit`"
+                                class="text-foreground line-clamp-2 font-medium whitespace-normal hover:underline focus-visible:underline focus-visible:outline-none"
+                                @click.stop
+                            >
+                                {{ video.name }}
+                            </Link>
                         </TableCell>
                         <TableCell class="text-muted-foreground hidden md:table-cell">
                             {{ video.speakers.length ? video.speakers.join(', ') : '—' }}
@@ -419,7 +431,7 @@ const resultLabel = computed(() => {
                         <TableCell class="text-muted-foreground hidden tabular-nums sm:table-cell">
                             {{ formatDuration(video.duration_seconds) || '—' }}
                         </TableCell>
-                        <TableCell>
+                        <TableCell @click.stop>
                             <DropdownMenu>
                                 <DropdownMenuTrigger as-child>
                                     <Button variant="ghost" size="icon" :aria-label="`Actions for ${video.name}`">


### PR DESCRIPTION
First two of the row-interactions mini-epic (#305) — coupled, so shipped together.

### 1. Click a row → toggle selection
Click anywhere on a row (except its interactive controls) toggles that row's checkbox, for faster multi-select before a bulk publish/unpublish/delete. The checkbox remains the keyboard-accessible control; row-click is a pointer enhancement (`cursor-pointer` + the existing hover/selected row styling).

### 2. Title → editor
The title is now an Inertia `<Link>` to `/studio/videos/<id>/edit` with an underline-on-hover affordance — a discoverable shortcut alongside the existing ⋯ → Edit.

### Click-target isolation
The checkbox cell, the title link, and the ⋯ actions cell each `@click.stop`, so they don't also toggle row selection.

### Verification
In-browser (local): clicking a row's blank area selects it and reveals the "N selected · Publish · Unpublish · Delete" bar; clicking the title opens the editor; the ⋯ menu opens without toggling. No backend change — pure presentational interaction, so no new automated tests (consistent with how page-level Vue interactions are verified here); full suite stays green.

### Deferred
Item 3 (thumbnail → mini-player) waits on your pick: un-gate the public `PersistentPlayer` dock on the Library, or a Studio-scoped modal player. Tracked in #305.