### PR TITLE
fix(search): don't 500 when the search param is missing (#329)

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -298,16 +298,25 @@ def search(request):
     return render(request, "Search", props)
 
 
+def _typesense_total_pages(found):
+    """Pages we can actually serve: at least one, and never past Typesense's window."""
+    return min(max(1, math.ceil(found / pagination_per_page)), MAX_SEARCH_PAGE)
+
+
 def _search_typesense(searchquery, page_num):
-    # Typesense refuses to page beyond its first 10,000 results, so ask within
-    # that window; a page past the end is then clamped to the last real page,
-    # matching Paginator.get_page() on the ORM path.
+    # Never ask past Typesense's window — it errors there, and pages beyond it
+    # don't exist as far as search is concerned.
     page_num = min(page_num, MAX_SEARCH_PAGE)
     hits, found = search_index.search_videos(searchquery, page=page_num, per_page=pagination_per_page)
-    total_pages = max(1, math.ceil(found / pagination_per_page))
+    total_pages = _typesense_total_pages(found)
     if page_num > total_pages:
+        # Past the end (a crawler guessing page numbers): serve the last real page,
+        # the same clamp Paginator.get_page() applies on the ORM path. With no
+        # results there is nothing to re-fetch — page 1 is just as empty.
         page_num = total_pages
-        hits, found = search_index.search_videos(searchquery, page=page_num, per_page=pagination_per_page)
+        if found:
+            hits, found = search_index.search_videos(searchquery, page=page_num, per_page=pagination_per_page)
+            total_pages = _typesense_total_pages(found)
 
     # Hydrate the ranked ids in one query, preserving Typesense's relevance order.
     by_id = {str(v.id): v for v in Video.objects.published().filter(id__in=[h.pk for h in hits])}
@@ -318,7 +327,7 @@ def _search_typesense(searchquery, page_num):
         "description": f"Found {found} {'video' if found == 1 else 'videos'} (page {page_num} of {total_pages})",
         "videos": video_card_props(ordered),
         "has_prev_page": page_num > 1,
