### PR TITLE
WatchVideo.vue: add word Duration to reduce confusion

### DIFF
--- a/resources/js/pages/WatchVideo.vue
+++ b/resources/js/pages/WatchVideo.vue
@@ -137,7 +137,7 @@ const entries = (key) => {
             <div class="mt-2 flex flex-wrap items-center justify-between gap-3">
                 <p class="text-muted-foreground text-sm tabular-nums">
                     {{ video.date_recorded ? `Recorded ${video.date_recorded}` : `Added ${video.date_created}` }}
-                    <template v-if="formatDuration(video.duration_seconds)"> · Duration: {{ formatDuration(video.duration_seconds) }}</template>
+                    <template v-if="formatDuration(video.duration_seconds)"> · Duration {{ formatDuration(video.duration_seconds) }}</template>
                 </p>
                 <ShareButton :title="video.name" />
             </div>

--- a/resources/js/pages/WatchVideo.vue
+++ b/resources/js/pages/WatchVideo.vue
@@ -137,7 +137,7 @@ const entries = (key) => {
             <div class="mt-2 flex flex-wrap items-center justify-between gap-3">
                 <p class="text-muted-foreground text-sm tabular-nums">
                     {{ video.date_recorded ? `Recorded ${video.date_recorded}` : `Added ${video.date_created}` }}
-                    <template v-if="formatDuration(video.duration_seconds)"> · {{ formatDuration(video.duration_seconds) }}</template>
+                    <template v-if="formatDuration(video.duration_seconds)"> · Duration: {{ formatDuration(video.duration_seconds) }}</template>
                 </p>
                 <ShareButton :title="video.name" />
             </div>


### PR DESCRIPTION
Adds the word "Duration" to the Watch Video page, because the duration (if present in the database) sits beside the Recorded date and looks confusingly like a time.