### PR TITLE
WatchVideo.vue: add word Duration to reduce confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ passage. Django + Inertia + Vue 3, currently being rebuilt on the `beta` branch.
 
 New here? This README gets you running locally in a few minutes. To see what's
 being worked on and what's planned, browse the
-[issues and project board](https://github.com/Clayton-TV/claytontv/issues).
+[issues](https://github.com/Clayton-TV/claytontv/issues) and [project board (only visible to Clayton TV developer team)](https://discord.gg/Gbh8fWthj).
 
 ## Prerequisites
 

--- a/resources/js/pages/WatchVideo.vue
+++ b/resources/js/pages/WatchVideo.vue
@@ -137,7 +137,7 @@ const entries = (key) => {
             <div class="mt-2 flex flex-wrap items-center justify-between gap-3">
                 <p class="text-muted-foreground text-sm tabular-nums">
                     {{ video.date_recorded ? `Recorded ${video.date_recorded}` : `Added ${video.date_created}` }}
-                    <template v-if="formatDuration(video.duration_seconds)"> · {{ formatDuration(video.duration_seconds) }}</template>
+                    <template v-if="formatDuration(video.duration_seconds)"> · Duration: {{ formatDuration(video.duration_seconds) }}</template>
                 </p>
                 <ShareButton :title="video.name" />
             </div>


### PR DESCRIPTION
Adds the word "Duration" to the WatchVideo page to avoid confusion with the "Recorded" date adjacent to it. 