### PR TITLE
ci: restore auto-deploy on push for dev (#352)

### DIFF
--- a/.github/workflows/deploy-to-dev.yaml
+++ b/.github/workflows/deploy-to-dev.yaml
@@ -1,8 +1,12 @@
 name: Deploy to Dev
 
 on:
-  # Manual only — dev is the fast-moving integration branch, so we deploy it on
-  # demand rather than on every push. Beta/production still auto-deploy on push.
+  # Dev only moves via CI-green PRs (branch protection, #347), so auto-deploying
+  # on push keeps the environment in step with the branch and surfaces
+  # migration/deploy breakage early. Manual dispatch remains for redeploys.
+  push:
+    branches:
+      - dev
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Re-adds the push trigger for the `dev` branch in `deploy-to-dev.yaml` (keeping `workflow_dispatch` for manual redeploys).

## Decision trail
- **#324** — original ask to stop dev auto-deploying, back when anyone could push straight to dev.
- **#325** — implemented manual-only (`workflow_dispatch:`), to avoid unstable pushes deploying automatically.
- **#347** — dev is now behind branch protection: it only moves via PRs with CI green, so the instability concern no longer applies.
- **#352** — with that guardrail in place, an environment that drifts from its branch just hides migration/deploy breakage until beta promotion. Returning to auto-deploy keeps dev in step with the branch.

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)