### PR TITLE
fix(studio): hide Regenerate until suggestions exist

### DIFF
--- a/resources/js/components/molecules/SuggestionsPanel.spec.ts
+++ b/resources/js/components/molecules/SuggestionsPanel.spec.ts
@@ -30,6 +30,11 @@ describe('SuggestionsPanel', () => {
         expect(wrapper.findAll('button').some((b) => b.text().includes('Generate suggestions'))).toBe(true);
     });
 
+    it('hides the header Regenerate action until something has been generated', () => {
+        const wrapper = mount(SuggestionsPanel, { props: { enrichment: null, taxonomy } });
+        expect(wrapper.findAll('button').some((b) => b.text().includes('Regenerate'))).toBe(false);
+    });
+
     it('renders the stored suggestions', () => {
         const wrapper = mount(SuggestionsPanel, { props: { enrichment, taxonomy } });
         expect(wrapper.text()).toContain('A sermon on grace.');

--- a/resources/js/components/molecules/SuggestionsPanel.vue
+++ b/resources/js/components/molecules/SuggestionsPanel.vue
@@ -94,7 +94,7 @@ const generatedLabel = computed(() => {
                     Drawn from the title &amp; description — review before applying. Nothing is published automatically.
                 </p>
             </div>
-            <Button variant="ghost" size="sm" class="shrink-0" @click="emit('regenerate')">Regenerate</Button>
+            <Button v-if="enrichment" variant="ghost" size="sm" class="shrink-0" @click="emit('regenerate')">Regenerate</Button>
         </div>
 
         <!-- No suggestions yet -->


### PR DESCRIPTION
Small UX fix to the editor Suggestions panel (Epic #201): the header "Regenerate" only appears once an enrichment exists. Before, an un-enriched video showed both "Regenerate" (header) and "Generate suggestions" (empty state) — redundant and mis-worded. Vitest covers both states (10 passing).