-        "has_next_page": page_num * pagination_per_page < found,
+        "has_next_page": page_num < total_pages,
     }
     if page_num == 1:
         cat_hits = search_index.search_categories(

--- a/app/views.py
+++ b/app/views.py
@@ -29,6 +29,9 @@ from catalogue.youtube_live import homepage_live_props, live_streams, upcoming_s
 
 pagination_per_page = 24
 
+# Typesense only serves the first 10,000 results of a query and errors past them.
+MAX_SEARCH_PAGE = 10_000 // pagination_per_page
+
 logger = logging.getLogger(__name__)
 
 # Newest first with undated entries at the END on both engines: Postgres
@@ -260,7 +263,8 @@ def search(request):
     Categories appear on page 1 only; both engines return the same prop shape."""
     searchquery = request.GET.get("search", "").strip()
     try:
-        page_num = int(request.GET.get("page", 1))
+        # Crawlers walk made-up page numbers; anything below 1 is page 1.
+        page_num = max(1, int(request.GET.get("page", 1)))
     except ValueError:
         page_num = 1
 
@@ -295,12 +299,20 @@ def search(request):
 
 
 def _search_typesense(searchquery, page_num):
+    # Typesense refuses to page beyond its first 10,000 results, so ask within
+    # that window; a page past the end is then clamped to the last real page,
+    # matching Paginator.get_page() on the ORM path.
+    page_num = min(page_num, MAX_SEARCH_PAGE)
     hits, found = search_index.search_videos(searchquery, page=page_num, per_page=pagination_per_page)
+    total_pages = max(1, math.ceil(found / pagination_per_page))
+    if page_num > total_pages:
+        page_num = total_pages
+        hits, found = search_index.search_videos(searchquery, page=page_num, per_page=pagination_per_page)
+
     # Hydrate the ranked ids in one query, preserving Typesense's relevance order.
     by_id = {str(v.id): v for v in Video.objects.published().filter(id__in=[h.pk for h in hits])}
     ordered = [by_id[h.pk] for h in hits if h.pk in by_id]
 
-    total_pages = max(1, math.ceil(found / pagination_per_page))
     props = {
         "title": f"Search for '{searchquery}'",
         "description": f"Found {found} {'video' if found == 1 else 'videos'} (page {page_num} of {total_pages})",
@@ -327,7 +339,9 @@ def _search_orm(searchquery, page_num):
         v for v in Video.objects.published().filter(description__icontains=searchquery) if v not in video_results
     ]
     paginator = Paginator(video_results, pagination_per_page)
-    paginated = paginator.page(page_num)
+    # get_page() never raises: a page past the end becomes the last real page.
+    paginated = paginator.get_page(page_num)
+    page_num = paginated.number
     description = (
         f"Found {len(video_results)} {'video' if len(video_results) == 1 else 'videos'} "
         f"(page {page_num} of {paginator.num_pages})"

--- a/app/views.py
+++ b/app/views.py
@@ -258,11 +258,27 @@ def search(request):
     """Full-page search. Served by Typesense (relevance-ranked, typo- and
     synonym-tolerant) with a graceful ORM fallback so search never hard-fails.
     Categories appear on page 1 only; both engines return the same prop shape."""
-    searchquery = request.GET["search"]
+    searchquery = request.GET.get("search", "").strip()
     try:
         page_num = int(request.GET.get("page", 1))
     except ValueError:
         page_num = 1
+
+    # No term at all (a bookmark of /search, a stripped link, a crawler): show the
+    # empty page rather than asking either engine for everything.
+    if not searchquery:
+        return render(
+            request,
+            "Search",
+            {
+                "title": "Search",
+                "description": "Type a word, a speaker's name, or a Bible book to find videos.",
+                "videos": [],
+                "categories": [],
+                "has_prev_page": False,
+                "has_next_page": False,
+            },
+        )
 
     try:
         props = _search_typesense(searchquery, page_num)

--- a/app/views.py
+++ b/app/views.py
@@ -265,14 +265,15 @@ def search(request):
         page_num = 1
 
     # No term at all (a bookmark of /search, a stripped link, a crawler): show the
-    # empty page rather than asking either engine for everything.
+    # empty page rather than asking either engine for everything. The page's own
+    # empty state carries the "how to search" nudge, so there's nothing to say here.
     if not searchquery:
         return render(
             request,
             "Search",
             {
                 "title": "Search",
-                "description": "Type a word, a speaker's name, or a Bible book to find videos.",
+                "description": "",
                 "videos": [],
                 "categories": [],
                 "has_prev_page": False,

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow:
+Disallow: /search

--- a/resources/js/pages/Search.vue
+++ b/resources/js/pages/Search.vue
@@ -30,7 +30,8 @@ const props = defineProps({
 // reactive, so this recomputes on every Inertia navigation — including a repeat
 // search from the global palette that REUSES this page component (no remount).
 const page = usePage();
-const query = computed(() => new URLSearchParams(page.url.split('?')[1] ?? '').get('search') ?? '');
+// Trimmed to match the server, which strips the term before searching.
+const query = computed(() => (new URLSearchParams(page.url.split('?')[1] ?? '').get('search') ?? '').trim());
 
 // Fire search_performed when the search TERM changes (initial load + each new
 // search) but not on pagination — paging changes ?page=, not ?search=. Search is
@@ -39,6 +40,10 @@ const query = computed(() => new URLSearchParams(page.url.split('?')[1] ?? '').g
 watch(
     query,
     (q) => {
+        // Landing on /search with no term isn't a search — don't log it as a
+        // zero-result one, or it drowns out the real content gaps.
+        if (!q) return;
+
         const videoCount = props.videos?.length ?? 0;
         const categoryCount = props.categories?.length ?? 0;
         track(EVENTS.searchPerformed, {
@@ -49,6 +54,15 @@ watch(
         });
     },
     { immediate: true },
+);
+
+// Arriving at /search with no term is a blank slate, not a failed search, so the
+// grid's empty state has to say something different.
+const emptyTitle = computed(() => (query.value ? 'No matching videos' : 'Nothing to show yet'));
+const emptyMessage = computed(() =>
+    query.value
+        ? "We couldn't find any videos for that search. Try a different word, a speaker's name, or a Bible book."
+        : "Use the search box at the top of the page to look for a word, a speaker's name, a series, or a Bible book.",
 );
 </script>
 
@@ -86,8 +100,8 @@ watch(
                 :has_next_page
                 track-context="search"
                 :track-query="query"
-                empty-title="No matching videos"
-                empty-message="We couldn't find any videos for that search. Try a different word, a speaker's name, or a Bible book."
+                :empty-title="emptyTitle"
+                :empty-message="emptyMessage"
             />
         </div>
     </div>

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -33,6 +33,40 @@ def test_search_first_page_includes_matching_categories(client):
     assert ("Series", "Amazing Grace") in categories
 
 
+def test_search_without_a_term_renders_the_empty_page(client):
+    # #329: a bookmark of /search (or a crawler) sends no ?search= at all.
+    VideoFactory(name="The Grace of God")
+
+    response = client.get("/search")
+    page = inertia_page(response)
+
+    assert response.status_code == 200
+    assert page["component"] == "Search"
+    assert page["props"]["videos"] == []
+    assert page["props"]["categories"] == []
+
+
+def test_search_with_only_a_page_param_renders_the_empty_page(client):
+    # #329: ?page=2 with no ?search= is the same missing-key crash.
+    VideoFactory(name="The Grace of God")
+
+    response = client.get("/search", {"page": 2})
+    page = inertia_page(response)
+
+    assert response.status_code == 200
+    assert page["props"]["videos"] == []
+
+
+@pytest.mark.parametrize("term", ["", "   "])
+def test_search_with_a_blank_term_renders_the_empty_page(client, term):
+    # A blank term must not list the whole catalogue via the ORM fallback.
+    VideoFactory(name="The Grace of God")
+
+    page = inertia_page(client.get("/search", {"search": term}))
+
+    assert page["props"]["videos"] == []
+
+
 def test_search_category_labels_are_cleaned(client):
     # Phase 6: depth-prefix mojibake leaked into search category chips.
     video = VideoFactory()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -71,6 +71,31 @@ def test_search_with_a_blank_term_renders_the_empty_page(client, term):
     assert page["props"]["videos"] == []
 
 
+@pytest.mark.parametrize("page", ["999", "0", "-3", "not-a-page"])
+def test_search_clamps_impossible_pages(client, page):
+    # Crawlers walk made-up page numbers; the ORM fallback used to 500 on them.
+    VideoFactory(name="The Grace of God")
+
+    response = client.get("/search", {"search": "grace", "page": page})
+    props = inertia_page(response)["props"]
+
+    assert response.status_code == 200
+    assert [v["name"] for v in props["videos"]] == ["The Grace of God"]
+    assert "page 1 of 1" in props["description"]
+    assert props["has_prev_page"] is False
+    assert props["has_next_page"] is False
+
+
+def test_search_clamped_last_page_still_shows_categories(client):
+    # Clamping to page 1 means page 1's props, categories included.
+    video = VideoFactory(name="Grace")
+    video.topic.add(TopicFactory(name="Grace"))
+
+    props = inertia_page(client.get("/search", {"search": "grace", "page": 999}))["props"]
+
+    assert ("Topics", "Grace") in {(c["category"], c["name"]) for c in props["categories"]}
+
+
 def test_search_category_labels_are_cleaned(client):
     # Phase 6: depth-prefix mojibake leaked into search category chips.
     video = VideoFactory()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -33,15 +33,19 @@ def test_search_first_page_includes_matching_categories(client):
     assert ("Series", "Amazing Grace") in categories
 
 
-def test_search_without_a_term_renders_the_empty_page(client):
+def test_search_without_a_term_renders_the_empty_page(client, django_assert_max_num_queries):
     # #329: a bookmark of /search (or a crawler) sends no ?search= at all.
     VideoFactory(name="The Grace of God")
 
-    response = client.get("/search")
+    # No term means no search work — the only query left is the live-stream check
+    # every page runs, so neither Typesense nor the ORM fallback was consulted.
+    with django_assert_max_num_queries(1):
+        response = client.get("/search")
     page = inertia_page(response)
 
     assert response.status_code == 200
     assert page["component"] == "Search"
+    assert page["props"]["title"] == "Search"
     assert page["props"]["videos"] == []
     assert page["props"]["categories"] == []
 

--- a/tests/test_search_proxy.py
+++ b/tests/test_search_proxy.py
@@ -8,6 +8,7 @@ typo/synonym tolerance end-to-end (skips without a container).
 
 import pytest
 
+from app.views import MAX_SEARCH_PAGE
 from catalogue import search
 from catalogue.search import Hit, SearchUnavailableError
 from tests.factories import VideoFactory
@@ -123,10 +124,59 @@ def test_search_clamps_pages_past_the_end_to_the_last_page(client, monkeypatch):
 
     props = inertia_page(client.get("/search", {"search": "romans", "page": "999"}))["props"]
 
-    assert requested_pages[-1] == 2  # the last real page
+    # Capped into Typesense's window first, then clamped to the last real page.
+    assert requested_pages == [MAX_SEARCH_PAGE, 2]
     assert [v["name"] for v in props["videos"]] == ["Romans 8"]
     assert props["description"] == "Found 30 videos (page 2 of 2)"
     assert props["has_next_page"] is False
+
+
+def test_search_never_advertises_pages_past_typesenses_window(client, monkeypatch):
+    # More results than Typesense will page through: the last page it can serve
+    # is the last page we may offer, or we invent an endless run of URLs.
+    monkeypatch.setattr(search, "search_videos", lambda q, **kw: ([], 20_000))
+
+    props = inertia_page(client.get("/search", {"search": "god", "page": "999"}))["props"]
+
+    assert props["description"] == f"Found 20000 videos (page {MAX_SEARCH_PAGE} of {MAX_SEARCH_PAGE})"
+    assert props["has_next_page"] is False
+
+
+def test_search_clamped_to_page_one_still_fetches_categories(client, monkeypatch):
+    requested_pages = []
+
+    def fake_search(query, *, page=1, **kw):
+        requested_pages.append(page)
+        return ([], 5)  # one page of results
+
+    monkeypatch.setattr(search, "search_videos", fake_search)
+    monkeypatch.setattr(
+        search,
+        "search_categories",
+        lambda q, **kw: [Hit(kind="series", pk="9", name="A Series", url="/series/9", videos_count=4)],
+    )
+
+    props = inertia_page(client.get("/search", {"search": "x", "page": "999"}))["props"]
+
+    assert requested_pages == [MAX_SEARCH_PAGE, 1]
+    assert props["categories"][0]["name"] == "A Series"
+
+
+def test_search_does_not_re_ask_typesense_when_there_are_no_results(client, monkeypatch):
+    requested_pages = []
+
+    def fake_search(query, *, page=1, **kw):
+        requested_pages.append(page)
+        return ([], 0)
+
+    monkeypatch.setattr(search, "search_videos", fake_search)
+    monkeypatch.setattr(search, "search_categories", lambda q, **kw: [])
+
+    props = inertia_page(client.get("/search", {"search": "asdfgh", "page": "5"}))["props"]
+
+    assert requested_pages == [5]  # nothing to clamp to; page 5 was empty already
+    assert props["videos"] == []
+    assert props["description"] == "Found 0 videos (page 1 of 1)"
 
 
 @pytest.mark.parametrize("page", ["0", "-3", "not-a-page"])

--- a/tests/test_search_proxy.py
+++ b/tests/test_search_proxy.py
@@ -108,6 +108,44 @@ def test_search_page_two_has_no_categories(client, monkeypatch):
     assert props["has_prev_page"] is True
 
 
+def test_search_clamps_pages_past_the_end_to_the_last_page(client, monkeypatch):
+    # Typesense errors past its 10k result window, which used to mean a crawler
+    # asking for page 999 tripped the "unexpected error" path into Sentry.
+    video = VideoFactory(name="Romans 8")
+    hit = Hit(kind="video", pk=str(video.id), name=video.name, url=f"/video/{video.id}", videos_count=0)
+    requested_pages = []
+
+    def fake_search(query, *, page=1, **kw):
+        requested_pages.append(page)
+        return ([hit], 30) if page == 2 else ([], 30)  # 30 results = 2 pages of 24
+
+    monkeypatch.setattr(search, "search_videos", fake_search)
+
+    props = inertia_page(client.get("/search", {"search": "romans", "page": "999"}))["props"]
+
+    assert requested_pages[-1] == 2  # the last real page
+    assert [v["name"] for v in props["videos"]] == ["Romans 8"]
+    assert props["description"] == "Found 30 videos (page 2 of 2)"
+    assert props["has_next_page"] is False
+
+
+@pytest.mark.parametrize("page", ["0", "-3", "not-a-page"])
+def test_search_never_asks_typesense_for_an_impossible_page(client, monkeypatch, page):
+    requested_pages = []
+
+    def fake_search(query, *, page=1, **kw):
+        requested_pages.append(page)
+        return ([], 30)
+
+    monkeypatch.setattr(search, "search_videos", fake_search)
+    monkeypatch.setattr(search, "search_categories", lambda q, **kw: [])
+
+    props = inertia_page(client.get("/search", {"search": "romans", "page": page}))["props"]
+
+    assert requested_pages == [1]
+    assert props["has_prev_page"] is False
+
+
 def test_search_falls_back_to_orm_when_typesense_unavailable(client, monkeypatch):
     def boom(*a, **k):
         raise SearchUnavailableError("down")


### PR DESCRIPTION
Opening the search page without a term — a bookmark of `/search`, a shared link
with the term stripped off, `/search?page=2`, or a crawler — returned a server
error instead of a page, and every hit was logged as a crash in Sentry. The view
read the query param with `request.GET["search"]`, which raises when the key is
absent entirely. (A bare `?search` or `?search=` never crashed; only the missing
key did.)

The view now reads the param defensively and, when there is no term, renders the
normal Search page with no results instead of asking Typesense — or the ORM
fallback — for everything. A blank or whitespace-only term takes the same path,
which also stops the fallback listing the entire catalogue via `icontains ""`.

## Page numbers, same crash class

`/search?search=grace&page=999` had the same problem from the other end: the
paginator in the ORM fallback raised on any page past the end, and `page=0` or a
negative page raised too. Both are trivially crawler-reachable and both were
logged as crashes. Now:

- a page below 1 is read as page 1, so neither engine is ever asked for page 0
- the ORM path uses `Paginator.get_page()`, which clamps a page past the end to
  the last real page and never raises
- the Typesense path clamps the same way, and — since Typesense only serves the
  first 10,000 results of a query and errors past them — it never asks for, nor
  advertises, a page beyond that window. Otherwise a common word would offer
  hundreds of pages that all render the same results and all claim another page
  after them, which is the endless URL space that got us here.

## Not indexing search results

`public/robots.txt` now disallows `/search`. Internal search-results pages are
thin wrappers around content that is already crawlable on its own pages, and the
query-string x page URL space is effectively infinite — walking it is what filled
Sentry with these crashes, and on production every one of those requests can fall
through to the DB-expensive ORM search. Real content pages stay fully crawlable.

## Along the way

Because the no-term page now actually renders, two front-end follow-ups came out
of self-review: the empty state says "nothing to show yet, use the search box"
rather than "we couldn't find any videos for that search", and we no longer fire
a `search_performed` analytics event for the empty term (which would have logged
every bookmark and crawl as a zero-result search and buried the real content
gaps).

Tests cover `/search` with no query string, with only `?page=2`, with a blank or
whitespace term, and with out-of-range, zero and negative pages on both engine
paths — including a query bound proving the no-term page consults neither engine,
and the Typesense window cap itself.

Noted while in here, not fixed (out of scope, happy to raise separately): nine
sibling views (`app/views.py` browse/index pages and `app/browse.py`) still call
`paginator.page()` behind the same ValueError-only guard, so `?page=999` and
`?page=0` still 500 there — the same two-line fix applies. `PaginationNav` also
derives the current page from the URL rather than a prop, so after a clamp its
Prev/Next point at the un-clamped neighbours.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ct6Xc71NfYo1sgyw9pCU5T
