### PR TITLE
fix(ingest): ride out the old site's wobbles in the hourly import (#366)

### DIFF
--- a/catalogue/ingest/live_admin.py
+++ b/catalogue/ingest/live_admin.py
@@ -11,6 +11,7 @@ app has no API or stable login endpoint. Expired sessions redirect to
 /accessdenied.html, which we detect and report clearly.
 """
 
+import logging
 import os
 import re
 import time
@@ -21,13 +22,42 @@ from bs4 import BeautifulSoup
 
 from .normalize import date_from_ref
 
+logger = logging.getLogger(__name__)
+
 BASE_URL = os.environ.get("LEGACY_ADMIN_BASE_URL", "https://clayton.tv/adminsection")
 PAGE_SIZE = 50
 MAX_AUTO_PAGES = 200  # auto-depth runaway stop: 10,000 programmes
 
+# The legacy server drops and stalls requests routinely — retry those rather
+# than abandoning the run (and alerting) over a blip. Waits before each retry;
+# one more attempt than there are waits.
+RETRY_WAITS_SECONDS = (2, 5)
+MAX_ATTEMPTS = len(RETRY_WAITS_SECONDS) + 1
+TRANSIENT_ERRORS = (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+
 
 class AdminAuthError(Exception):
     pass
+
+
+def _with_retries(description, request):
+    """Call `request()`, retrying transient network failures with a growing
+    wait. Once the attempts are spent the error is raised as before, so a
+    genuinely-down site still surfaces."""
+    for attempt, wait in enumerate(RETRY_WAITS_SECONDS, start=1):
+        try:
+            return request()
+        except TRANSIENT_ERRORS as exc:
+            logger.warning(
+                "Legacy admin %s failed (attempt %s/%s): %s — retrying in %ss",
+                description,
+                attempt,
+                MAX_ATTEMPTS,
+                exc,
+                wait,
+            )
+            time.sleep(wait)
+    return request()
 
 
 def login(session):
@@ -39,19 +69,23 @@ def login(session):
     if not (user and password):
         return False
 
-    page = session.get(f"{BASE_URL}/", timeout=30)  # sets the ASP session cookie, lands on login.asp?at=...
+    # Sets the ASP session cookie, lands on login.asp?at=...
+    page = _with_retries("login page", lambda: session.get(f"{BASE_URL}/", timeout=30))
     soup = BeautifulSoup(page.text, "html.parser")
     form = soup.find("form")
     action = (form.get("action") if form else None) or page.url
-    response = session.post(
-        action,
-        data={
-            "kt_login_user": user,
-            "kt_login_password": password,
-            "kt_login_rememberme": "1",
-            "kt_login1": "Login",
-        },
-        timeout=30,
+    response = _with_retries(
+        "login submission",
+        lambda: session.post(
+            action,
+            data={
+                "kt_login_user": user,
+                "kt_login_password": password,
+                "kt_login_rememberme": "1",
+                "kt_login1": "Login",
+            },
+            timeout=30,
+        ),
     )
     if "kt_login_password" in response.text:  # still on the login form
         raise AdminAuthError("Legacy admin login failed — check LEGACY_ADMIN_USERNAME/PASSWORD.")
@@ -75,7 +109,10 @@ def session_from_env():
 
 
 def fetch(session, path, _retried=False):
-    response = session.get(f"{BASE_URL}/{path}", timeout=30, allow_redirects=True)
+    response = _with_retries(
+        f"GET {path}",
+        lambda: session.get(f"{BASE_URL}/{path}", timeout=30, allow_redirects=True),
+    )
     if "accessdenied" in response.url or response.status_code in (401, 403):
         # Session lapsed mid-run: re-login once if we hold credentials
         if not _retried and not os.environ.get("LEGACY_ADMIN_COOKIE") and login(session):

--- a/catalogue/ingest/live_admin.py
+++ b/catalogue/ingest/live_admin.py
@@ -33,7 +33,11 @@ MAX_AUTO_PAGES = 200  # auto-depth runaway stop: 10,000 programmes
 # one more attempt than there are waits.
 RETRY_WAITS_SECONDS = (2, 5)
 MAX_ATTEMPTS = len(RETRY_WAITS_SECONDS) + 1
-TRANSIENT_ERRORS = (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+TRANSIENT_ERRORS = (
+    requests.exceptions.ConnectionError,  # refused, aborted, hung up before replying
+    requests.exceptions.Timeout,  # too slow to connect, or to answer
+    requests.exceptions.ChunkedEncodingError,  # hung up part-way through the page
+)
 
 
 class AdminAuthError(Exception):

--- a/tests/test_live_admin_sync.py
+++ b/tests/test_live_admin_sync.py
@@ -260,7 +260,8 @@ def test_adapted_records_flow_through_the_standard_ingest():
 
 @pytest.fixture
 def instant_sleeps(monkeypatch):
-    """Record the waits the retry helper asks for, without serving them."""
+    """Record every `time.sleep` (retry backoff and sync's own pacing between
+    programmes) without actually serving it, so the tests stay instant."""
     waits = []
     monkeypatch.setattr("time.sleep", waits.append)
     return waits
@@ -315,6 +316,25 @@ def test_fetch_gives_up_when_the_old_site_is_genuinely_down(instant_sleeps):
         live_admin.fetch(session, "mediaProgramme.asp?offset=0")
 
     assert session.attempts == live_admin.MAX_ATTEMPTS
+
+
+def test_failures_that_are_not_wobbles_are_not_retried(instant_sleeps):
+    """Retries are for a flaky connection, not for a broken request — anything
+    a retry can't fix must fail on the first attempt, as it always did."""
+    from catalogue.ingest import live_admin
+
+    session = FlakySession(
+        [list_html("12404")],
+        failures=99,
+        on="mediaProgramme.asp",
+        error=requests.exceptions.TooManyRedirects("redirect loop"),
+    )
+
+    with pytest.raises(requests.exceptions.TooManyRedirects):
+        live_admin.fetch(session, "mediaProgramme.asp?offset=0")
+
+    assert session.attempts == 1
+    assert instant_sleeps == []
 
 
 def test_a_single_blip_mid_sync_does_not_abort_the_run(instant_sleeps):

