### PR TITLE
feat(studio): Library thumbnail → mini-player (closes #305)

### DIFF
--- a/app/studio/services.py
+++ b/app/studio/services.py
@@ -76,6 +76,7 @@ def _serialize(videos):
             {
                 "id": v.id,
                 "name": v.name,
+                "url": v.url,  # source URL — lets the row load the video into the player dock
                 "thumbnail": v.thumbnail,
                 "speakers": [s.name for s in v.speaker.all()],
                 "series": series_names.get(v.id),

--- a/resources/js/components/layouts/AppLayout.vue
+++ b/resources/js/components/layouts/AppLayout.vue
@@ -8,10 +8,16 @@ import Toaster from '@/organisms/Toaster.vue';
 import { usePage } from '@inertiajs/vue3';
 import { computed } from 'vue';
 
-// The Studio is an editor workspace, not a watch context — keep the floating
-// mini-player out of it so it never overlaps the content tables.
+// The mini-player shows on watch contexts. In the Studio it's allowed on the
+// browse-like surfaces (Library + Review, where clicking a thumbnail previews a
+// video) but kept off the form/editor surfaces so it never overlaps their UI.
 const page = usePage();
-const showPlayer = computed(() => !page.url.startsWith('/studio'));
+const STUDIO_PLAYER_PATHS = ['/studio', '/studio/', '/studio/review'];
+const showPlayer = computed(() => {
+    const path = page.url.split('?')[0];
+    if (!path.startsWith('/studio')) return true;
+    return STUDIO_PLAYER_PATHS.includes(path);
+});
 </script>
 
 <template>

--- a/resources/js/pages/Studio/Library.vue
+++ b/resources/js/pages/Studio/Library.vue
@@ -11,14 +11,16 @@ import { Skeleton } from '@/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/ui/table';
 import { Head, Link, router } from '@inertiajs/vue3';
 import { useDebounceFn } from '@vueuse/core';
-import { ArrowDown, ArrowUp, ChevronsUpDown, ExternalLink, Film, MoreHorizontal, Pencil, Plus, Search } from 'lucide-vue-next';
+import { ArrowDown, ArrowUp, ChevronsUpDown, ExternalLink, Film, MoreHorizontal, Pencil, Play, Plus, Search } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
+import { usePlayerDock } from '~/composables/usePlayerDock';
 import { formatDuration } from '~/lib/duration';
 
 // The strict Inertia encoder hands us plain dicts only (app/studio/services.py).
 interface VideoRow {
     id: string;
     name: string;
+    url: string;
     thumbnail: string | null;
     speakers: string[];
     series: string | null;
@@ -86,6 +88,13 @@ function sortBy(col: SortKey) {
 }
 
 const ariaSort = (col: SortKey) => (props.sort === col ? (props.dir === 'asc' ? 'ascending' : 'descending') : 'none');
+
+// Click a thumbnail to preview the video in the persistent mini-player dock
+// (the same dock the public site uses; enabled on the Library in AppLayout).
+const dock = usePlayerDock();
+function play(video: VideoRow) {
+    dock.load({ id: video.id, name: video.name, url: video.url });
+}
 
 watch(search, () => runSearch());
 
@@ -397,10 +406,20 @@ const resultLabel = computed(() => {
                                 :aria-label="`Select ${video.name}`"
                             />
                         </TableCell>
-                        <TableCell>
-                            <div class="bg-muted aspect-video w-16 overflow-hidden rounded">
+                        <TableCell @click.stop>
+                            <button
+                                type="button"
+                                class="group/play bg-muted focus-visible:ring-ring relative block aspect-video w-16 cursor-pointer overflow-hidden rounded outline-none focus-visible:ring-2"
+                                :aria-label="`Play ${video.name}`"
+                                @click="play(video)"
+                            >
                                 <img v-if="video.thumbnail" :src="video.thumbnail" alt="" loading="lazy" class="h-full w-full object-cover" />
-                            </div>
+                                <span
+                                    class="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity duration-150 group-hover/play:opacity-100 group-focus-visible/play:opacity-100 motion-reduce:transition-none"
+                                >
+                                    <Play class="size-5 fill-white text-white" aria-hidden="true" />
+                                </span>
+                            </button>
                         </TableCell>
                         <TableCell class="max-w-xs">
                             <Link

--- a/tests/test_studio_library.py
+++ b/tests/test_studio_library.py
@@ -149,6 +149,15 @@ def test_library_row_carries_speakers_and_series(client):
     assert row["status"] == PUBLISHED
 
 
+def test_library_row_carries_source_url_for_the_player(client):
+    # The row's source URL feeds the thumbnail → mini-player dock (Epic #305).
+    login_editor(client)
+    VideoFactory(name="Playable", url="https://www.youtube.com/watch?v=abc123")
+
+    row = next(v for v in library_props(client)["videos"] if v["name"] == "Playable")
+    assert row["url"] == "https://www.youtube.com/watch?v=abc123"
+
+
 def test_status_filter_narrows(client):
     login_editor(client)
     VideoFactory(name="Live One", status=PUBLISHED)


### PR DESCRIPTION
Final piece of the row-interactions mini-epic (#305). Clicking a Library row's thumbnail loads the video into the **persistent mini-player dock** — the same dock the public site uses (`usePlayerDock`), so it carries resume/position memory and a consistent feel (your chosen approach).

- **AppLayout**: the dock was gated off *all* of `/studio`; now it's allowed on the browse-like **Library + Review** surfaces but still kept off the form/editor routes so it never overlaps their UI.
- **services._serialize**: rows now carry the source `url` (the dock needs the YouTube/Vimeo source, not the page URL).
- **Library.vue**: the thumbnail is now a play button (aria-labelled, hover/focus play overlay, reduced-motion-safe) calling `dock.load()`; `@click.stop` so it plays rather than toggling row selection.

### Verification (in-browser, local)
Clicking a thumbnail opens the mini-dock bottom-right with the correct title + the Vimeo/YouTube embed, and `ctv:active-player` persists; the row is **not** selected (stop-propagation works). Full suite **426 passed, 89%**.

Closes #305 (items 1 + 2 shipped in #306).