### PR TITLE
analytics: tag events with deployment environment (super-property)

### DIFF
--- a/resources/js/lib/analytics.ts
+++ b/resources/js/lib/analytics.ts
@@ -49,6 +49,16 @@ export const EVENTS = {
 let entryPath: string | null = null;
 let hasLeftEntry = false;
 
+// Which deployment is sending events. Derived from the host (deploys are
+// per-domain), so a single PostHog project can distinguish environments without
+// the paid "Environments" feature — and prod tags itself once it gets a key.
+function detectEnvironment(): string {
+    const host = window.location.hostname;
+    if (host.startsWith('beta.')) return 'beta';
+    if (host === 'claytontv.co.uk' || host === 'www.claytontv.co.uk') return 'production';
+    return 'development';
+}
+
 export async function initializeAnalytics() {
     const key = import.meta.env.VITE_POSTHOG_KEY;
 
@@ -81,6 +91,11 @@ export async function initializeAnalytics() {
     });
 
     posthog = ph;
+
+    // Tag every event with the deployment that sent it (beta / production), so a
+    // single PostHog project can tell environments apart without the paid
+    // "Environments" feature.
+    ph.register({ environment: detectEnvironment() });
 
     // React to consent decisions made after boot (the banner on first visit, or
     // the footer "Cookie settings" later).


### PR DESCRIPTION
## What
Registers an `environment` PostHog **super-property** on every event — `beta` / `production` / `development` — so our single Clayton TV PostHog project can distinguish environments without the paid "Environments" feature.

Derived from the host at init (`detectEnvironment()` in `analytics.ts`): deploys are per-domain, so `beta.claytontv.co.uk → beta`, `claytontv.co.uk → production`, everything else → `development`. No build/CI change needed, and prod self-tags the moment it gets a key.

## Why now
PostHog was reinstalled clean (the old single-project cap is lifted; we now run 5 projects, one per site). This is step 1 of re-wiring Clayton TV onto its own project after the reinstall.

## Ops follow-up (not in this PR)
Beta's `VITE_POSTHOG_KEY` environment secret must be updated to the **current** Clayton TV project key (`phc_AkXYt2th…`) — the old key's project was wiped in the reinstall, so beta events won't ingest until the secret is rotated. Being handled alongside merge.

## Verification
- Local gate green: `type-check`, `lint-check` (oxlint + eslint), `format-check`, `build-only`.
- Post-merge: beta redeploys → confirm events land in project #1 with `environment = beta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)