--- a/tests/test_live_admin_sync.py
+++ b/tests/test_live_admin_sync.py
@@ -2,7 +2,10 @@
 observed form structure (input/textarea/select names verified in the
 authenticated recon of 2026-06-12; see data/legacy_rescue/lookups/README.md)."""
 
+import logging
+
 import pytest
+import requests
 
 from catalogue.ingest.legacy import ingest_programmes
 from catalogue.ingest.live_admin import list_programme_ids, parse_meta_page, to_dump_record
@@ -253,6 +256,123 @@ def test_adapted_records_flow_through_the_standard_ingest():
     # And the cornerstone: re-sync is a no-op
     again = ingest_programmes([to_dump_record("12404", parse_meta_page(META_HTML))])
     assert again["created"] == 0 and again["updated"] == 1
+
+
+@pytest.fixture
+def instant_sleeps(monkeypatch):
+    """Record the waits the retry helper asks for, without serving them."""
+    waits = []
+    monkeypatch.setattr("time.sleep", waits.append)
+    return waits
+
+
+class FlakySession(PagedSession):
+    """Raises a transient network error on the first `failures` requests for
+    any URL containing `on`, then behaves normally."""
+
+    def __init__(self, *args, failures, on="", error=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.failures = failures
+        self.on = on
+        self.error = error or requests.exceptions.ReadTimeout("Read timed out.")
+        self.attempts = 0
+
+    def get(self, url, **kwargs):
+        if self.on in url:
+            self.attempts += 1
+            if self.attempts <= self.failures:
+                raise self.error
+        return super().get(url, **kwargs)
+
+
+def test_fetch_retries_a_wobbly_request_and_carries_on(instant_sleeps, caplog):
+    """Two dropped replies from the dying old site must not end the run: the
+    third attempt's response is returned, with a warning logged per retry."""
+    from catalogue.ingest import live_admin
+
+    session = FlakySession([list_html("12404")], failures=2, on="mediaProgramme.asp")
+
+    with caplog.at_level(logging.WARNING):
+        html = live_admin.fetch(session, "mediaProgramme.asp?offset=0")
+
+    assert "ID=12404" in html
+    assert session.attempts == 3
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 2
+    # Backoff escalates rather than hammering the server
+    assert instant_sleeps == sorted(instant_sleeps) and len(instant_sleeps) == 2
+    assert instant_sleeps[0] < instant_sleeps[-1]
+
+
+def test_fetch_gives_up_when_the_old_site_is_genuinely_down(instant_sleeps):
+    """Retries are bounded — a site that never answers still raises, so a real
+    outage surfaces instead of being swallowed."""
+    from catalogue.ingest import live_admin
+
+    session = FlakySession([list_html("12404")], failures=99, on="mediaProgramme.asp")
+
+    with pytest.raises(requests.exceptions.ReadTimeout):
+        live_admin.fetch(session, "mediaProgramme.asp?offset=0")
+
+    assert session.attempts == live_admin.MAX_ATTEMPTS
+
+
+def test_a_single_blip_mid_sync_does_not_abort_the_run(instant_sleeps):
+    """The whole point of #366: one wobble on a programme page costs a pause,
+    not the hour's import."""
+    from catalogue.ingest import live_admin
+
+    session = FlakySession(
+        [list_html("12404")],
+        metas={"mediaProgrammeMeta.asp": META_HTML},
+        failures=1,
+        on="mediaProgrammeMeta.asp",
+        error=requests.exceptions.ConnectionError("Remote end closed connection"),
+    )
+
+    stats, _records = live_admin.sync(pages=1, delay_seconds=0, session=session)
+
+    assert stats["created"] == 1
+    assert Video.objects.filter(id="12404").exists()
+
+
+def test_login_retries_transient_failures_too(instant_sleeps, monkeypatch):
+    from catalogue.ingest import live_admin
+
+    monkeypatch.setenv("LEGACY_ADMIN_USERNAME", "ettie")
+    monkeypatch.setenv("LEGACY_ADMIN_PASSWORD", "secret")
+
+    class S:
+        def __init__(self):
+            self.headers = {}
+            self.gets = 0
+            self.posts = 0
+
+        def get(self, url, **kw):
+            self.gets += 1
+            if self.gets == 1:
+                raise requests.exceptions.ConnectTimeout("connect timed out")
+
+            class R:
+                url = "https://clayton.tv/adminsection/login.asp"
+                text = '<form action="https://clayton.tv/adminsection/login.asp"></form>'
+
+            return R()
+
+        def post(self, url, data=None, **kw):
+            self.posts += 1
+            if self.posts == 1:
+                raise requests.exceptions.ReadTimeout("read timed out")
+
+            class R:
+                text = "<html>Channel Manager</html>"
+
+            return R()
+
+    session = S()
+
+    assert live_admin.login(session) is True
+    assert (session.gets, session.posts) == (2, 2)
 
 
 def test_login_submits_the_observed_form_fields(monkeypatch):


### PR DESCRIPTION
The hourly import from the old clayton.tv site gave up the whole run whenever a
single reply was slow or dropped. That hour's videos arrived late, and each
failure filed a fresh error report — which is where #310, #315, #328, #330 and
#331 all came from.

Now the import treats a wobbly old site as normal: if a request drops or stalls,
it waits a couple of seconds and tries again, up to three attempts in total
(waits of 2s then 5s). Each retry is written to the log as a warning, so a
degraded site is still visible in the cron output. If all three attempts fail,
the error is raised exactly as it was before — so a site that is genuinely down
still reaches us.

Only connection wobbles are retried: a refused, aborted or hung-up connection, a
timeout, and a page that arrives half-written. Anything a retry cannot fix — a
rejected login, an HTTP error page, a redirect loop — fails immediately, just as
it did before. Nothing else changes: runs still ingest page by page, so an
interrupted run keeps everything already fetched and the next run picks up from
a smaller gap.

This also clears the way for the cutover (#287), where the final catch-up copy of
the remaining programmes is a multi-hour run against this same flaky site.

## Testing

Tests first, with a mocked session and the sleeps patched out so they run
instantly. New coverage: two dropped replies then success (returns the page,
logs two warnings, waits escalate); every attempt failing (raises, bounded to
three attempts); a blip mid-sync leaving the run to complete and the video
created; login retrying its own two requests; and non-transient errors not being
retried at all. Full suite: 430 passed, 7 skipped, coverage 89%.

Reviewed by a fresh sub-agent against the diff; its one substantive finding
(a truncated response body surfaces as `ChunkedEncodingError`, not
`ConnectionError`, so it was slipping past the retry) is fixed in the second
commit, along with a test pinning the retry boundary.

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct6Xc71NfYo1sgyw9pCU5T
